### PR TITLE
Translate the delete_by_query method into a command object

### DIFF
--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -57,7 +57,8 @@ module Elastomer
         unless response.nil?
           @response_stats['took'] += response['took']
 
-          response['items'].map { |i| i['delete'] }.each do |i|
+          response['items'].each do |i|
+            i = i['delete']
             (@response_stats['_indices'][i['_index']] ||= {}).merge!(categorize(i)) { |_, n, m| n + m }
             @response_stats['_indices']['_all'].merge!(categorize(i)) { |_, n, m| n + m }
             @response_stats['failures'] << i unless is_ok? i['status']

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -54,7 +54,7 @@ module Elastomer
       end
 
       def accumulate(response)
-        unless response == nil
+        unless response.nil?
           @response_stats['took'] += response['took']
 
           response['items'].map { |i| i['delete'] }.each do |i|

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -29,27 +29,33 @@ module Elastomer
         @responses << response unless response == nil
       end
 
-      # Perform bulk indexing and/or delete operations. The current index name
-      # and document type will be passed to the bulk API call as part of the
-      # request parameters.
+      # Delete documents from one or more indices and one or more types based
+      # on a query. This method supports both the "request body" query and the
+      # "URI request" query. When using the request body semantics, the query
+      # hash must contain the :query key. Otherwise we assume a URI request is
+      # being made.
       #
-      # params - Parameters Hash that will be passed to the bulk API call.
-      # block  - Required block that is used to accumulate bulk API operations.
-      #          All the operations will be passed to the search cluster via a
-      #          single API request.
+      # The return value follows the format returned by the Elasticsearch Delete
+      # by Query plugin: https://github.com/elastic/elasticsearch/blob/master/docs/plugins/delete-by-query.asciidoc#response-body
       #
-      # Yields a Bulk instance for building bulk API call bodies.
+      # Internally, this method uses a combination of scroll and bulk delete
+      # instead of the Delete by Query API, which was removed in Elasticsearch
+      # 2.0.
+      #
+      # query  - The query body as a Hash
+      # params - Parameters Hash
       #
       # Examples
       #
-      #   docs.bulk do |b|
-      #     b.index( document1 )
-      #     b.index( document2 )
-      #     b.delete( document3 )
-      #     ...
-      #   end
+      #   # request body query
+      #   delete_by_query({:query => {:match_all => {}}}, :type => 'tweet')
       #
-      # Returns the response body as a Hash
+      #   # same thing but using the URI request method
+      #   delete_by_query(:q => '*:*', :type => 'tweet')
+      #
+      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+      #
+      # Returns a Hash of statistics about the delete operations
       def execute()
         # accumulate is called both inside and outside the bulk block in order
         # to capture bulk responses returned from calls to `delete` and the call

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -57,11 +57,11 @@ module Elastomer
         unless response.nil?
           @response_stats['took'] += response['took']
 
-          response['items'].each do |i|
-            i = i['delete']
-            (@response_stats['_indices'][i['_index']] ||= {}).merge!(categorize(i)) { |_, n, m| n + m }
-            @response_stats['_indices']['_all'].merge!(categorize(i)) { |_, n, m| n + m }
-            @response_stats['failures'] << i unless is_ok? i['status']
+          response['items'].each do |item|
+            item = item['delete']
+            (@response_stats['_indices'][item['_index']] ||= {}).merge!(categorize(item)) { |_, n, m| n + m }
+            @response_stats['_indices']['_all'].merge!(categorize(item)) { |_, n, m| n + m }
+            @response_stats['failures'] << item unless is_ok? item['status']
           end
         end
       end
@@ -70,9 +70,9 @@ module Elastomer
         # accumulate is called both inside and outside the bulk block in order
         # to capture bulk responses returned from calls to `delete` and the call
         # to `bulk`
-        accumulate(@client.bulk(@params) do |b|
+        accumulate(@client.bulk(@params) do |bulk|
           @client.scan(@query, @params).each_document do |hit|
-            accumulate(b.delete(_id: hit["_id"], _type: hit["_type"], _index: hit["_index"]))
+            accumulate(bulk.delete(_id: hit["_id"], _type: hit["_type"], _index: hit["_index"]))
           end
         end)
 

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -109,7 +109,7 @@ module Elastomer
       # Perform the Delete by Query action
       #
       # Returns a Hash of statistics about the bulk operation
-      def execute()
+      def execute
         # accumulate is called both inside and outside the bulk block in order
         # to capture bulk responses returned from calls to `delete` and the call
         # to `bulk`

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -24,7 +24,26 @@ module Elastomer
     #
     # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
     #
-    # Returns a Hash of statistics about the delete operations
+    # Returns a Hash of statistics about the delete operations, for example:
+    #
+    #   {
+    #     "took" : 639,
+    #     "_indices" : {
+    #       "_all" : {
+    #         "found" : 5901,
+    #         "deleted" : 5901,
+    #         "missing" : 0,
+    #         "failed" : 0
+    #       },
+    #       "twitter" : {
+    #         "found" : 5901,
+    #         "deleted" : 5901,
+    #         "missing" : 0,
+    #         "failed" : 0
+    #       }
+    #     },
+    #     "failures" : [ ]
+    #   }
     def delete_by_query(query, params = {})
       DeleteByQuery.new(self, query, params).execute
     end

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -4,7 +4,7 @@ module Elastomer
     class DeleteByQuery
 
       def initialize( docs, query, params = nil )
-        @docs    = docs
+        @docs      = docs
         @query     = query
         @params    = params
         @responses = []
@@ -16,7 +16,7 @@ module Elastomer
         status.between?(200, 299)
       end
 
-      def categorize ( items )
+      def categorize( items )
         {
           "found" => items.count { |i| i["found"] },
           "deleted" => items.count { |i| is_ok(i["status"]) },

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -12,16 +12,16 @@ module Elastomer
 
       attr_reader :client, :query, :params, :response_stats
 
-      def is_ok( status )
+      def is_ok?( status )
         status.between?(200, 299)
       end
 
       def categorize( item )
         {
           "found" => item["found"] ? 1 : 0,
-          "deleted" => is_ok(item["status"]) ? 1 : 0,
+          "deleted" => is_ok?(item["status"]) ? 1 : 0,
           "missing" => !item["found"] ? 1 : 0,
-          "failed" => item["found"] && !is_ok(item["status"]) ? 1 : 0,
+          "failed" => item["found"] && !is_ok?(item["status"]) ? 1 : 0,
         }
       end
 
@@ -32,7 +32,7 @@ module Elastomer
           response['items'].map { |i| i['delete'] }.each do |i|
             (@response_stats['_indices'][i['_index']] ||= {}).merge!(categorize(i)) { |_, n, m| n + m }
             @response_stats['_indices']['_all'].merge!(categorize(i)) { |_, n, m| n + m }
-            @response_stats['failures'] << i unless is_ok i['status']
+            @response_stats['failures'] << i unless is_ok? i['status']
           end
         end
       end

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -1,9 +1,37 @@
 module Elastomer
   class Client
 
+    # Delete documents from one or more indices and one or more types based
+    # on a query.
+    #
+    # The return value follows the format returned by the Elasticsearch Delete
+    # by Query plugin: https://github.com/elastic/elasticsearch/blob/master/docs/plugins/delete-by-query.asciidoc#response-body
+    #
+    # Internally, this method uses a combination of scroll and bulk delete
+    # instead of the Delete by Query API, which was removed in Elasticsearch
+    # 2.0.
+    #
+    # query  - The query body as a Hash
+    # params - Parameters Hash
+    #
+    # Examples
+    #
+    #   # request body query
+    #   delete_by_query({:query => {:match_all => {}}}, :type => 'tweet')
+    #
+    #   # same thing but using the URI request method
+    #   delete_by_query(nil, { :q => '*:*', :type => 'tweet' })
+    #
+    # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+    #
+    # Returns a Hash of statistics about the delete operations
+    def delete_by_query(query, params = {})
+      DeleteByQuery.new(self, query, params).execute
+    end
+
     class DeleteByQuery
 
-      def initialize(client, query, params = nil)
+      def initialize(client, query, params = {})
         @client = client
         @query = query
         @params = params
@@ -37,33 +65,6 @@ module Elastomer
         end
       end
 
-      # Delete documents from one or more indices and one or more types based
-      # on a query. This method supports both the "request body" query and the
-      # "URI request" query. When using the request body semantics, the query
-      # hash must contain the :query key. Otherwise we assume a URI request is
-      # being made.
-      #
-      # The return value follows the format returned by the Elasticsearch Delete
-      # by Query plugin: https://github.com/elastic/elasticsearch/blob/master/docs/plugins/delete-by-query.asciidoc#response-body
-      #
-      # Internally, this method uses a combination of scroll and bulk delete
-      # instead of the Delete by Query API, which was removed in Elasticsearch
-      # 2.0.
-      #
-      # query  - The query body as a Hash
-      # params - Parameters Hash
-      #
-      # Examples
-      #
-      #   # request body query
-      #   delete_by_query({:query => {:match_all => {}}}, :type => 'tweet')
-      #
-      #   # same thing but using the URI request method
-      #   delete_by_query(:q => '*:*', :type => 'tweet')
-      #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
-      #
-      # Returns a Hash of statistics about the delete operations
       def execute()
         # accumulate is called both inside and outside the bulk block in order
         # to capture bulk responses returned from calls to `delete` and the call

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -1,37 +1,6 @@
 module Elastomer
   class Client
 
-    # Delete documents from one or more indices and one or more types based
-    # on a query. This method supports both the "request body" query and the
-    # "URI request" query. When using the request body semantics, the query
-    # hash must contain the :query key. Otherwise we assume a URI request is
-    # being made.
-    #
-    # The return value follows the format returned by the Elasticsearch Delete
-    # by Query plugin: https://github.com/elastic/elasticsearch/blob/master/docs/plugins/delete-by-query.asciidoc#response-body
-    #
-    # Internally, this method uses a combination of scroll and bulk delete
-    # instead of the Delete by Query API, which was removed in Elasticsearch
-    # 2.0.
-    #
-    # query  - The query body as a Hash
-    # params - Parameters Hash
-    #
-    # Examples
-    #
-    #   # request body query
-    #   delete_by_query({:query => {:match_all => {}}}, :type => 'tweet')
-    #
-    #   # same thing but using the URI request method
-    #   delete_by_query(:q => '*:*', :type => 'tweet')
-    #
-    # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
-    #
-    # Returns a Hash of statistics about the delete operations
-    def delete_by_query( docs, query, params = nil )
-      DeleteByQuery.new(docs, query, params).execute()
-    end
-
     class DeleteByQuery
 
       def initialize( docs, query, params = nil )

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -3,7 +3,7 @@ module Elastomer
 
     class DeleteByQuery
 
-      def initialize( client, query, params = nil )
+      def initialize(client, query, params = nil)
         @client = client
         @query = query
         @params = params
@@ -12,11 +12,11 @@ module Elastomer
 
       attr_reader :client, :query, :params, :response_stats
 
-      def is_ok?( status )
+      def is_ok?(status)
         status.between?(200, 299)
       end
 
-      def categorize( item )
+      def categorize(item)
         {
           "found" => item["found"] ? 1 : 0,
           "deleted" => is_ok?(item["status"]) ? 1 : 0,
@@ -25,7 +25,7 @@ module Elastomer
         }
       end
 
-      def accumulate( response )
+      def accumulate(response)
         unless response == nil
           @response_stats['took'] += response['took']
 

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -1,0 +1,92 @@
+module Elastomer
+  class Client
+
+    # Delete documents from one or more indices and one or more types based
+    # on a query. This method supports both the "request body" query and the
+    # "URI request" query. When using the request body semantics, the query
+    # hash must contain the :query key. Otherwise we assume a URI request is
+    # being made.
+    #
+    # The return value follows the format returned by the Elasticsearch Delete
+    # by Query plugin: https://github.com/elastic/elasticsearch/blob/master/docs/plugins/delete-by-query.asciidoc#response-body
+    #
+    # Internally, this method uses a combination of scroll and bulk delete
+    # instead of the Delete by Query API, which was removed in Elasticsearch
+    # 2.0.
+    #
+    # query  - The query body as a Hash
+    # params - Parameters Hash
+    #
+    # Examples
+    #
+    #   # request body query
+    #   delete_by_query({:query => {:match_all => {}}}, :type => 'tweet')
+    #
+    #   # same thing but using the URI request method
+    #   delete_by_query(:q => '*:*', :type => 'tweet')
+    #
+    # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+    #
+    # Returns a Hash of statistics about the delete operations
+    def delete_by_query( docs, query, params = nil )
+      DeleteByQuery.new(docs, query, params).execute()
+    end
+
+    class DeleteByQuery
+
+      def initialize( docs, query, params = nil )
+        @docs    = docs
+        @query     = query
+        @params    = params
+        @responses = []
+      end
+
+      attr_reader :docs, :query, :params, :responses
+
+      def is_ok( status )
+        status.between?(200, 299)
+      end
+
+      def categorize ( items )
+        {
+          "found" => items.count { |i| i["found"] },
+          "deleted" => items.count { |i| is_ok(i["status"]) },
+          "missing" => items.count { |i| !i["found"] },
+          "failed" => items.count { |i| i["found"] && !is_ok(i["status"]) },
+        }
+      end
+
+      def accumulate( response )
+        @responses << response unless response == nil
+      end
+
+      def execute()
+        # accumulate is called both inside and outside the bulk block in order
+        # to capture bulk responses returned from calls to `delete` and the call
+        # to `bulk`
+        accumulate(@docs.bulk(@params) do |b|
+          @docs.scan(@query, @params).each_document do |hit|
+            accumulate(b.delete(_id: hit["_id"], _type: hit["_type"], _index: hit["_index"]))
+          end
+        end)
+
+        # collects the array of responses containing arrays of delete action
+        # hashes into an array
+        response_items = @responses.flat_map { |r| r["items"].map { |i| i["delete"] } }
+
+        indices = Hash[response_items
+          .group_by { |i| i["_index"] } # indexes the delete hashes by index name
+          .map { |index, items| [index, categorize(items)] }]
+
+        indices_with_all = indices.merge({ "_all" => indices.values.reduce({}) { |acc, i| acc.merge(i) { |_, n, m| n + m } } })
+
+        {
+          "took" => @responses.map { |r| r["took"] }.reduce(:+),
+          "_indices" => indices_with_all,
+          "failures" => response_items.select { |i| !is_ok(i["status"]) },
+        }
+      end
+
+    end  # DeleteByQuery
+  end  # Client
+end  # Elastomer

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -29,6 +29,27 @@ module Elastomer
         @responses << response unless response == nil
       end
 
+      # Perform bulk indexing and/or delete operations. The current index name
+      # and document type will be passed to the bulk API call as part of the
+      # request parameters.
+      #
+      # params - Parameters Hash that will be passed to the bulk API call.
+      # block  - Required block that is used to accumulate bulk API operations.
+      #          All the operations will be passed to the search cluster via a
+      #          single API request.
+      #
+      # Yields a Bulk instance for building bulk API call bodies.
+      #
+      # Examples
+      #
+      #   docs.bulk do |b|
+      #     b.index( document1 )
+      #     b.index( document2 )
+      #     b.delete( document3 )
+      #     ...
+      #   end
+      #
+      # Returns the response body as a Hash
       def execute()
         # accumulate is called both inside and outside the bulk block in order
         # to capture bulk responses returned from calls to `delete` and the call

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -50,6 +50,12 @@ module Elastomer
 
     class DeleteByQuery
 
+      # Create a new DeleteByQuery command for deleting documents matching a
+      # query
+      #
+      # client - Elastomer::Client used for HTTP requests to the server
+      # query  - The query used to find documents to delete
+      # params - Other URL parameters
       def initialize(client, query, params = {})
         @client = client
         @query = query
@@ -59,10 +65,22 @@ module Elastomer
 
       attr_reader :client, :query, :params, :response_stats
 
+      # Internal: Determine whether or not an HTTP status code is in the range
+      # 200 to 299
+      #
+      # status - HTTP status code
+      #
+      # Returns a boolean
       def is_ok?(status)
         status.between?(200, 299)
       end
 
+      # Internal: Tally the contributions of an item to the found, deleted,
+      # missing, and failed counts for the summary statistics
+      #
+      # item - An element of the items array from a bulk response
+      #
+      # Returns a Hash of counts for each category
       def categorize(item)
         {
           "found" => item["found"] ? 1 : 0,
@@ -72,6 +90,9 @@ module Elastomer
         }
       end
 
+      # Internal: Combine the items in a response with the existing statistics
+      #
+      # response - A bulk response
       def accumulate(response)
         unless response.nil?
           @response_stats['took'] += response['took']
@@ -85,6 +106,9 @@ module Elastomer
         end
       end
 
+      # Perform the Delete by Query action
+      #
+      # Returns a Hash of statistics about the bulk operation
       def execute()
         # accumulate is called both inside and outside the bulk block in order
         # to capture bulk responses returned from calls to `delete` and the call

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -3,14 +3,14 @@ module Elastomer
 
     class DeleteByQuery
 
-      def initialize( docs, query, params = nil )
-        @docs      = docs
+      def initialize( client, query, params = nil )
+        @client    = client
         @query     = query
         @params    = params
         @responses = []
       end
 
-      attr_reader :docs, :query, :params, :responses
+      attr_reader :client, :query, :params, :responses
 
       def is_ok( status )
         status.between?(200, 299)
@@ -33,8 +33,8 @@ module Elastomer
         # accumulate is called both inside and outside the bulk block in order
         # to capture bulk responses returned from calls to `delete` and the call
         # to `bulk`
-        accumulate(@docs.bulk(@params) do |b|
-          @docs.scan(@query, @params).each_document do |hit|
+        accumulate(@client.bulk(@params) do |b|
+          @client.scan(@query, @params).each_document do |hit|
             accumulate(b.delete(_id: hit["_id"], _type: hit["_type"], _index: hit["_index"]))
           end
         end)

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -275,8 +275,9 @@ module Elastomer
       # Returns a Hash of statistics about the delete operations
       def delete_by_query( query, params = nil )
         query, params = extract_params(query) if params.nil?
+        params = { :index => @name, :type => @type }.merge params
 
-        DeleteByQuery.new(self, query, params).execute()
+        DeleteByQuery.new(@client, query, params).execute()
       end
 
       # Returns information and statistics on terms in the fields of a

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -252,25 +252,7 @@ module Elastomer
       # hash must contain the :query key. Otherwise we assume a URI request is
       # being made.
       #
-      # The return value follows the format returned by the Elasticsearch Delete
-      # by Query plugin: https://github.com/elastic/elasticsearch/blob/master/docs/plugins/delete-by-query.asciidoc#response-body
-      #
-      # Internally, this method uses a combination of scroll and bulk delete
-      # instead of the Delete by Query API, which was removed in Elasticsearch
-      # 2.0.
-      #
-      # query  - The query body as a Hash
-      # params - Parameters Hash
-      #
-      # Examples
-      #
-      #   # request body query
-      #   delete_by_query({:query => {:match_all => {}}}, :type => 'tweet')
-      #
-      #   # same thing but using the URI request method
-      #   delete_by_query(:q => '*:*', :type => 'tweet')
-      #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+      # See Client#delete_by_query for more information.
       #
       # Returns a Hash of statistics about the delete operations
       def delete_by_query(query, params = nil)

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -275,9 +275,8 @@ module Elastomer
       # Returns a Hash of statistics about the delete operations
       def delete_by_query(query, params = nil)
         query, params = extract_params(query) if params.nil?
-        params = { :index => @name, :type => @type }.merge params
 
-        DeleteByQuery.new(@client, query, params).execute()
+        DeleteByQuery.new(@client, query, update_params(params, { :index => @name, :type => @type })).execute()
       end
 
       # Returns information and statistics on terms in the fields of a

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -276,7 +276,7 @@ module Elastomer
       def delete_by_query(query, params = nil)
         query, params = extract_params(query) if params.nil?
 
-        DeleteByQuery.new(@client, query, update_params(params, { :index => @name, :type => @type })).execute()
+        @client.delete_by_query(query, update_params(params, { :index => @name, :type => @type }))
       end
 
       # Returns information and statistics on terms in the fields of a

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -273,7 +273,7 @@ module Elastomer
       # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
       #
       # Returns a Hash of statistics about the delete operations
-      def delete_by_query( query, params = nil )
+      def delete_by_query(query, params = nil)
         query, params = extract_params(query) if params.nil?
         params = { :index => @name, :type => @type }.merge params
 

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -276,7 +276,7 @@ module Elastomer
       def delete_by_query(query, params = nil)
         query, params = extract_params(query) if params.nil?
 
-        @client.delete_by_query(query, update_params(params, { :index => @name, :type => @type }))
+        @client.delete_by_query(query, update_params(params))
       end
 
       # Returns information and statistics on terms in the fields of a

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -526,25 +526,7 @@ module Elastomer
       # Delete documents from one or more indices and one or more types based
       # on a query.
       #
-      # The return value follows the format returned by the Elasticsearch Delete
-      # by Query plugin: https://github.com/elastic/elasticsearch/blob/master/docs/plugins/delete-by-query.asciidoc#response-body
-      #
-      # Internally, this method uses a combination of scroll and bulk delete
-      # instead of the Delete by Query API, which was removed in Elasticsearch
-      # 2.0.
-      #
-      # query  - The query body as a Hash
-      # params - Parameters Hash
-      #
-      # Examples
-      #
-      #   # request body query
-      #   delete_by_query({:query => {:match_all => {}}}, :type => 'tweet')
-      #
-      #   # same thing but using the URI request method
-      #   delete_by_query(:q => '*:*', :type => 'tweet')
-      #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+      # See Client#delete_by_query for more information.
       #
       # Returns a Hash of statistics about the delete operations
       def delete_by_query(query, params = nil)

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -523,6 +523,34 @@ module Elastomer
         client.warmer(name, warmer_name)
       end
 
+      # Delete documents from one or more indices and one or more types based
+      # on a query.
+      #
+      # The return value follows the format returned by the Elasticsearch Delete
+      # by Query plugin: https://github.com/elastic/elasticsearch/blob/master/docs/plugins/delete-by-query.asciidoc#response-body
+      #
+      # Internally, this method uses a combination of scroll and bulk delete
+      # instead of the Delete by Query API, which was removed in Elasticsearch
+      # 2.0.
+      #
+      # query  - The query body as a Hash
+      # params - Parameters Hash
+      #
+      # Examples
+      #
+      #   # request body query
+      #   delete_by_query({:query => {:match_all => {}}}, :type => 'tweet')
+      #
+      #   # same thing but using the URI request method
+      #   delete_by_query(:q => '*:*', :type => 'tweet')
+      #
+      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+      #
+      # Returns a Hash of statistics about the delete operations
+      def delete_by_query(query, params = nil)
+        docs.delete_by_query(query, params)
+      end
+
       # Internal: Add default parameters to the `params` Hash and then apply
       # `overrides` to the params if any are given.
       #

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -362,5 +362,25 @@ describe Elastomer::Client::Index do
       response = @index.segments
       assert_includes response["indices"], "elastomer-index-test"
     end
+
+    it 'deletes by query' do
+      @index.docs('foo').index("foo" => "bar")
+      @index.refresh
+      r = @index.delete_by_query(:q => '*')
+      assert_equal({
+        '_all' => {
+          'found' => 1,
+          'deleted' => 1,
+          'missing' => 0,
+          'failed' => 0,
+        },
+        @name => {
+          'found' => 1,
+          'deleted' => 1,
+          'missing' => 0,
+          'failed' => 0,
+        }
+      }, r['_indices'])
+    end
   end
 end


### PR DESCRIPTION
This breaks up the rather large delete_by_query method and puts it in its own class so that it's more manageable. Note that is a branch off of use-scroll-for-delete-by-query, not master.

Command objects are new to me, so this probably isn't the proper way to do it. Let me know if you have any feedback.

/cc @TwP @grantr