### PR TITLE
add MIT license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013 GitHub, Inc.
+Copyright (c) 2013 GitHub Inc.
 
 MIT License
 


### PR DESCRIPTION
The spec already said the license was MIT, but we didn't have a license file. Now we do.

/cc @TwP @github/legal
