### PR TITLE
Run the snapshot tests only when repo creation is possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ sudo: true
 
 before_install:
     - curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.7.1.deb
-    - "echo 'repo.path: /tmp/elasticsearch' >> /etc/elasticsearch/elasticsearch.yml"
+    - "sudo echo 'repo.path: /tmp/elasticsearch' >> /etc/elasticsearch/elasticsearch.yml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,7 @@ services:
 notifications:
   email: false
 
-sudo: false
+sudo: true
+
+before_install:
+    - curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.7.1.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ sudo: true
 
 before_install:
     - curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.7.1.deb
-    - "sudo echo 'repo.path: /tmp/elasticsearch' >> /etc/elasticsearch/elasticsearch.yml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ sudo: true
 
 before_install:
     - curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.7.1.deb
+    - echo "repo.path: /tmp/elasticsearch" >> /etc/elasticsearch/elasticsearch.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,4 @@ services:
 notifications:
   email: false
 
-sudo: true
-
-before_install:
-    - curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.7.1.deb
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ sudo: true
 
 before_install:
     - curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.deb && sudo dpkg -i --force-confnew elasticsearch-1.7.1.deb
-    - echo "repo.path: /tmp/elasticsearch" >> /etc/elasticsearch/elasticsearch.yml
+    - "echo 'repo.path: /tmp/elasticsearch' >> /etc/elasticsearch/elasticsearch.yml"

--- a/script/cibuild
+++ b/script/cibuild
@@ -12,11 +12,6 @@ PATH="$(pwd)/bin:$(pwd)/script:/usr/share/rbenv/shims:$PATH"
 git log -n 1 || true
 echo
 
-# Create a snapshot dir and make it world writable
-export SNAPSHOT_DIR=/tmp/elastomer-client-snapshot-test
-mkdir -p $SNAPSHOT_DIR
-chmod a+rw $SNAPSHOT_DIR
-
 result=0
 
 export RBENV_VERSION="2.1.1-github"

--- a/test/client/repository_test.rb
+++ b/test/client/repository_test.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../test_helper', __FILE__)
 
 describe Elastomer::Client::Repository do
 
-  if es_version_1_x?
+  if es_version_1_x? && run_snapshot_tests?
 
     before do
       @name = 'elastomer-repository-test'

--- a/test/client/snapshot_test.rb
+++ b/test/client/snapshot_test.rb
@@ -2,7 +2,7 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 describe Elastomer::Client::Snapshot do
-  if es_version_1_x?
+  if es_version_1_x? && run_snapshot_tests?
     before do
       @index_name = 'elastomer-snapshot-test-index'
       @index = $client.index(@index_name)


### PR DESCRIPTION
On ES 1.6+ creation of FS repositories is impossible unless `repo.path` is set in the config. This causes snapshot and repository tests to fail with a default ES config, which is not great.

Instead of always running snapshot tests, only run them if repo creation succeeds. If repo creation fails, snapshot tests are skipped and a warning is displayed:

```
Could not create a snapshot repo. Snapshot tests will be disabled.
To enable snapshot tests, add a path.repo setting to your elasticsearch.yml file.
```

/cc @TwP