### PR TITLE
Faster UUID Generator

### DIFF
--- a/lib/elastomer/middleware/opaque_id.rb
+++ b/lib/elastomer/middleware/opaque_id.rb
@@ -45,8 +45,11 @@ module Elastomer
       # Returns the UUID string.
       def generate_uuid
         t = Thread.current
-        t[:opaque_id_base] ||= (SecureRandom.urlsafe_base64(12) + '%08x').freeze
-        t[:opaque_id_counter] ||= -1
+
+        unless t.key? :opaque_id_base
+          t[:opaque_id_base]    = (SecureRandom.urlsafe_base64(12) + '%08x').freeze
+          t[:opaque_id_counter] = -1
+        end
 
         t[:opaque_id_counter] += 1
         t[:opaque_id_counter] = 0 if t[:opaque_id_counter] > COUNTER_MAX


### PR DESCRIPTION
Using the trick Andrew and @grantr mentioned today of creating a UUID once and then adding an incrementing counter to the end. The actual `SecureRandom.uuid` call is kinda slow. So we just keep that string around and slap an extra four hex digits on the end. When our incrementing counter rolls over, we'll generate a new UUID.

/cc @github/search
