### PR TITLE
JSON encoded document strings

### DIFF
--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -51,7 +51,15 @@ module Elastomer
       # Returns the response body as a Hash
       def index( document, params = {} )
         overrides = from_document(document)
-        response = client.put '/{index}/{type}/{id}', update_params(params, overrides)
+        params = update_params(params, overrides)
+
+        response =
+            if params.key? :id
+              client.put '/{index}/{type}/{id}', params
+            else
+              client.post '/{index}/{type}', params
+            end
+
         response.body
       end
       alias :add :index
@@ -178,7 +186,6 @@ module Elastomer
 =begin
 Multi Search
 Percolate
-Bulk
 Bulk UDP
 Count
 More Like This

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -36,10 +36,45 @@ describe Elastomer::Client::Docs do
   end
 
   after do
-    # @docs.delete_by_query :q => '*:*'
-    # @index.flush
-    # @index.refresh
     @index.delete if @index.exists?
+  end
+
+  it 'autogenerates IDs for documents' do
+    h = @docs.index \
+          :_type  => 'doc2',
+          :title  => 'the author of logging',
+          :author => 'pea53'
+
+    assert h['ok'], 'everything is NOT ok'
+    assert_match %r/^\S{22}$/, h['_id']
+  end
+
+  it 'uses the provided document ID' do
+    h = @docs.index \
+          :_id    => '42',
+          :_type  => 'doc2',
+          :title  => 'the author of logging',
+          :author => 'pea53'
+
+    assert h['ok'], 'everything is NOT ok'
+    assert_equal '42', h['_id']
+  end
+
+  it 'accepts JSON encoded document strings' do
+    h = @docs.index \
+          '{"author":"pea53", "title":"the author of logging"}',
+          :id   => '42',
+          :type => 'doc2'
+
+    assert h['ok'], 'everything is NOT ok'
+    assert_equal '42', h['_id']
+
+    h = @docs.index \
+          '{"author":"grantr", "title":"the author of rubber-band"}',
+          :type => 'doc2'
+
+    assert h['ok'], 'everything is NOT ok'
+    assert_match %r/^\S{22}$/, h['_id']
   end
 
   it 'gets documents from the search index' do


### PR DESCRIPTION
Small change that allows the user to pass in documents as JSON encoded Strings. Just a proof of concept to get some discussion going.

cc @github/search
