### PR TITLE
Tweaked faraday dependency version to fix script/bootstrap

### DIFF
--- a/elastomer.gemspec
+++ b/elastomer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   # runtime dependencies
   s.add_dependency 'addressable',         '~> 2.3'
-  s.add_dependency 'faraday',             '~> 0.8'
+  s.add_dependency 'faraday',             '~> 0.8.0'
   s.add_dependency 'faraday_middleware',  '~> 0.9'
   s.add_dependency 'multi_json',          '~> 1.7'
 
@@ -27,4 +27,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'json',          '~> 1.7'
   s.add_development_dependency 'minitest',      '~> 4.7'
 end
-


### PR DESCRIPTION
Was getting the following error whilst running `script/bootstrap`:

```
Bundler could not find compatible versions for gem "faraday":
  In Gemfile:
    elastomer (>= 0) ruby depends on
      faraday (< 0.9, >= 0.7.4) ruby

    elastomer (>= 0) ruby depends on
      faraday (0.9.0)
```

@github/search 
