### PR TITLE
ES 1.4 updates

### DIFF
--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -91,7 +91,7 @@ describe Elastomer::Client::Bulk do
     assert_bulk_create h['items'].last
 
     book_id = items.last['create']['_id']
-    assert_match %r/^\S{22}$/, book_id
+    assert_match %r/^\S{20,22}$/, book_id
 
     @index.refresh
 
@@ -112,7 +112,7 @@ describe Elastomer::Client::Bulk do
     assert_bulk_delete h['items'].last, 'expected to delete a book'
 
     book_id2 = items.first['create']['_id']
-    assert_match %r/^\S{22}$/, book_id2
+    assert_match %r/^\S{20,22}$/, book_id2
 
     @index.refresh
 

--- a/test/client/cluster_test.rb
+++ b/test/client/cluster_test.rb
@@ -113,7 +113,9 @@ describe Elastomer::Client::Cluster do
 
     it 'adds and gets an alias' do
       hash = @cluster.get_aliases
-      assert_empty hash[@name]['aliases']
+      if es_version_always_returns_aliases?
+        assert_empty hash[@name]['aliases']
+      end
 
       @cluster.update_aliases \
         :add => {:index => @name, :alias => 'elastomer-test-unikitty'}
@@ -124,7 +126,9 @@ describe Elastomer::Client::Cluster do
 
     it 'adds and gets an alias with .aliases' do
       hash = @cluster.aliases
-      assert_empty hash[@name]['aliases']
+      if es_version_always_returns_aliases?
+        assert_empty hash[@name]['aliases']
+      end
 
       @cluster.update_aliases \
         :add => {:index => @name, :alias => 'elastomer-test-unikitty'}

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -43,7 +43,7 @@ describe Elastomer::Client::Docs do
           :author => 'pea53'
 
     assert_created h
-    assert_match %r/^\S{22}$/, h['_id']
+    assert_match %r/^\S{20,22}$/, h['_id']
 
     h = @docs.index \
           :_id    => nil,
@@ -52,7 +52,7 @@ describe Elastomer::Client::Docs do
           :author => 'grantr'
 
     assert_created h
-    assert_match %r/^\S{22}$/, h['_id']
+    assert_match %r/^\S{20,22}$/, h['_id']
 
     h = @docs.index \
           :_id    => '',
@@ -61,7 +61,7 @@ describe Elastomer::Client::Docs do
           :author => 'mojombo'
 
     assert_created h
-    assert_match %r/^\S{22}$/, h['_id']
+    assert_match %r/^\S{20,22}$/, h['_id']
   end
 
   it 'uses the provided document ID' do
@@ -89,7 +89,7 @@ describe Elastomer::Client::Docs do
           :type => 'doc2'
 
     assert_created h
-    assert_match %r/^\S{22}$/, h['_id']
+    assert_match %r/^\S{20,22}$/, h['_id']
   end
 
   it 'extracts underscore attributes from the document' do

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -199,7 +199,6 @@ describe Elastomer::Client::Index do
 
   it 'lists all aliases to the index' do
     @index.create(nil)
-    response = @index.get_aliases
 
     if es_version_always_returns_aliases?
       assert_equal({@name => {'aliases' => {}}}, @index.get_aliases)

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -194,7 +194,12 @@ describe Elastomer::Client::Index do
 
     response = @index.delete_mapping 'doco'
     assert_acknowledged response
-    assert @index.mapping == {} || @index.mapping[@name] == {}
+
+    mapping = @index.get_mapping
+    mapping = mapping[@name] if mapping.key? @name
+    mapping = mapping["mappings"] if mapping.key? "mappings"
+
+    assert_empty mapping, "no mappings are present"
   end
 
   it 'lists all aliases to the index' do

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -199,7 +199,13 @@ describe Elastomer::Client::Index do
 
   it 'lists all aliases to the index' do
     @index.create(nil)
-    assert_equal({@name => {'aliases' => {}}}, @index.get_aliases)
+    response = @index.get_aliases
+
+    if es_version_always_returns_aliases?
+      assert_equal({@name => {'aliases' => {}}}, @index.get_aliases)
+    else
+      assert_equal({@name => {}}, @index.get_aliases)
+    end
 
     $client.cluster.update_aliases :add => {:index => @name, :alias => 'foofaloo'}
     assert_equal({@name => {'aliases' => {'foofaloo' => {}}}}, @index.get_aliases)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -89,6 +89,15 @@ def es_version_1_x?
   $client.semantic_version >= '1.0.0'
 end
 
+# Elasticsearch 1.4 changed the response body for interacting with index
+# alaises. If an index does not contain any aliases, then an "alises" key is no
+# longer returned in the resopsne.
+#
+# Reeturns `true` if the response contains an "alises" key.
+def es_version_always_returns_aliases?
+  $client.semantic_version <= '1.4.0'
+end
+
 # Elasticsearch 1.2 removed support for gateway snapshots.
 #
 # Returns true if Elasticsearch version supports gateway snapshots.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -95,7 +95,7 @@ end
 #
 # Reeturns `true` if the response contains an "alises" key.
 def es_version_always_returns_aliases?
-  $client.semantic_version <= '1.4.0' &&
+  $client.semantic_version <= '1.4.0' ||
   $client.semantic_version >= '1.4.3'
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -95,7 +95,8 @@ end
 #
 # Reeturns `true` if the response contains an "alises" key.
 def es_version_always_returns_aliases?
-  $client.semantic_version <= '1.4.0'
+  $client.semantic_version <= '1.4.0' &&
+  $client.semantic_version >= '1.4.3'
 end
 
 # Elasticsearch 1.2 removed support for gateway snapshots.


### PR DESCRIPTION
Making sure everything works with ElasticSearch 1.4. Thus far it has only been test changes to support differences in response bodies from `aliases` methods and `mappings` methods.

/cc @grantr @dewski @shayfrendt 