### PR TITLE
Exception wrapping

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -274,8 +274,8 @@ module Elastomer
     # Raises an Elastomer::Client::Error on 500 responses or responses
     # containing and 'error' field.
     def handle_errors( response )
-      raise Error, response if response.status >= 500
-      raise Error, response if Hash === response.body && response.body['error']
+      raise ServerError, response if response.status >= 500
+      raise RequestError, response if Hash === response.body && response.body['error']
 
       response
     end

--- a/test/client/errors_test.rb
+++ b/test/client/errors_test.rb
@@ -22,7 +22,27 @@ describe Elastomer::Client::Error do
     err.set_backtrace %w[one two three four]
 
     err = Elastomer::Client::Error.new(err, "POST", "/index/doc")
-    assert_equal "could not connect to host: POST /index/doc", err.message
+    assert_equal "could not connect to host :: POST /index/doc", err.message
     assert_equal %w[one two three four], err.backtrace
+  end
+
+  it "is fatal by default" do
+    assert Elastomer::Client::Error.fatal?, "client errors are fatal by default"
+
+    error = Elastomer::Client::Error.new "oops!"
+    assert !error.retry?, "client errors are not retryable by default"
+  end
+
+  it "has some fatal subclasses" do
+    assert Elastomer::Client::ResourceNotFound.fatal?, "Resource not found is fatal"
+    assert Elastomer::Client::ParsingError.fatal?, "Parsing error is fatal"
+    assert Elastomer::Client::SSLError.fatal?, "SSL error is fatal"
+    assert Elastomer::Client::RequestError.fatal?, "Request error is fatal"
+  end
+
+  it "has some non-fatal subclasses" do
+    assert !Elastomer::Client::TimeoutError.fatal?, "Timeouts are not fatal"
+    assert !Elastomer::Client::ConnectionFailed.fatal?, "Connection failures are not fatal"
+    assert !Elastomer::Client::ServerError.fatal?, "Server errors are not fatal"
   end
 end


### PR DESCRIPTION
Wrappering up Faraday errors with Elastomer errors so there is only one top-level exception class that users need to worry about. See https://github.com/github/github/pull/30758#discussion_r16034142 for more details.

closes #72

/cc @github/search 
