### PR TITLE
add a default require

### DIFF
--- a/lib/elastomer.rb
+++ b/lib/elastomer.rb
@@ -1,0 +1,1 @@
+require 'elastomer/client'


### PR DESCRIPTION
adds `lib/elastomer.rb` which just requires `elastomer/client`. This makes it slightly easier to bundle elastomer and conforms better to the default rubygems behavior of `require 'gem_name'`.
