### PR TITLE
Response body in the notifications payload

### DIFF
--- a/lib/elastomer/notifications.rb
+++ b/lib/elastomer/notifications.rb
@@ -20,7 +20,7 @@ module Elastomer
   # The payload contains the following bits of information:
   #
   # * :index  - index name (if any)
-  # * :type   - documeht type (if any)
+  # * :type   - document type (if any)
   # * :action - the action being performed
   # * :url    - request URL
   # * :method - request method (:head, :get, :put, :post, :delete)
@@ -42,7 +42,7 @@ module Elastomer
     # The name to subscribe to for notifications
     NAME = 'request.client.elastomer'.freeze
 
-    # Internal: Execute the given block and provide instrumentaiton info to
+    # Internal: Execute the given block and provide instrumentation info to
     # subscribers. The name we use for subscriptions is
     # `request.client.elastomer` and a supplemental payload is provided with
     # more information about the specific ElasticSearch request.
@@ -55,18 +55,20 @@ module Elastomer
     # Returns the response from the block
     def instrument( path, body, params )
       payload = {
-        :index   => params[:index],
-        :type    => params[:type],
-        :action  => params[:action],
-        :context => params[:context],
-        :body    => body
+        :index        => params[:index],
+        :type         => params[:type],
+        :action       => params[:action],
+        :context      => params[:context],
+        :request_body => body,
+        :body         => body   # for backwards compatibility
       }
 
       ::Elastomer::Notifications.service.instrument(NAME, payload) do
         response = yield
-        payload[:url]    = response.env[:url]
-        payload[:method] = response.env[:method]
-        payload[:status] = response.status
+        payload[:url]           = response.env[:url]
+        payload[:method]        = response.env[:method]
+        payload[:status]        = response.status
+        payload[:response_body] = response.body
         response
       end
     end

--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,5 +1,5 @@
 module Elastomer
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 
   def self.version
     VERSION

--- a/test/notifications_test.rb
+++ b/test/notifications_test.rb
@@ -56,6 +56,22 @@ describe Elastomer::Notifications do
     @index.delete; assert_action_event('index.delete')
   end
 
+  it 'includes the response body in the payload' do
+    @index.create('number_of_replicas' => 0)
+    event = @events.detect { |e| e.payload[:action] == 'index.create' }
+    assert event.payload[:response_body]
+  end
+
+  it 'includes the request body in the payload' do
+    @index.create('number_of_replicas' => 0)
+    event = @events.detect { |e| e.payload[:action] == 'index.create' }
+
+    payload = event.payload
+    assert payload[:response_body]
+    assert payload[:request_body]
+    assert_same payload[:body], payload[:request_body]
+  end
+
   def assert_action_event(action)
     assert @events.detect { |e| e.payload[:action] == action }, "expected #{action} event"
   end


### PR DESCRIPTION
I've found a need to access the response body in the notifications payload. I would like to measure the different between the request timing and the search time reported by ES in the response. The difference between the two timing values is the network latency.

/cc @grantr @dewski @shayfrendt 