### PR TITLE
don't require a bulk request_size

### DIFF
--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -197,7 +197,7 @@ module Elastomer
           @current_request_size += document.length
         end
 
-        call if request_size.nil? || @current_request_size >= request_size
+        call if request_size && @current_request_size >= request_size
 
         self
       end

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -82,7 +82,7 @@ describe Elastomer::Client::Bulk do
   end
 
   it 'supports a nice block syntax' do
-    h = @index.bulk(:request_size => 1024) do |b|
+    h = @index.bulk do |b|
       b.index :_id => 1,   :_type => 'tweet', :author => 'pea53', :message => 'just a test tweet'
       b.index :_id => nil, :_type => 'book', :author => 'John Scalzi', :title => 'Old Mans War'
     end
@@ -128,7 +128,7 @@ describe Elastomer::Client::Bulk do
   end
 
   it 'allows documents to be JSON strings' do
-    h = @index.bulk(:request_size => 1024) do |b|
+    h = @index.bulk do |b|
       b.index  '{"author":"pea53", "message":"just a test tweet"}', :_id => 1, :_type => 'tweet'
       b.create '{"author":"John Scalzi", "title":"Old Mans War"}',  :_id => 1, :_type => 'book'
     end


### PR DESCRIPTION
Allow bulk requests that don't have a `:request_size` set to still be sent as bulk. In this case it should assemble the request as normal and allow the user to decide when to issue the bulk request. Current master makes a bulk request for each bulk action.

See #18 and #25 for more on this.
