### PR TITLE
Propagate original Scroller options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0 (2015-09-11)
+- Support all URL parameters when using `Client.#scroll`
+- BREAKING: Moved some `Scroller` reader methods into `Scroller.opts`
+
 ## 0.5.1 (2015-04-03)
 - Add response body to notification payload
 

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -128,19 +128,22 @@ module Elastomer
       #
       def initialize( client, query, opts = {} )
         @client = client
-        @query  = query
 
-        @index       = opts.fetch(:index, nil)
-        @type        = opts.fetch(:type, nil)
-        @scroll      = opts.fetch(:scroll, '5m')
-        @size        = opts.fetch(:size, 50)
-        @search_type = opts.fetch(:search_type, nil)
+        default_opts = {
+          :index => nil,
+          :type => nil,
+          :scroll => '5m',
+          :size => 50,
+          :body => query,
+        }
+
+        @opts = default_opts.merge opts
 
         @scroll_id = nil
         @offset = 0
       end
 
-      attr_reader :client, :query, :index, :type, :scroll, :size, :search_type, :scroll_id
+      attr_reader :client, :query, :scroll_id
 
       # Iterate over all the search results from the scan query.
       #
@@ -203,31 +206,17 @@ module Elastomer
       # Returns the response body as a Hash.
       def do_scroll
         if scroll_id.nil?
-          body = client.start_scroll(scroll_opts)
+          body = client.start_scroll(@opts)
           if body['hits']['hits'].empty?
             @scroll_id = body['_scroll_id']
             return do_scroll
           end
         else
-          body = client.continue_scroll(scroll_id, scroll)
+          body = client.continue_scroll(scroll_id, @opts[:scroll])
         end
 
         @scroll_id = body['_scroll_id']
         body
-      end
-
-      # Internal: Returns the options Hash that should be passed to the initial
-      # `Client#start_scroll` method call.
-      def scroll_opts
-        hash = {
-          :scroll => scroll,
-          :size   => size,
-          :index  => index,
-          :type   => type,
-          :body   => query
-        }
-        hash[:search_type] = search_type unless search_type.nil?
-        hash
       end
 
     end  # Scroller

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -101,6 +101,13 @@ module Elastomer
       response.body
     end
 
+    DEFAULT_OPTS = {
+      :index => nil,
+      :type => nil,
+      :scroll => '5m',
+      :size => 50,
+    }.freeze
+
     class Scroller
       # Create a new scroller that can be used to iterate over all the documents
       # returned by the `query`. The Scroller supports both the 'scan' and the
@@ -129,15 +136,7 @@ module Elastomer
       def initialize( client, query, opts = {} )
         @client = client
 
-        default_opts = {
-          :index => nil,
-          :type => nil,
-          :scroll => '5m',
-          :size => 50,
-          :body => query,
-        }
-
-        @opts = default_opts.merge opts
+        @opts = DEFAULT_OPTS.merge({ :body => query }).merge(opts)
 
         @scroll_id = nil
         @offset = 0

--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,5 +1,5 @@
 module Elastomer
-  VERSION = '0.5.1'
+  VERSION = '0.6.0'
 
   def self.version
     VERSION

--- a/test/client/scroller_test.rb
+++ b/test/client/scroller_test.rb
@@ -83,6 +83,16 @@ describe Elastomer::Client::Scroller do
     assert_equal expected, tweets
   end
 
+  it 'propagates URL query strings' do
+    scan = @index.scan(nil, { :q => 'author:pea53 || title:17' })
+
+    counts = {'tweet' => 0, 'book' => 0}
+    scan.each_document { |h| counts[h['_type']] += 1 }
+
+    assert_equal 50, counts['tweet']
+    assert_equal 1, counts['book']
+  end
+
   def populate!
     h = @index.bulk do |b|
       50.times { |num|


### PR DESCRIPTION
This allows for other URL parameters (such as the query string in #106)
to be applied to a scroll operation.

I would like to hear feedback on the approach taken here (using an `@opts` instance variable to bundle the options together) and the code style.