### PR TITLE
Skip individual tests

### DIFF
--- a/test/client/repository_test.rb
+++ b/test/client/repository_test.rb
@@ -2,9 +2,13 @@ require File.expand_path('../../test_helper', __FILE__)
 
 describe Elastomer::Client::Repository do
 
-  if es_version_1_x? && run_snapshot_tests?
+  if es_version_1_x?
 
     before do
+      if !run_snapshot_tests?
+        skip "To enable snapshot tests, add a path.repo setting to your elasticsearch.yml file."
+      end
+
       @name = 'elastomer-repository-test'
       @repo = $client.repository(@name)
     end

--- a/test/client/snapshot_test.rb
+++ b/test/client/snapshot_test.rb
@@ -2,15 +2,19 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 describe Elastomer::Client::Snapshot do
-  if es_version_1_x? && run_snapshot_tests?
+  if es_version_1_x?
     before do
+      if !run_snapshot_tests?
+        skip "To enable snapshot tests, add a path.repo setting to your elasticsearch.yml file."
+      end
+
       @index_name = 'elastomer-snapshot-test-index'
       @index = $client.index(@index_name)
       @name = 'elastomer-test'
     end
 
     after do
-      @index.delete if @index.exists?
+      @index.delete if @index && @index.exists?
     end
 
     it 'determines if a snapshot exists' do
@@ -99,7 +103,7 @@ describe Elastomer::Client::Snapshot do
       end
 
       after do
-        @restored_index.delete if @restored_index.exists?
+        @restored_index.delete if @restored_index && @restored_index.exists?
       end
 
       it 'restores snapshots with options' do


### PR DESCRIPTION
Cheating a little bit here and putting the `skip` statement in the `before` block so that we check if snapshots are possible with the current ES configuration. If not, then each test is skipped and a nice message is displayed to the user telling them how to enable these tests.

/cc @grantr 