### PR TITLE
Reset http connection on timeouts

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -187,6 +187,11 @@ module Elastomer
 
         # wrap Faraday errors with appropriate Elastomer::Client error classes
         rescue Faraday::Error::ClientError => boom
+          # reset connection on timeouts to avoid reading incorrect response on next request
+          if Faraday::Error::TimeoutError === boom
+            @connection = nil
+          end
+
           error_name = boom.class.name.split('::').last
           error_class = Elastomer::Client.const_get(error_name) rescue Elastomer::Client::Error
           raise error_class.new(boom, method.upcase, path)


### PR DESCRIPTION
Avoids re-using the same http connection after a read timeout, which can lead to reading in the wrong response on the next request (when the elasticsearch server eventually finishes processing the initial request which we timed out reading a response for).

fixes #100

cc @TwP 