### PR TITLE
Add endpoints for index/cluster recovery

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -25,7 +25,6 @@ The event namespace is `request.client.elastomer`.
 - cluster.get_settings
 - cluster.health
 - cluster.info
-- cluster.recovery
 - cluster.reroute
 - cluster.shutdown
 - cluster.state

--- a/lib/elastomer/client/cluster.rb
+++ b/lib/elastomer/client/cluster.rb
@@ -165,18 +165,6 @@ module Elastomer
         response.body
       end
 
-      # Provides insight into on-going index shard recoveries cluster-wide.
-      #
-      # params - Parameters Hash
-      #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-recovery.html
-      #
-      # Returns the response as a Hash
-      def recovery( params = {} )
-        response = client.get '/_recovery', params.merge(:action => 'cluster.recovery')
-        response.body
-      end
-
       # Retrieve the current aliases. An :index name can be given (or an
       # array of index names) to get just the aliases for those indexes. You
       # can also use the alias name here since it is acting the part of an

--- a/test/client/cluster_test.rb
+++ b/test/client/cluster_test.rb
@@ -76,14 +76,6 @@ describe Elastomer::Client::Cluster do
     assert_equal %w[cluster_name indices nodes status timestamp], h.keys.sort
   end
 
-  if es_version_1_x?
-    it 'returns cluster recovery' do
-      indices = @cluster.indices.keys.sort
-      h = @cluster.recovery
-      assert_equal indices, h.keys.sort
-    end
-  end
-
   it 'returns a list of pending tasks' do
     h = @cluster.pending_tasks
     assert_equal %w[tasks], h.keys.sort


### PR DESCRIPTION
When indices are being recovered I was attempting to create a status command in github/shell#1505 but there was no recovery endpoint available on `Elastomer::Client::Index` or `Elastomer::Client::Cluster`. This adds the endpoints, docs, and tests for [_recovery](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-recovery.html#indices-recovery).

/cc @shayfrendt @TwP @grantr 
