### PR TITLE
Params for all the `index` methods

### DIFF
--- a/lib/elastomer/client/cluster.rb
+++ b/lib/elastomer/client/cluster.rb
@@ -1,4 +1,3 @@
-
 module Elastomer
   class Client
 
@@ -6,7 +5,6 @@ module Elastomer
     def cluster
       @cluster ||= Cluster.new self
     end
-
 
     class Cluster
 
@@ -49,10 +47,11 @@ module Elastomer
       # params - Parameters Hash
       #
       # Returns the response as a Hash
-      def settings( params = {} )
-        response = client.get '/_cluster/settings', params.merge(:action => 'cluster.settings.get')
+      def get_settings( params = {} )
+        response = client.get '/_cluster/settings', params.merge(:action => 'cluster.get_settings')
         response.body
       end
+      alias :settings :get_settings
 
       # Update cluster wide specific settings. Settings updated can either be
       # persistent (applied cross restarts) or transient (will not survive a
@@ -65,7 +64,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def update_settings( body, params = {} )
-        response = client.put '/_cluster/settings', params.merge(:body => body, :action => 'cluster.settings.update')
+        response = client.put '/_cluster/settings', params.merge(:body => body, :action => 'cluster.update_settings')
         response.body
       end
 
@@ -104,35 +103,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def shutdown( params = {} )
-        response = client.post '/_shutdown', params.merge(:action => 'shutdown')
-        response.body
-      end
-
-      # Perform an aliases action on the cluster. We are just a teensy bit
-      # clever here in that a single action can be given or an array of
-      # actions. This API method will wrap the request in the appropriate
-      # {:actions => [...]} body construct.
-      #
-      # See http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
-      #
-      # actions - An action Hash or an Array of action Hashes
-      # params  - Parameters Hash
-      #
-      # Examples
-      #
-      #   aliases(:add => { :index => 'users-1', :alias => 'users' })
-      #
-      #   aliases([
-      #     { :remove => { :index => 'users-1', :alias => 'users' }},
-      #     { :add    => { :index => 'users-2', :alias => 'users' }}
-      #   ])
-      #
-      # Returns the response body as a Hash
-      def aliases( actions, params = {} )
-        actions = [actions] unless Array === actions
-        body = {:actions => actions}
-
-        response = client.post '/_aliases', params.merge(:body => body, :action => 'aliases.update')
+        response = client.post '/_shutdown', params.merge(:action => 'cluster.shutdown')
         response.body
       end
 
@@ -152,7 +123,36 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_aliases( params = {} )
-        response = client.get '{/index}/_aliases', params.merge(:action => 'aliases.get')
+        response = client.get '{/index}/_aliases', params.merge(:action => 'cluster.get_aliases')
+        response.body
+      end
+      alias :aliases :get_aliases
+
+      # Perform an aliases action on the cluster. We are just a teensy bit
+      # clever here in that a single action can be given or an array of
+      # actions. This API method will wrap the request in the appropriate
+      # {:actions => [...]} body construct.
+      #
+      # See http://www.elasticsearch.org/guide/reference/api/admin-indices-aliases/
+      #
+      # actions - An action Hash or an Array of action Hashes
+      # params  - Parameters Hash
+      #
+      # Examples
+      #
+      #   update_aliases(:add => { :index => 'users-1', :alias => 'users' })
+      #
+      #   update_aliases([
+      #     { :remove => { :index => 'users-1', :alias => 'users' }},
+      #     { :add    => { :index => 'users-2', :alias => 'users' }}
+      #   ])
+      #
+      # Returns the response body as a Hash
+      def update_aliases( actions, params = {} )
+        actions = [actions] unless Array === actions
+        body = {:actions => actions}
+
+        response = client.post '/_aliases', params.merge(:body => body, :action => 'cluster.update_aliases')
         response.body
       end
 
@@ -196,6 +196,6 @@ module Elastomer
         h['nodes']
       end
 
-    end  # Cluster
-  end  # Client
-end  # Elastomer
+    end
+  end
+end

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -39,7 +39,7 @@ module Elastomer
       def index( document, params = {} )
         overrides = from_document(document)
         params = update_params(params, overrides)
-        params[:action] = 'document.index'
+        params[:action] = 'docs.index'
 
         params.delete(:id) if params[:id].nil? || params[:id].to_s =~ /\A\s*\z/
 
@@ -63,7 +63,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete( params = {} )
-        response = client.delete '/{index}/{type}/{id}', update_params(params, :action => 'document.delete')
+        response = client.delete '/{index}/{type}/{id}', update_params(params, :action => 'docs.delete')
         response.body
       end
 
@@ -76,7 +76,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get( params = {} )
-        response = client.get '/{index}/{type}/{id}', update_params(params, :action => 'document.get')
+        response = client.get '/{index}/{type}/{id}', update_params(params, :action => 'docs.get')
         response.body
       end
 
@@ -89,7 +89,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def source( params = {} )
-        response = client.get '/{index}/{type}/{id}/_source', update_params(params, :action => 'document.source')
+        response = client.get '/{index}/{type}/{id}/_source', update_params(params, :action => 'docs.source')
         response.body
       end
 
@@ -102,7 +102,7 @@ module Elastomer
       # Returns the response body as a Hash
       def multi_get( docs, params = {} )
         overrides = from_document(docs)
-        overrides[:action] = 'mget'
+        overrides[:action] = 'docs.multi_get'
 
         response = client.get '{/index}{/type}{/id}/_mget', update_params(params, overrides)
         response.body
@@ -117,7 +117,7 @@ module Elastomer
       # Returns the response body as a Hash
       def update( script, params = {} )
         overrides = from_document(script)
-        overrides[:action] = 'document.update'
+        overrides[:action] = 'docs.update'
 
         response = client.post '/{index}/{type}/{id}/_update', update_params(params, overrides)
         response.body
@@ -146,7 +146,7 @@ module Elastomer
       def search( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
-        response = client.get '/{index}{/type}/_search', update_params(params, :body => query, :action => 'search')
+        response = client.get '/{index}{/type}/_search', update_params(params, :body => query, :action => 'docs.search')
         response.body
       end
 
@@ -200,7 +200,7 @@ module Elastomer
       def delete_by_query( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
-        response = client.delete '/{index}{/type}/_query', update_params(params, :body => query, :action => 'delete_by_query')
+        response = client.delete '/{index}{/type}/_query', update_params(params, :body => query, :action => 'docs.delete_by_query')
         response.body
       end
 
@@ -230,7 +230,7 @@ Percolate
       def more_like_this(query, params = nil)
         query, params = extract_params(query) if params.nil?
 
-        response = client.get '/{index}/{type}/{id}/_mlt', update_params(params, :body => query)
+        response = client.get '/{index}/{type}/{id}/_mlt', update_params(params, :body => query, :action => 'docs.more_like_this')
         response.body
       end
 
@@ -253,7 +253,7 @@ Percolate
       def explain(query, params = nil)
         query, params = extract_params(query) if params.nil?
 
-        response = client.get '/{index}/{type}/{id}/_explain', update_params(params, :body => query)
+        response = client.get '/{index}/{type}/{id}/_explain', update_params(params, :body => query, :action => 'docs.explain')
         response.body
       end
 
@@ -277,8 +277,8 @@ Percolate
       # Returns the response body as a hash
       def validate(query, params = nil)
         query, params = extract_params(query) if params.nil?
-        
-        response = client.get '/{index}{/type}/_validate/query', update_params(params, :body => query)
+
+        response = client.get '/{index}{/type}/_validate/query', update_params(params, :body => query, :action => 'docs.validate')
         response.body
       end
 

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -90,10 +90,11 @@ module Elastomer
       # params - Parameters Hash
       #
       # Returns the response body as a Hash
-      def settings( params = {} )
-        response = client.get '{/index}/_settings', update_params(params, :action => 'index.settings')
+      def get_settings( params = {} )
+        response = client.get '{/index}/_settings', update_params(params, :action => 'index.get_settings')
         response.body
       end
+      alias :settings :get_settings
 
       # Change specific index level settings in real time.
       # See http://www.elasticsearch.org/guide/reference/api/admin-indices-update-settings/
@@ -158,6 +159,7 @@ module Elastomer
         response = client.get '/{index}/_aliases', update_params(:action => 'index.get_aliases')
         response.body
       end
+      alias :aliases :get_aliases
 
       # Performs the analysis process on a text and return the tokens breakdown of the text.
       # See http://www.elasticsearch.org/guide/reference/api/admin-indices-analyze/

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -105,7 +105,7 @@ describe Elastomer::Client::Index do
     @index.create(nil)
     assert_equal({@name => {'aliases' => {}}}, @index.get_aliases)
 
-    $client.cluster.aliases :add => {:index => @name, :alias => 'foofaloo'}
+    $client.cluster.update_aliases :add => {:index => @name, :alias => 'foofaloo'}
     assert_equal({@name => {'aliases' => {'foofaloo' => {}}}}, @index.get_aliases)
   end
 


### PR DESCRIPTION
In an attempt to bring some consistency to our interface, I've added `params = {}` to all the index methods. Now we can pass along params to any request without trouble. I've also made the `:action` names consistent, too.

And I just couldn't resist fixing up the cluster test so it works with ES 1.0

@grantr what are you thoughts on these action titles? For index settings we previously had: `index.settings.get` and `index.settings.update`. This PR changes those to be `index.settings` and `index.update_settings` to reflect the method names. I feel like I'm being pedantic, but I would like these things to be consistent in some manner.
