### PR TITLE
Fixing test file patterns

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "bundler/gem_tasks"
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|
-    t.pattern = "test/**/*_test.rb"
+    t.test_files = FileList["test/**/*_test.rb"]
 end
 
 task :default => :test

--- a/script/test
+++ b/script/test
@@ -2,5 +2,5 @@
 set -e
 cd "$(dirname "$0")/.."
 
-fn=${1:-"test/**/*_test.rb"}
+fn=${1:-"test/**/*_test.rb test/*_test.rb"}
 bundle exec testrb -Itest $fn $@


### PR DESCRIPTION
Test files located directly under the `test/` folder were not being run. The matching patterns would only find test files located in sub-folders of the `test/` folder.

/cc @grantr