### PR TITLE
Set up RuboCop and Overcommit

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -2,4 +2,4 @@ PreCommit:
   RuboCop:
     enabled: true
     problem_on_unmodified_line: ignore
-    flags: ['--fail-level', 'error']
+    flags: ['--fail-level', 'error', '--format', 'emacs']

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,5 @@
+PreCommit:
+  RuboCop:
+    enabled: true
+    problem_on_unmodified_line: ignore
+    flags: ['--fail-level', 'error']

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,81 @@
+# Ruby linting configuration.
+# We only worry about two kinds of issues: 'error' and anything less than that.
+# Error is not about severity, but about taste. Simple style choices that
+# never have a great excuse to be broken, such as 1.9 JSON-like hash syntax,
+# are errors. Choices that tend to have good exceptions in practice, such as
+# line length, are warnings.
+
+# If you'd like to make changes, a full list of available issues is at
+#   https://github.com/bbatsov/rubocop/blob/master/config/enabled.yml
+# A list of configurable issues is at:
+#   https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+#
+# If you disable a check, document why.
+
+
+StringLiterals:
+  EnforcedStyle: double_quotes
+  Severity: error
+
+HashSyntax:
+  EnforcedStyle: hash_rockets
+  Severity: error
+
+AlignHash:
+  SupportedLastArgumentHashStyles: always_ignore
+
+AlignParameters:
+  Enabled: false # This is usually true, but we often want to roll back to
+                 # the start of a line.
+
+Attr:
+  Enabled: false # We have no styleguide guidance here, and it seems to be
+                 # in frequent use.
+
+ClassAndModuleChildren:
+  Enabled: false # module X<\n>module Y is just as good as module X::Y.
+
+Documentation:
+  Exclude:
+    - !ruby/regexp /test\/*.rb/
+
+ClassLength:
+  Exclude:
+    - !ruby/regexp /test\/*.rb/
+
+PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%w': '{}'
+
+LineLength:
+  Max: 79
+  Severity: warning
+
+MultilineTernaryOperator:
+  Severity: error
+
+UnreachableCode:
+  Severity: error
+
+AndOr:
+  Severity: error
+
+EndAlignment:
+  Severity: error
+
+IndentationWidth:
+  Severity: error
+
+MethodLength:
+  CountComments: false  # count full line comments?
+  Max: 20
+  Severity: error
+
+Alias:
+  Enabled: false # We have no guidance on alias vs alias_method
+
+RedundantSelf:
+  Enabled: false # Sometimes a self.field is a bit more clear
+
+IfUnlessModifier:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,8 @@
 #
 # If you disable a check, document why.
 
+AllCops:
+  DisabledByDefault: true
 
 StringLiterals:
   EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
-gem 'simplecov', :require => false, :group => :development, :platform => :ruby_19
+gem "simplecov", :require => false, :group => :development, :platform => :ruby_19

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "bundler/gem_tasks"
 
-require 'rake/testtask'
+require "rake/testtask"
 
 Rake::TestTask.new do |t|
   t.test_files = FileList["test/**/*_test.rb"]

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "bundler/gem_tasks"
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|
-    t.test_files = FileList["test/**/*_test.rb"]
+  t.test_files = FileList["test/**/*_test.rb"]
 end
 
 task :default => :test

--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest","~> 4.7"
   spec.add_development_dependency "webmock","~> 1.21"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "overcommit"
+  spec.add_development_dependency "rubocop"
 end

--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'elastomer/version'
+require "elastomer/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "elastomer-client"

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -75,9 +75,11 @@ module Elastomer
         conn.response :parse_json
         conn.request  :opaque_id if @opaque_id
 
-        @adapter.is_a?(Array) ?
-          conn.adapter(*@adapter) :
+        if @adapter.is_a?(Array)
+          conn.adapter(*@adapter)
+        else
           conn.adapter(@adapter)
+        end
 
         conn.options[:timeout]      = read_timeout
         conn.options[:open_timeout] = open_timeout

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -150,6 +150,7 @@ module Elastomer
     #
     # Returns a Faraday::Response
     # Raises an Elastomer::Client::Error on 4XX and 5XX responses
+    # rubocop:disable Metrics/MethodLength
     def request( method, path, params )
       read_timeout = params.delete :read_timeout
       body = extract_body params
@@ -193,6 +194,7 @@ module Elastomer
         end
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Internal: Extract the :body from the params Hash and convert it to a
     # JSON String format. If the params Hash does not contain a :body then no

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -160,31 +160,32 @@ module Elastomer
 
       instrument(path, body, params) do
         begin
-          response = case method
-          when :head
-            connection.head(path) { |req| req.options[:timeout] = read_timeout if read_timeout }
+          response =
+            case method
+            when :head
+              connection.head(path) { |req| req.options[:timeout] = read_timeout if read_timeout }
 
-          when :get
-            connection.get(path) { |req|
-              req.body = body if body
-              req.options[:timeout] = read_timeout if read_timeout
-            }
+            when :get
+              connection.get(path) { |req|
+                req.body = body if body
+                req.options[:timeout] = read_timeout if read_timeout
+              }
 
-          when :put
-            connection.put(path, body) { |req| req.options[:timeout] = read_timeout if read_timeout }
+            when :put
+              connection.put(path, body) { |req| req.options[:timeout] = read_timeout if read_timeout }
 
-          when :post
-            connection.post(path, body) { |req| req.options[:timeout] = read_timeout if read_timeout }
+            when :post
+              connection.post(path, body) { |req| req.options[:timeout] = read_timeout if read_timeout }
 
-          when :delete
-            connection.delete(path) { |req|
-              req.body = body if body
-              req.options[:timeout] = read_timeout if read_timeout
-            }
+            when :delete
+              connection.delete(path) { |req|
+                req.body = body if body
+                req.options[:timeout] = read_timeout if read_timeout
+              }
 
-          else
-            raise ArgumentError, "unknown HTTP request method: #{method.inspect}"
-          end
+            else
+              raise ArgumentError, "unknown HTTP request method: #{method.inspect}"
+            end
 
           handle_errors response
 

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -1,9 +1,9 @@
-require 'addressable/template'
-require 'faraday'
-require 'multi_json'
-require 'semantic'
+require "addressable/template"
+require "faraday"
+require "multi_json"
+require "semantic"
 
-require 'elastomer/version'
+require "elastomer/version"
 
 module Elastomer
 
@@ -22,7 +22,7 @@ module Elastomer
     #   :opaque_id    - set to `true` to use the 'X-Opaque-Id' request header
     #
     def initialize( opts = {} )
-      host = opts.fetch :host, 'localhost'
+      host = opts.fetch :host, "localhost"
       port = opts.fetch :port, 9200
       @url = opts.fetch :url,  "http://#{host}:#{port}"
 
@@ -41,7 +41,7 @@ module Elastomer
 
     # Returns true if the server is available; returns false otherwise.
     def ping
-      response = head '/', :action => 'cluster.ping'
+      response = head "/", :action => "cluster.ping"
       response.success?
     rescue StandardError
       false
@@ -50,7 +50,7 @@ module Elastomer
 
     # Returns the version String of the attached ElasticSearch instance.
     def version
-      @version ||= info['version']['number']
+      @version ||= info["version"]["number"]
     end
 
     # Returns a Semantic::Version for the attached ElasticSearch instance.
@@ -61,7 +61,7 @@ module Elastomer
 
     # Returns the information Hash from the attached ElasticSearch instance.
     def info
-      response = get '/', :action => 'cluster.info'
+      response = get "/", :action => "cluster.info"
       response.body
     end
 
@@ -191,7 +191,7 @@ module Elastomer
 
         # wrap Faraday errors with appropriate Elastomer::Client error classes
         rescue Faraday::Error::ClientError => boom
-          error_name = boom.class.name.split('::').last
+          error_name = boom.class.name.split("::").last
           error_class = Elastomer::Client.const_get(error_name) rescue Elastomer::Client::Error
           raise error_class.new(boom, method.upcase, path)
         end
@@ -295,7 +295,7 @@ module Elastomer
     # containing and 'error' field.
     def handle_errors( response )
       raise ServerError, response if response.status >= 500
-      raise RequestError, response if response.body.is_a?(Hash) && response.body['error']
+      raise RequestError, response if response.body.is_a?(Hash) && response.body["error"]
 
       response
     end
@@ -315,7 +315,7 @@ module Elastomer
     #
     # Returns the validated param as a String.
     # Raises an ArgumentError if the param is not valid.
-    def assert_param_presence( param, name = 'input value' )
+    def assert_param_presence( param, name = "input value" )
       case param
       when String, Symbol, Numeric
         param = param.to_s.strip
@@ -323,7 +323,7 @@ module Elastomer
         param
 
       when Array
-        param.flatten.map { |item| assert_param_presence(item, name) }.join(',')
+        param.flatten.map { |item| assert_param_presence(item, name) }.join(",")
 
       when nil
         raise ArgumentError, "#{name} cannot be nil"
@@ -337,7 +337,7 @@ module Elastomer
 end  # Elastomer
 
 # require all files in the `client` sub-directory
-Dir.glob(File.expand_path('../client/*.rb', __FILE__)).each { |fn| require fn }
+Dir.glob(File.expand_path("../client/*.rb", __FILE__)).each { |fn| require fn }
 
 # require all files in the `middleware` sub-directory
-Dir.glob(File.expand_path('../middleware/*.rb', __FILE__)).each { |fn| require fn }
+Dir.glob(File.expand_path("../middleware/*.rb", __FILE__)).each { |fn| require fn }

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -35,10 +35,10 @@ module Elastomer
         bulk_obj.call
 
       else
-        raise 'bulk request body cannot be nil' if body.nil?
+        raise "bulk request body cannot be nil" if body.nil?
         params ||= {}
 
-        response = self.post '{/index}{/type}/_bulk', params.merge(:body => body, :action => 'bulk')
+        response = self.post "{/index}{/type}/_bulk", params.merge(:body => body, :action => "bulk")
         response.body
       end
     end

--- a/lib/elastomer/client/cluster.rb
+++ b/lib/elastomer/client/cluster.rb
@@ -34,7 +34,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def health( params = {} )
-        response = client.get '/_cluster/health{/index}', params.merge(:action => 'cluster.health')
+        response = client.get "/_cluster/health{/index}", params.merge(:action => "cluster.health")
         response.body
       end
 
@@ -52,7 +52,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def state( params = {} )
-        response = client.get '/_cluster/state{/metrics}{/indices}', params.merge(:action => 'cluster.state')
+        response = client.get "/_cluster/state{/metrics}{/indices}", params.merge(:action => "cluster.state")
         response.body
       end
 
@@ -67,7 +67,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def stats( params = {} )
-        response = client.get '/_cluster/stats', params.merge(:action => 'cluster.stats')
+        response = client.get "/_cluster/stats", params.merge(:action => "cluster.stats")
         response.body
       end
 
@@ -80,7 +80,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def pending_tasks( params = {} )
-        response = client.get '/_cluster/pending_tasks', params.merge(:action => 'cluster.pending_tasks')
+        response = client.get "/_cluster/pending_tasks", params.merge(:action => "cluster.pending_tasks")
         response.body
       end
 
@@ -101,7 +101,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def get_settings( params = {} )
-        response = client.get '/_cluster/settings', params.merge(:action => 'cluster.get_settings')
+        response = client.get "/_cluster/settings", params.merge(:action => "cluster.get_settings")
         response.body
       end
       alias_method :settings, :get_settings
@@ -117,7 +117,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def update_settings( body, params = {} )
-        response = client.put '/_cluster/settings', params.merge(:body => body, :action => 'cluster.update_settings')
+        response = client.put "/_cluster/settings", params.merge(:body => body, :action => "cluster.update_settings")
         response.body
       end
 
@@ -157,7 +157,7 @@ module Elastomer
           body = {:commands => Array(commands)}
         end
 
-        response = client.post '/_cluster/reroute', params.merge(:body => body, :action => 'cluster.reroute')
+        response = client.post "/_cluster/reroute", params.merge(:body => body, :action => "cluster.reroute")
         response.body
       end
 
@@ -170,7 +170,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def shutdown( params = {} )
-        response = client.post '/_shutdown', params.merge(:action => 'cluster.shutdown')
+        response = client.post "/_shutdown", params.merge(:action => "cluster.shutdown")
         response.body
       end
 
@@ -191,7 +191,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_aliases( params = {} )
-        response = client.get '{/index}/_aliases', params.merge(:action => 'cluster.get_aliases')
+        response = client.get "{/index}/_aliases", params.merge(:action => "cluster.get_aliases")
         response.body
       end
       alias_method :aliases, :get_aliases
@@ -227,7 +227,7 @@ module Elastomer
           body = {:actions => Array(actions)}
         end
 
-        response = client.post '/_aliases', params.merge(:body => body, :action => 'cluster.update_aliases')
+        response = client.post "/_aliases", params.merge(:body => body, :action => "cluster.update_aliases")
         response.body
       end
 
@@ -238,8 +238,8 @@ module Elastomer
       def templates
         # ES 1.x supports state filtering via a path segment called metrics.
         # ES 0.90 uses query parameters instead.
-        if client.semantic_version >= '1.0.0'
-          h = state(:metrics => 'metadata')
+        if client.semantic_version >= "1.0.0"
+          h = state(:metrics => "metadata")
         else
           h = state(
             :filter_blocks        => true,
@@ -247,7 +247,7 @@ module Elastomer
             :filter_routing_table => true,
           )
         end
-        h['metadata']['templates']
+        h["metadata"]["templates"]
       end
 
       # List all indices currently defined. This is just a convenience method
@@ -257,8 +257,8 @@ module Elastomer
       def indices
         # ES 1.x supports state filtering via a path segment called metrics.
         # ES 0.90 uses query parameters instead.
-        if client.semantic_version >= '1.0.0'
-          h = state(:metrics => 'metadata')
+        if client.semantic_version >= "1.0.0"
+          h = state(:metrics => "metadata")
         else
           h = state(
             :filter_blocks        => true,
@@ -266,7 +266,7 @@ module Elastomer
             :filter_routing_table => true,
           )
         end
-        h['metadata']['indices']
+        h["metadata"]["indices"]
       end
 
       # List all nodes currently part of the cluster. This is just a convenience
@@ -277,8 +277,8 @@ module Elastomer
       def nodes
         # ES 1.x supports state filtering via a path segment called metrics.
         # ES 0.90 uses query parameters instead.
-        if client.semantic_version >= '1.0.0'
-          h = state(:metrics => 'nodes')
+        if client.semantic_version >= "1.0.0"
+          h = state(:metrics => "nodes")
         else
           h = state(
             :filter_blocks        => true,
@@ -286,7 +286,7 @@ module Elastomer
             :filter_routing_table => true,
           )
         end
-        h['nodes']
+        h["nodes"]
       end
 
     end

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -60,7 +60,7 @@ module Elastomer
         @client = client
         @query = query
         @params = params
-        @response_stats = { 'took' => 0, '_indices' => { '_all' => {} }, 'failures' => [] }
+        @response_stats = { "took" => 0, "_indices" => { "_all" => {} }, "failures" => [] }
       end
 
       attr_reader :client, :query, :params, :response_stats
@@ -95,9 +95,9 @@ module Elastomer
       # item - A bulk response item
       def accumulate(item)
         item = item["delete"]
-        (@response_stats['_indices'][item['_index']] ||= {}).merge!(categorize(item)) { |_, n, m| n + m }
-        @response_stats['_indices']['_all'].merge!(categorize(item)) { |_, n, m| n + m }
-        @response_stats['failures'] << item unless is_ok? item['status']
+        (@response_stats["_indices"][item["_index"]] ||= {}).merge!(categorize(item)) { |_, n, m| n + m }
+        @response_stats["_indices"]["_all"].merge!(categorize(item)) { |_, n, m| n + m }
+        @response_stats["failures"] << item unless is_ok? item["status"]
       end
 
       # Perform the Delete by Query action
@@ -111,7 +111,7 @@ module Elastomer
         end
 
         stats = @client.bulk_stream_items(ops, @params) { |item| accumulate(item) }
-        @response_stats['took'] = stats['took']
+        @response_stats["took"] = stats["took"]
         @response_stats
       end
 

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -106,7 +106,7 @@ module Elastomer
       def execute
         ops = Enumerator.new do |yielder|
           @client.scan(@query, @params.merge(:_source => false)).each_document do |hit|
-            yielder.yield([:delete, { _id: hit["_id"], _type: hit["_type"], _index: hit["_index"] }])
+            yielder.yield([:delete, { :_id => hit["_id"], :_type => hit["_type"], :_index => hit["_index"] }])
           end
         end
 

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -26,8 +26,8 @@ module Elastomer
       #
       def initialize( client, name, type = nil )
         @client = client
-        @name   = @client.assert_param_presence(name, 'index name') unless name.nil?
-        @type   = @client.assert_param_presence(type, 'document type') unless type.nil?
+        @name   = @client.assert_param_presence(name, "index name") unless name.nil?
+        @type   = @client.assert_param_presence(type, "document type") unless type.nil?
       end
 
       attr_reader :client, :name, :type
@@ -68,15 +68,15 @@ module Elastomer
       def index( document, params = {} )
         overrides = from_document document
         params = update_params(params, overrides)
-        params[:action] = 'docs.index'
+        params[:action] = "docs.index"
 
         params.delete(:id) if params[:id].nil? || params[:id].to_s =~ /\A\s*\z/
 
         response =
             if params[:id]
-              client.put '/{index}/{type}/{id}', params
+              client.put "/{index}/{type}/{id}", params
             else
-              client.post '/{index}/{type}', params
+              client.post "/{index}/{type}", params
             end
 
         response.body
@@ -92,7 +92,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete( params = {} )
-        response = client.delete '/{index}/{type}/{id}', update_params(params, :action => 'docs.delete')
+        response = client.delete "/{index}/{type}/{id}", update_params(params, :action => "docs.delete")
         response.body
       end
 
@@ -106,7 +106,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get( params = {} )
-        response = client.get '/{index}/{type}/{id}', update_params(params, :action => 'docs.get')
+        response = client.get "/{index}/{type}/{id}", update_params(params, :action => "docs.get")
         response.body
       end
 
@@ -120,7 +120,7 @@ module Elastomer
       #
       # Returns true if the document exists
       def exists?( params = {} )
-        response = client.head '/{index}/{type}/{id}', update_params(params, :action => 'docs.exists')
+        response = client.head "/{index}/{type}/{id}", update_params(params, :action => "docs.exists")
         response.success?
       end
       alias_method :exist?, :exists?
@@ -135,7 +135,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def source( params = {} )
-        response = client.get '/{index}/{type}/{id}/_source', update_params(params, :action => 'docs.source')
+        response = client.get "/{index}/{type}/{id}/_source", update_params(params, :action => "docs.source")
         response.body
       end
 
@@ -149,9 +149,9 @@ module Elastomer
       # Returns the response body as a Hash
       def multi_get( body, params = {} )
         overrides = from_document body
-        overrides[:action] = 'docs.multi_get'
+        overrides[:action] = "docs.multi_get"
 
-        response = client.get '{/index}{/type}/_mget', update_params(params, overrides)
+        response = client.get "{/index}{/type}/_mget", update_params(params, overrides)
         response.body
       end
       alias_method :mget, :multi_get
@@ -166,9 +166,9 @@ module Elastomer
       # Returns the response body as a Hash
       def update( script, params = {} )
         overrides = from_document script
-        overrides[:action] = 'docs.update'
+        overrides[:action] = "docs.update"
 
-        response = client.post '/{index}/{type}/{id}/_update', update_params(params, overrides)
+        response = client.post "/{index}/{type}/{id}/_update", update_params(params, overrides)
         response.body
       end
 
@@ -197,7 +197,7 @@ module Elastomer
       def search( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
-        response = client.get '/{index}{/type}/_search', update_params(params, :body => query, :action => 'docs.search')
+        response = client.get "/{index}{/type}/_search", update_params(params, :body => query, :action => "docs.search")
         response.body
       end
 
@@ -215,7 +215,7 @@ module Elastomer
       #
       # Returns the response body as a hash
       def search_shards( params = {} )
-        response = client.get '/{index}{/type}/_search_shards', update_params(params, :action => 'docs.search_shards')
+        response = client.get "/{index}{/type}/_search_shards", update_params(params, :action => "docs.search_shards")
         response.body
       end
 
@@ -242,7 +242,7 @@ module Elastomer
       def count( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
-        response = client.get '/{index}{/type}/_count', update_params(params, :body => query, :action => 'docs.count')
+        response = client.get "/{index}{/type}/_count", update_params(params, :body => query, :action => "docs.count")
         response.body
       end
 
@@ -273,7 +273,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def percolate(body, params = {})
-        response = client.get '/{index}/{type}{/id}/_percolate', update_params(params, :body => body, :action => 'percolator.percolate')
+        response = client.get "/{index}/{type}{/id}/_percolate", update_params(params, :body => body, :action => "percolator.percolate")
         response.body
       end
 
@@ -289,7 +289,7 @@ module Elastomer
       #
       # Returns the count
       def percolate_count(body, params = {})
-        response = client.get '/{index}/{type}{/id}/_percolate/count', update_params(params, :body => body, :action => 'percolator.percolate_count')
+        response = client.get "/{index}/{type}{/id}/_percolate/count", update_params(params, :body => body, :action => "percolator.percolate_count")
         response.body["total"]
       end
 
@@ -304,7 +304,7 @@ module Elastomer
       #
       # Returns the response body as a hash
       def termvector( params = {} )
-        response = client.get '/{index}/{type}/{id}/_termvector', update_params(params, :action => 'docs.termvector')
+        response = client.get "/{index}/{type}/{id}/_termvector", update_params(params, :action => "docs.termvector")
         response.body
       end
       alias_method :termvectors, :termvector
@@ -322,7 +322,7 @@ module Elastomer
       #
       # Returns the response body as a hash
       def multi_termvectors( body, params = {} )
-        response = client.get '{/index}{/type}/_mtermvectors', update_params(params, :body => body, :action => 'docs.multi_termvectors')
+        response = client.get "{/index}{/type}/_mtermvectors", update_params(params, :body => body, :action => "docs.multi_termvectors")
         response.body
       end
       alias_method :multi_term_vectors, :multi_termvectors
@@ -354,7 +354,7 @@ Percolate
       def more_like_this( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
-        response = client.get '/{index}/{type}/{id}/_mlt', update_params(params, :body => query, :action => 'docs.more_like_this')
+        response = client.get "/{index}/{type}/{id}/_mlt", update_params(params, :body => query, :action => "docs.more_like_this")
         response.body
       end
 
@@ -378,7 +378,7 @@ Percolate
       def explain( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
-        response = client.get '/{index}/{type}/{id}/_explain', update_params(params, :body => query, :action => 'docs.explain')
+        response = client.get "/{index}/{type}/{id}/_explain", update_params(params, :body => query, :action => "docs.explain")
         response.body
       end
 
@@ -403,7 +403,7 @@ Percolate
       def validate( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
-        response = client.get '/{index}{/type}/_validate/query', update_params(params, :body => query, :action => 'docs.validate')
+        response = client.get "/{index}{/type}/_validate/query", update_params(params, :body => query, :action => "docs.validate")
         response.body
       end
 
@@ -429,7 +429,7 @@ Percolate
       #
       # Returns the response body as a Hash
       def bulk( params = {}, &block )
-        raise 'a block is required' if block.nil?
+        raise "a block is required" if block.nil?
 
         params = {:index => self.name, :type => self.type}.merge params
         client.bulk params, &block
@@ -513,7 +513,7 @@ Percolate
       #
       # Returns the response body as a Hash
       def multi_search( params = {}, &block )
-        raise 'a block is required' if block.nil?
+        raise "a block is required" if block.nil?
 
         params = {:index => self.name, :type => self.type}.merge params
         client.multi_search params, &block
@@ -580,7 +580,7 @@ Percolate
       def update_params( params, overrides = nil )
         h = defaults.update params
         h.update overrides unless overrides.nil?
-        h[:routing] = h[:routing].join(',') if Array === h[:routing]
+        h[:routing] = h[:routing].join(",") if Array === h[:routing]
         h
       end
 

--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -29,11 +29,11 @@ module Elastomer
           @status = response.status
           body = response.body
 
-          message = body.is_a?(Hash) && body['error'] || body.to_s
+          message = body.is_a?(Hash) && body["error"] || body.to_s
           super message
 
         else
-          super args.join(' ')
+          super args.join(" ")
         end
       end
 

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -24,7 +24,7 @@ module Elastomer
       #
       def initialize( client, name )
         @client = client
-        @name   = @client.assert_param_presence(name, 'index name') unless name.nil?
+        @name   = @client.assert_param_presence(name, "index name") unless name.nil?
       end
 
       attr_reader :client, :name
@@ -40,7 +40,7 @@ module Elastomer
       #
       # Returns true if the index (or type) exists
       def exists?( params = {} )
-        response = client.head '/{index}{/type}', update_params(params, :action => 'index.exists')
+        response = client.head "/{index}{/type}", update_params(params, :action => "index.exists")
         response.success?
       end
       alias_method :exist?, :exists?
@@ -54,7 +54,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create( body, params = {} )
-        response = client.post '/{index}', update_params(params, :body => body, :action => 'index.create')
+        response = client.post "/{index}", update_params(params, :body => body, :action => "index.create")
         response.body
       end
 
@@ -66,7 +66,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete( params = {} )
-        response = client.delete '/{index}', update_params(params, :action => 'index.delete')
+        response = client.delete "/{index}", update_params(params, :action => "index.delete")
         response.body
       end
 
@@ -78,7 +78,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def open( params = {} )
-        response = client.post '/{index}/_open', update_params(params, :action => 'index.open')
+        response = client.post "/{index}/_open", update_params(params, :action => "index.open")
         response.body
       end
 
@@ -90,7 +90,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def close( params = {} )
-        response = client.post '/{index}/_close', update_params(params, :action => 'index.close')
+        response = client.post "/{index}/_close", update_params(params, :action => "index.close")
         response.body
       end
 
@@ -102,7 +102,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_settings( params = {} )
-        response = client.get '{/index}/_settings', update_params(params, :action => 'index.get_settings')
+        response = client.get "{/index}/_settings", update_params(params, :action => "index.get_settings")
         response.body
       end
       alias_method :settings, :get_settings
@@ -116,7 +116,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def update_settings( body, params = {} )
-        response = client.put '{/index}/_settings', update_params(params, :body => body, :action => 'index.update_settings')
+        response = client.put "{/index}/_settings", update_params(params, :body => body, :action => "index.update_settings")
         response.body
       end
 
@@ -130,7 +130,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_mapping( params = {} )
-        response = client.get '/{index}{/type}/_mapping', update_params(params, :action => 'index.get_mapping')
+        response = client.get "/{index}{/type}/_mapping", update_params(params, :action => "index.get_mapping")
         response.body
       end
       alias_method :mapping, :get_mapping
@@ -145,7 +145,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def update_mapping( type, body, params = {} )
-        response = client.put '/{index}/{type}/_mapping', update_params(params, :body => body, :type => type, :action => 'index.update_mapping')
+        response = client.put "/{index}/{type}/_mapping", update_params(params, :body => body, :type => type, :action => "index.update_mapping")
         response.body
       end
       alias_method :put_mapping, :update_mapping
@@ -160,7 +160,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete_mapping( type, params = {} )
-        response = client.delete '/{index}/{type}', update_params(params, :type => type, :action => 'index.delete_mapping')
+        response = client.delete "/{index}/{type}", update_params(params, :type => type, :action => "index.delete_mapping")
         response.body
       end
 
@@ -172,7 +172,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_aliases( params = {} )
-        response = client.get '/{index}/_aliases', update_params(:action => 'index.get_aliases')
+        response = client.get "/{index}/_aliases", update_params(:action => "index.get_aliases")
         response.body
       end
       alias_method :aliases, :get_aliases
@@ -193,7 +193,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_alias( name, params = {} )
-        response = client.get '/{index}/_alias/{name}', update_params(params, :name => name, :action => 'index.get_alias')
+        response = client.get "/{index}/_alias/{name}", update_params(params, :name => name, :action => "index.get_alias")
         response.body
       end
 
@@ -212,7 +212,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def add_alias( name, params = {} )
-        response = client.put '/{index}/_alias/{name}', update_params(params, :name => name, :action => 'index.add_alias')
+        response = client.put "/{index}/_alias/{name}", update_params(params, :name => name, :action => "index.add_alias")
         response.body
       end
 
@@ -230,7 +230,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete_alias( name, params = {} )
-        response = client.delete '/{index}/_alias/{name}', update_params(params, :name => name, :action => 'index.delete_alias')
+        response = client.delete "/{index}/_alias/{name}", update_params(params, :name => name, :action => "index.delete_alias")
         response.body
       end
 
@@ -243,7 +243,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def analyze( text, params = {} )
-        response = client.get '{/index}/_analyze', update_params(params, :body => text.to_s, :action => 'index.analyze')
+        response = client.get "{/index}/_analyze", update_params(params, :body => text.to_s, :action => "index.analyze")
         response.body
       end
 
@@ -257,7 +257,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def refresh( params = {} )
-        response = client.post '{/index}/_refresh', update_params(params, :action => 'index.refresh')
+        response = client.post "{/index}/_refresh", update_params(params, :action => "index.refresh")
         response.body
       end
 
@@ -270,7 +270,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def flush( params = {} )
-        response = client.post '{/index}/_flush', update_params(params, :action => 'index.flush')
+        response = client.post "{/index}/_flush", update_params(params, :action => "index.flush")
         response.body
       end
 
@@ -284,7 +284,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def optimize( params = {} )
-        response = client.post '{/index}/_optimize', update_params(params, :action => 'index.optimize')
+        response = client.post "{/index}/_optimize", update_params(params, :action => "index.optimize")
         response.body
       end
 
@@ -300,7 +300,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def snapshot( params = {} )
-        response = client.post '{/index}/_gateway/snapshot', update_params(params, :action => 'index.snapshot')
+        response = client.post "{/index}/_gateway/snapshot", update_params(params, :action => "index.snapshot")
         response.body
       end
 
@@ -313,7 +313,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def recovery( params = {} )
-        response = client.get '{/index}/_recovery', update_params(params, :action => 'index.recovery')
+        response = client.get "{/index}/_recovery", update_params(params, :action => "index.recovery")
         response.body
       end
 
@@ -327,7 +327,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def clear_cache( params = {} )
-        response = client.post '{/index}/_cache/clear', update_params(params, :action => 'index.clear_cache')
+        response = client.post "{/index}/_cache/clear", update_params(params, :action => "index.clear_cache")
         response.body
       end
 
@@ -340,7 +340,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def stats( params = {} )
-        response = client.get '{/index}/_stats', update_params(params, :action => 'index.stats')
+        response = client.get "{/index}/_stats", update_params(params, :action => "index.stats")
         response.body
       end
 
@@ -355,7 +355,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def status( params = {} )
-        response = client.get '{/index}/_status', update_params(params, :action => 'index.status')
+        response = client.get "{/index}/_status", update_params(params, :action => "index.status")
         response.body
       end
 
@@ -368,7 +368,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def segments( params = {} )
-        response = client.get '{/index}/_segments', update_params(params, :action => 'index.segments')
+        response = client.get "{/index}/_segments", update_params(params, :action => "index.segments")
         response.body
       end
 
@@ -407,7 +407,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def bulk( params = {}, &block )
-        raise 'a block is required' if block.nil?
+        raise "a block is required" if block.nil?
 
         params = {:index => self.name}.merge params
         client.bulk params, &block
@@ -495,7 +495,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def multi_search( params = {}, &block )
-        raise 'a block is required' if block.nil?
+        raise "a block is required" if block.nil?
 
         params = {:index => self.name}.merge params
         client.multi_search params, &block

--- a/lib/elastomer/client/multi_percolate.rb
+++ b/lib/elastomer/client/multi_percolate.rb
@@ -37,10 +37,10 @@ module Elastomer
         yield mpercolate_obj = MultiPercolate.new(self, params)
         mpercolate_obj.call
       else
-        raise 'multi_percolate request body cannot be nil' if body.nil?
+        raise "multi_percolate request body cannot be nil" if body.nil?
         params ||= {}
 
-        response = self.post '{/index}{/type}/_mpercolate', params.merge(:body => body)
+        response = self.post "{/index}{/type}/_mpercolate", params.merge(:body => body)
         response.body
       end
     end

--- a/lib/elastomer/client/multi_search.rb
+++ b/lib/elastomer/client/multi_search.rb
@@ -37,10 +37,10 @@ module Elastomer
         yield msearch_obj = MultiSearch.new(self, params)
         msearch_obj.call
       else
-        raise 'multi_search request body cannot be nil' if body.nil?
+        raise "multi_search request body cannot be nil" if body.nil?
         params ||= {}
 
-        response = self.post '{/index}{/type}/_msearch', params.merge(:body => body)
+        response = self.post "{/index}{/type}/_msearch", params.merge(:body => body)
         response.body
       end
     end

--- a/lib/elastomer/client/nodes.rb
+++ b/lib/elastomer/client/nodes.rb
@@ -49,7 +49,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def info( params = {} )
-        response = client.get '/_nodes{/node_id}{/info}', update_params(params, :action => 'nodes.info')
+        response = client.get "/_nodes{/node_id}{/info}", update_params(params, :action => "nodes.info")
         response.body
       end
 
@@ -69,7 +69,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def stats( params = {} )
-        response = client.get '/_nodes{/node_id}/stats{/stats}', update_params(params, :action => 'nodes.stats')
+        response = client.get "/_nodes{/node_id}/stats{/stats}", update_params(params, :action => "nodes.stats")
         response.body
       end
 
@@ -87,7 +87,7 @@ module Elastomer
       #
       # Returns the response as a String
       def hot_threads( params = {} )
-        response = client.get '/_nodes{/node_id}/hot_threads', update_params(params, :action => 'nodes.hot_threads')
+        response = client.get "/_nodes{/node_id}/hot_threads", update_params(params, :action => "nodes.hot_threads")
         response.body
       end
 
@@ -101,7 +101,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def shutdown( params = {} )
-        response = client.post '/_cluster/nodes{/node_id}/_shutdown', update_params(params, :action => 'nodes.shutdown')
+        response = client.post "/_cluster/nodes{/node_id}/_shutdown", update_params(params, :action => "nodes.shutdown")
         response.body
       end
 

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -10,8 +10,8 @@ module Elastomer
       # id         - The _id for the query
       def initialize(client, index_name, id)
         @client = client
-        @index_name = client.assert_param_presence(index_name, 'index name')
-        @id = client.assert_param_presence(id, 'id')
+        @index_name = client.assert_param_presence(index_name, "index name")
+        @id = client.assert_param_presence(id, "id")
       end
 
       attr_reader :client, :index_name, :id
@@ -25,7 +25,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create(body, params = {})
-        response = client.put("/{index}/.percolator/{id}", defaults.merge(params.merge(:body => body, :action => 'percolator.create')))
+        response = client.put("/{index}/.percolator/{id}", defaults.merge(params.merge(:body => body, :action => "percolator.create")))
         response.body
       end
 
@@ -38,7 +38,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get(params = {})
-        response = client.get("/{index}/.percolator/{id}", defaults.merge(params.merge(:action => 'percolator.get')))
+        response = client.get("/{index}/.percolator/{id}", defaults.merge(params.merge(:action => "percolator.get")))
         response.body
       end
 
@@ -51,7 +51,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete(params = {})
-        response = client.delete("/{index}/.percolator/{id}", defaults.merge(params.merge(:action => 'percolator.delete')))
+        response = client.delete("/{index}/.percolator/{id}", defaults.merge(params.merge(:action => "percolator.delete")))
         response.body
       end
 

--- a/lib/elastomer/client/repository.rb
+++ b/lib/elastomer/client/repository.rb
@@ -14,7 +14,7 @@ module Elastomer
       # name   - The name of the index as a String or an Array of names
       def initialize(client, name = nil)
         @client = client
-        @name   = @client.assert_param_presence(name, 'repository name') unless name.nil?
+        @name   = @client.assert_param_presence(name, "repository name") unless name.nil?
       end
 
       attr_reader :client, :name
@@ -26,7 +26,7 @@ module Elastomer
       #
       # Returns true if the repository exists
       def exists?(params = {})
-        response = client.get '/_snapshot{/repository}', update_params(params, :action => 'repository.exists')
+        response = client.get "/_snapshot{/repository}", update_params(params, :action => "repository.exists")
         response.success?
       rescue Elastomer::Client::Error => exception
         if exception.message =~ /RepositoryMissingException/
@@ -45,7 +45,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create(body, params = {})
-        response = client.put '/_snapshot/{repository}', update_params(params, :body => body, :action => 'repository.create')
+        response = client.put "/_snapshot/{repository}", update_params(params, :body => body, :action => "repository.create")
         response.body
       end
 
@@ -56,7 +56,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get(params = {})
-        response = client.get '/_snapshot{/repository}', update_params(params, :action => 'repository.get')
+        response = client.get "/_snapshot{/repository}", update_params(params, :action => "repository.get")
         response.body
       end
 
@@ -67,7 +67,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def status(params = {})
-        response = client.get '/_snapshot{/repository}/_status', update_params(params, :action => 'repository.status')
+        response = client.get "/_snapshot{/repository}/_status", update_params(params, :action => "repository.status")
         response.body
       end
 
@@ -79,7 +79,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def update(body, params = {})
-        response = client.put '/_snapshot/{repository}', update_params(params, :body => body, :action => 'repository.update')
+        response = client.put "/_snapshot/{repository}", update_params(params, :body => body, :action => "repository.update")
         response.body
       end
 
@@ -90,7 +90,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete(params = {})
-        response = client.delete '/_snapshot/{repository}', update_params(params, :action => 'repository.delete')
+        response = client.delete "/_snapshot/{repository}", update_params(params, :action => "repository.delete")
         response.body
       end
 

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -43,7 +43,7 @@ module Elastomer
     #
     # Returns a new Scroller instance
     def scan( query, opts = {} )
-      opts = opts.merge(:search_type => 'scan')
+      opts = opts.merge(:search_type => "scan")
       Scroller.new(self, query, opts)
     end
 
@@ -72,8 +72,8 @@ module Elastomer
     #
     # Returns the response body as a Hash.
     def start_scroll( opts = {} )
-      opts = opts.merge :action => 'search.start_scroll'
-      response = get '{/index}{/type}/_search', opts
+      opts = opts.merge :action => "search.start_scroll"
+      response = get "{/index}{/type}/_search", opts
       response.body
     end
 
@@ -96,15 +96,15 @@ module Elastomer
     #   # repeat until the results are empty
     #
     # Returns the response body as a Hash.
-    def continue_scroll( scroll_id, scroll = '5m' )
-      response = get '/_search/scroll', :body => scroll_id, :scroll => scroll, :action => 'search.scroll'
+    def continue_scroll( scroll_id, scroll = "5m" )
+      response = get "/_search/scroll", :body => scroll_id, :scroll => scroll, :action => "search.scroll"
       response.body
     end
 
     DEFAULT_OPTS = {
       :index => nil,
       :type => nil,
-      :scroll => '5m',
+      :scroll => "5m",
       :size => 50,
     }.freeze
 
@@ -165,11 +165,11 @@ module Elastomer
         loop do
           body = do_scroll
 
-          hits = body['hits']
-          break if hits['hits'].empty?
+          hits = body["hits"]
+          break if hits["hits"].empty?
 
-          hits['offset'] = @offset
-          @offset += hits['hits'].length
+          hits["offset"] = @offset
+          @offset += hits["hits"].length
 
           yield hits
         end
@@ -195,7 +195,7 @@ module Elastomer
       #
       # Returns this Scan instance.
       def each_document( &block )
-        each { |hits| hits['hits'].each(&block) }
+        each { |hits| hits["hits"].each(&block) }
       end
 
       # Internal: Perform the actual scroll requests. This method wil call out
@@ -206,15 +206,15 @@ module Elastomer
       def do_scroll
         if scroll_id.nil?
           body = client.start_scroll(@opts)
-          if body['hits']['hits'].empty?
-            @scroll_id = body['_scroll_id']
+          if body["hits"]["hits"].empty?
+            @scroll_id = body["_scroll_id"]
             return do_scroll
           end
         else
           body = client.continue_scroll(scroll_id, @opts[:scroll])
         end
 
-        @scroll_id = body['_scroll_id']
+        @scroll_id = body["_scroll_id"]
         body
       end
 

--- a/lib/elastomer/client/snapshot.rb
+++ b/lib/elastomer/client/snapshot.rb
@@ -22,8 +22,8 @@ module Elastomer
       def initialize(client, repository = nil, name = nil)
         @client     = client
         # don't allow nil repository if snapshot name is not nil
-        @repository = @client.assert_param_presence(repository, 'repository name') unless repository.nil? && name.nil?
-        @name       = @client.assert_param_presence(name, 'snapshot name') unless name.nil?
+        @repository = @client.assert_param_presence(repository, "repository name") unless repository.nil? && name.nil?
+        @name       = @client.assert_param_presence(name, "snapshot name") unless name.nil?
       end
 
       attr_reader :client, :repository, :name
@@ -35,7 +35,7 @@ module Elastomer
       #
       # Returns true if the snapshot exists
       def exists?(params = {})
-        response = client.get '/_snapshot/{repository}/{snapshot}', update_params(params, :action => 'snapshot.exists')
+        response = client.get "/_snapshot/{repository}/{snapshot}", update_params(params, :action => "snapshot.exists")
         response.success?
       rescue Elastomer::Client::Error => exception
         if exception.message =~ /SnapshotMissingException/
@@ -54,7 +54,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create(body = {}, params = {})
-        response = client.put '/_snapshot/{repository}/{snapshot}', update_params(params, :body => body, :action => 'snapshot.create')
+        response = client.put "/_snapshot/{repository}/{snapshot}", update_params(params, :body => body, :action => "snapshot.create")
         response.body
       end
 
@@ -66,8 +66,8 @@ module Elastomer
       # Returns the response body as a Hash
       def get(params = {})
         # Set snapshot name or we'll get the repository instead
-        snapshot = name || '_all'
-        response = client.get '/_snapshot/{repository}/{snapshot}', update_params(params, :snapshot => snapshot, :action => 'snapshot.get')
+        snapshot = name || "_all"
+        response = client.get "/_snapshot/{repository}/{snapshot}", update_params(params, :snapshot => snapshot, :action => "snapshot.get")
         response.body
       end
 
@@ -78,7 +78,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def status(params = {})
-        response = client.get '/_snapshot{/repository}{/snapshot}/_status', update_params(params, :action => 'snapshot.status')
+        response = client.get "/_snapshot{/repository}{/snapshot}/_status", update_params(params, :action => "snapshot.status")
         response.body
       end
 
@@ -90,7 +90,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def restore(body = {}, params = {})
-        response = client.post '/_snapshot/{repository}/{snapshot}/_restore', update_params(params, :body => body, :action => 'snapshot.restore')
+        response = client.post "/_snapshot/{repository}/{snapshot}/_restore", update_params(params, :body => body, :action => "snapshot.restore")
         response.body
       end
 
@@ -101,7 +101,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete(params = {})
-        response = client.delete '/_snapshot/{repository}/{snapshot}', update_params(params, :action => 'snapshot.delete')
+        response = client.delete "/_snapshot/{repository}/{snapshot}", update_params(params, :action => "snapshot.delete")
         response.body
       end
 

--- a/lib/elastomer/client/template.rb
+++ b/lib/elastomer/client/template.rb
@@ -36,7 +36,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get( params = {} )
-        response = client.get '/_template/{template}', update_params(params, :action => 'template.get')
+        response = client.get "/_template/{template}", update_params(params, :action => "template.get")
         response.body
       end
 
@@ -48,7 +48,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create( template, params = {} )
-        response = client.put '/_template/{template}', update_params(params, :body => template, :action => 'template.create')
+        response = client.put "/_template/{template}", update_params(params, :body => template, :action => "template.create")
         response.body
       end
 
@@ -59,7 +59,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete( params = {} )
-        response = client.delete '/_template/{template}', update_params(params, :action => 'template.delete')
+        response = client.delete "/_template/{template}", update_params(params, :action => "template.delete")
         response.body
       end
 

--- a/lib/elastomer/client/warmer.rb
+++ b/lib/elastomer/client/warmer.rb
@@ -10,8 +10,8 @@ module Elastomer
       # name       - The name of the warmer as a String
       def initialize(client, index_name, name)
         @client     = client
-        @index_name = @client.assert_param_presence(index_name, 'index name')
-        @name       = @client.assert_param_presence(name, 'warmer name')
+        @index_name = @client.assert_param_presence(index_name, "index name")
+        @name       = @client.assert_param_presence(name, "warmer name")
       end
 
       attr_reader :client, :index_name, :name
@@ -28,7 +28,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create(query, params = {})
-        response = client.put '/{index}{/type}/_warmer/{warmer}', defaults.update(params.update(:body => query))
+        response = client.put "/{index}{/type}/_warmer/{warmer}", defaults.update(params.update(:body => query))
         response.body
       end
 
@@ -39,7 +39,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete(params = {})
-        response = client.delete '/{index}{/type}/_warmer/{warmer}', defaults.update(params)
+        response = client.delete "/{index}{/type}/_warmer/{warmer}", defaults.update(params)
         response.body
       end
 
@@ -50,7 +50,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get(params = {})
-        response = client.get '/{index}{/type}/_warmer/{warmer}', defaults.update(params)
+        response = client.get "/{index}{/type}/_warmer/{warmer}", defaults.update(params)
         response.body
       end
 

--- a/lib/elastomer/core_ext/time.rb
+++ b/lib/elastomer/core_ext/time.rb
@@ -1,4 +1,4 @@
-require 'time'
+require "time"
 
 class Time
   def to_json(ignore = nil)

--- a/lib/elastomer/middleware/encode_json.rb
+++ b/lib/elastomer/middleware/encode_json.rb
@@ -8,8 +8,8 @@ module Elastomer
     #
     # Doesn't try to encode bodies that already are in string form.
     class EncodeJson < Faraday::Middleware
-      CONTENT_TYPE = 'Content-Type'.freeze
-      MIME_TYPE    = 'application/json'.freeze
+      CONTENT_TYPE = "Content-Type".freeze
+      MIME_TYPE    = "application/json".freeze
 
       def call(env)
         match_content_type(env) do |data|
@@ -40,7 +40,7 @@ module Elastomer
 
       def request_type(env)
         type = env[:request_headers][CONTENT_TYPE].to_s
-        type = type.split(';', 2).first if type.index(';')
+        type = type.split(";", 2).first if type.index(";")
         type
       end
     end

--- a/lib/elastomer/middleware/encode_json.rb
+++ b/lib/elastomer/middleware/encode_json.rb
@@ -31,11 +31,11 @@ module Elastomer
 
       def process_request?(env)
         type = request_type(env)
-        has_body?(env) and (type.empty? or type == MIME_TYPE)
+        has_body?(env) && (type.empty? || type == MIME_TYPE)
       end
 
       def has_body?(env)
-        body = env[:body] and !(body.respond_to?(:to_str) and body.empty?)
+        (body = env[:body]) && !(body.respond_to?(:to_str) && body.empty?)
       end
 
       def request_type(env)

--- a/lib/elastomer/middleware/opaque_id.rb
+++ b/lib/elastomer/middleware/opaque_id.rb
@@ -1,4 +1,4 @@
-require 'securerandom'
+require "securerandom"
 
 module Elastomer
   module Middleware
@@ -19,7 +19,7 @@ module Elastomer
     # header](https://github.com/elasticsearch/elasticsearch/issues/1202)
     # for more details.
     class OpaqueId < ::Faraday::Middleware
-      X_OPAQUE_ID = 'X-Opaque-Id'.freeze
+      X_OPAQUE_ID = "X-Opaque-Id".freeze
       COUNTER_MAX = 2**32 - 1
 
       # Faraday middleware implementation.
@@ -47,7 +47,7 @@ module Elastomer
         t = Thread.current
 
         unless t.key? :opaque_id_base
-          t[:opaque_id_base]    = (SecureRandom.urlsafe_base64(12) + '%08x').freeze
+          t[:opaque_id_base]    = (SecureRandom.urlsafe_base64(12) + "%08x").freeze
           t[:opaque_id_counter] = -1
         end
 

--- a/lib/elastomer/middleware/parse_json.rb
+++ b/lib/elastomer/middleware/parse_json.rb
@@ -3,8 +3,8 @@ module Elastomer
 
     # Parse response bodies as JSON.
     class ParseJson < Faraday::Middleware
-      CONTENT_TYPE = 'Content-Type'.freeze
-      MIME_TYPE    = 'application/json'.freeze
+      CONTENT_TYPE = "Content-Type".freeze
+      MIME_TYPE    = "application/json".freeze
 
       def call(environment)
         @app.call(environment).on_complete do |env|
@@ -28,7 +28,7 @@ module Elastomer
 
       def response_type(env)
         type = env[:response_headers][CONTENT_TYPE].to_s
-        type = type.split(';', 2).first if type.index(';')
+        type = type.split(";", 2).first if type.index(";")
         type
       end
     end

--- a/lib/elastomer/middleware/parse_json.rb
+++ b/lib/elastomer/middleware/parse_json.rb
@@ -16,14 +16,14 @@ module Elastomer
 
       # Parse the response body.
       def parse(body)
-        MultiJson.load(body) if body.respond_to?(:to_str) and !body.strip.empty?
+        MultiJson.load(body) if body.respond_to?(:to_str) && !body.strip.empty?
       rescue StandardError, SyntaxError => e
         raise Faraday::Error::ParsingError, e
       end
 
       def process_response?(env)
         type = response_type(env)
-        type.empty? or type == MIME_TYPE
+        type.empty? || type == MIME_TYPE
       end
 
       def response_type(env)

--- a/lib/elastomer/notifications.rb
+++ b/lib/elastomer/notifications.rb
@@ -1,6 +1,6 @@
-require 'active_support/notifications'
-require 'securerandom'
-require 'elastomer/client'
+require "active_support/notifications"
+require "securerandom"
+require "elastomer/client"
 
 module Elastomer
 
@@ -40,7 +40,7 @@ module Elastomer
     end
 
     # The name to subscribe to for notifications
-    NAME = 'request.client.elastomer'.freeze
+    NAME = "request.client.elastomer".freeze
 
     # Internal: Execute the given block and provide instrumentation info to
     # subscribers. The name we use for subscriptions is

--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,5 +1,5 @@
 module Elastomer
-  VERSION = '0.8.0'
+  VERSION = "0.8.0"
 
   def self.version
     VERSION

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,3 +7,5 @@ if bundle check 1>/dev/null 2>&1; then
 else
     exec bundle install --binstubs --path vendor/gems "$@"
 fi
+
+overcommit --install

--- a/script/console
+++ b/script/console
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
-require 'irb'
-require 'rubygems'
-require 'bundler/setup'
+require "irb"
+require "rubygems"
+require "bundler/setup"
 
-$LOAD_PATH.unshift 'lib'
-require 'elastomer/client'
+$LOAD_PATH.unshift "lib"
+require "elastomer/client"
 
 IRB.start

--- a/test/assertions.rb
+++ b/test/assertions.rb
@@ -4,7 +4,7 @@ module Minitest::Assertions
   # in index responses. Check for either one so we are compatible
   # with 0.90 and 1.0.
   def assert_created(response)
-    assert response['created'] || response['ok'], 'document was not created'
+    assert response["created"] || response["ok"], "document was not created"
   end
 
   #COMPATIBILITY
@@ -12,7 +12,7 @@ module Minitest::Assertions
   # in many responses. Check for either one so we are compatible
   # with 0.90 and 1.0.
   def assert_acknowledged(response)
-    assert response['acknowledged'] || response['ok'], 'document was not acknowledged'
+    assert response["acknowledged"] || response["ok"], "document was not acknowledged"
   end
 
   #COMPATIBILITY
@@ -20,32 +20,32 @@ module Minitest::Assertions
   # get document response. Check for either one so we are compatible
   # with 0.90 and 1.0.
   def assert_found(response)
-    assert response['found'] || response['exists'], 'document was not found'
+    assert response["found"] || response["exists"], "document was not found"
   end
 
   def refute_found(response)
-    refute response['found'] || response['exists'], 'document was unexpectedly found'
+    refute response["found"] || response["exists"], "document was unexpectedly found"
   end
 
   #COMPATIBILITY
   # ES 1.0 replaced the 'ok' attribute in the bulk response item with a
   # 'status' attribute. Here we check for either one for compatibility
   # with 0.90 and 1.0.
-  def assert_bulk_index(item, message='bulk index did not succeed')
-    ok     = item['index']['ok']
-    status = item['index']['status']
+  def assert_bulk_index(item, message="bulk index did not succeed")
+    ok     = item["index"]["ok"]
+    status = item["index"]["status"]
     assert ok == true || status == 201, message
   end
 
-  def assert_bulk_create(item, message='bulk create did not succeed')
-    ok     = item['create']['ok']
-    status = item['create']['status']
+  def assert_bulk_create(item, message="bulk create did not succeed")
+    ok     = item["create"]["ok"]
+    status = item["create"]["status"]
     assert ok == true || status == 201, message
   end
 
-  def assert_bulk_delete(item, message='bulk delete did not succeed')
-    ok     = item['delete']['ok']
-    status = item['delete']['status']
+  def assert_bulk_delete(item, message="bulk delete did not succeed")
+    ok     = item["delete"]["ok"]
+    status = item["delete"]["status"]
     assert ok == true || status == 200, message
   end
 
@@ -56,8 +56,8 @@ module Minitest::Assertions
   # mapping["test-index"]["doco"]
   def assert_mapping_exists(response, type, message="mapping expected to exist, but doesn't")
     mapping =
-      if response.has_key?('mappings')
-        response['mappings'][type]
+      if response.has_key?("mappings")
+        response["mappings"][type]
       else
         response[type]
       end
@@ -66,11 +66,11 @@ module Minitest::Assertions
 
   def assert_property_exists(response, type, property, message="property expected to exist, but doesn't")
     mapping =
-      if response.has_key?('mappings')
-        response['mappings'][type]
+      if response.has_key?("mappings")
+        response["mappings"][type]
       else
         response[type]
       end
-    assert mapping['properties'].has_key?(property), message
+    assert mapping["properties"].has_key?(property), message
   end
 end

--- a/test/assertions.rb
+++ b/test/assertions.rb
@@ -55,20 +55,22 @@ module Minitest::Assertions
   # ES 0.90 doesn't have the "mappings" element:
   # mapping["test-index"]["doco"]
   def assert_mapping_exists(response, type, message="mapping expected to exist, but doesn't")
-    mapping = if response.has_key?('mappings')
-      response['mappings'][type]
-    else
-      response[type]
-    end
+    mapping =
+      if response.has_key?('mappings')
+        response['mappings'][type]
+      else
+        response[type]
+      end
     refute_nil mapping, message
   end
 
   def assert_property_exists(response, type, property, message="property expected to exist, but doesn't")
-    mapping = if response.has_key?('mappings')
-      response['mappings'][type]
-    else
-      response[type]
-    end
+    mapping =
+      if response.has_key?('mappings')
+        response['mappings'][type]
+      else
+        response[type]
+      end
     assert mapping['properties'].has_key?(property), message
   end
 end

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -1,27 +1,27 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Bulk do
 
   before do
-    @name  = 'elastomer-bulk-test'
+    @name  = "elastomer-bulk-test"
     @index = $client.index(@name)
 
     unless @index.exists?
       @index.create \
-        :settings => { 'index.number_of_shards' => 1, 'index.number_of_replicas' => 0 },
+        :settings => { "index.number_of_shards" => 1, "index.number_of_replicas" => 0 },
         :mappings => {
           :tweet => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :message => { :type => 'string', :analyzer => 'standard' },
-              :author  => { :type => 'string', :index => 'not_analyzed' }
+              :message => { :type => "string", :analyzer => "standard" },
+              :author  => { :type => "string", :index => "not_analyzed" }
             }
           },
           :book => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => 'string', :analyzer => 'standard' },
-              :author => { :type => 'string', :index => 'not_analyzed' }
+              :title  => { :type => "string", :analyzer => "standard" },
+              :author => { :type => "string", :index => "not_analyzed" }
             }
           }
         }
@@ -34,7 +34,7 @@ describe Elastomer::Client::Bulk do
     @index.delete if @index.exists?
   end
 
-  it 'performs bulk index actions' do
+  it "performs bulk index actions" do
     body = [
       '{"index" : {"_id":"1", "_type":"tweet", "_index":"elastomer-bulk-test"}}',
       '{"author":"pea53", "message":"just a test tweet"}',
@@ -45,16 +45,16 @@ describe Elastomer::Client::Bulk do
     body = body.join "\n"
     h = $client.bulk body
 
-    assert_bulk_index(h['items'][0])
-    assert_bulk_index(h['items'][1])
+    assert_bulk_index(h["items"][0])
+    assert_bulk_index(h["items"][1])
 
     @index.refresh
 
-    h = @index.docs('tweet').get :id => 1
-    assert_equal 'pea53', h['_source']['author']
+    h = @index.docs("tweet").get :id => 1
+    assert_equal "pea53", h["_source"]["author"]
 
-    h = @index.docs('book').get :id => 1
-    assert_equal 'John Scalzi', h['_source']['author']
+    h = @index.docs("book").get :id => 1
+    assert_equal "John Scalzi", h["_source"]["author"]
 
 
     body = [
@@ -66,239 +66,239 @@ describe Elastomer::Client::Bulk do
     body = body.join "\n"
     h = $client.bulk body, :index => @name
 
-    assert_bulk_index h['items'].first, 'expected to index a book'
-    assert_bulk_delete h['items'].last, 'expected to delete a book'
+    assert_bulk_index h["items"].first, "expected to index a book"
+    assert_bulk_delete h["items"].last, "expected to delete a book"
 
     @index.refresh
 
-    h = @index.docs('book').get :id => 1
-    assert !h['exists'], 'was not successfully deleted'
+    h = @index.docs("book").get :id => 1
+    assert !h["exists"], "was not successfully deleted"
 
-    h = @index.docs('book').get :id => 2
-    assert_equal 'Tolkien', h['_source']['author']
+    h = @index.docs("book").get :id => 2
+    assert_equal "Tolkien", h["_source"]["author"]
   end
 
-  it 'supports a nice block syntax' do
+  it "supports a nice block syntax" do
     h = @index.bulk do |b|
-      b.index :_id => 1,   :_type => 'tweet', :author => 'pea53', :message => 'just a test tweet'
-      b.index :_id => nil, :_type => 'book', :author => 'John Scalzi', :title => 'Old Mans War'
+      b.index :_id => 1,   :_type => "tweet", :author => "pea53", :message => "just a test tweet"
+      b.index :_id => nil, :_type => "book", :author => "John Scalzi", :title => "Old Mans War"
     end
-    items = h['items']
+    items = h["items"]
 
-    assert_instance_of Fixnum, h['took']
+    assert_instance_of Fixnum, h["took"]
 
-    assert_bulk_index h['items'].first
-    assert_bulk_create h['items'].last
+    assert_bulk_index h["items"].first
+    assert_bulk_create h["items"].last
 
-    book_id = items.last['create']['_id']
+    book_id = items.last["create"]["_id"]
     assert_match %r/^\S{20,22}$/, book_id
 
     @index.refresh
 
-    h = @index.docs('tweet').get :id => 1
-    assert_equal 'pea53', h['_source']['author']
+    h = @index.docs("tweet").get :id => 1
+    assert_equal "pea53", h["_source"]["author"]
 
-    h = @index.docs('book').get :id => book_id
-    assert_equal 'John Scalzi', h['_source']['author']
+    h = @index.docs("book").get :id => book_id
+    assert_equal "John Scalzi", h["_source"]["author"]
 
 
     h = @index.bulk do |b|
-      b.index  :_id => '', :_type => 'book', :author => 'Tolkien', :title => 'The Silmarillion'
-      b.delete :_id => book_id, :_type => 'book'
+      b.index  :_id => "", :_type => "book", :author => "Tolkien", :title => "The Silmarillion"
+      b.delete :_id => book_id, :_type => "book"
     end
-    items = h['items']
+    items = h["items"]
 
-    assert_bulk_create h['items'].first, 'expected to create a book'
-    assert_bulk_delete h['items'].last, 'expected to delete a book'
+    assert_bulk_create h["items"].first, "expected to create a book"
+    assert_bulk_delete h["items"].last, "expected to delete a book"
 
-    book_id2 = items.first['create']['_id']
+    book_id2 = items.first["create"]["_id"]
     assert_match %r/^\S{20,22}$/, book_id2
 
     @index.refresh
 
-    h = @index.docs('book').get :id => book_id
-    assert !h['exists'], 'was not successfully deleted'
+    h = @index.docs("book").get :id => book_id
+    assert !h["exists"], "was not successfully deleted"
 
-    h = @index.docs('book').get :id => book_id2
-    assert_equal 'Tolkien', h['_source']['author']
+    h = @index.docs("book").get :id => book_id2
+    assert_equal "Tolkien", h["_source"]["author"]
   end
 
-  it 'allows documents to be JSON strings' do
+  it "allows documents to be JSON strings" do
     h = @index.bulk do |b|
-      b.index  '{"author":"pea53", "message":"just a test tweet"}', :_id => 1, :_type => 'tweet'
-      b.create '{"author":"John Scalzi", "title":"Old Mans War"}',  :_id => 1, :_type => 'book'
+      b.index  '{"author":"pea53", "message":"just a test tweet"}', :_id => 1, :_type => "tweet"
+      b.create '{"author":"John Scalzi", "title":"Old Mans War"}',  :_id => 1, :_type => "book"
     end
-    items = h['items']
+    items = h["items"]
 
-    assert_instance_of Fixnum, h['took']
+    assert_instance_of Fixnum, h["took"]
 
-    assert_bulk_index h['items'].first
-    assert_bulk_create h['items'].last
+    assert_bulk_index h["items"].first
+    assert_bulk_create h["items"].last
 
     @index.refresh
 
-    h = @index.docs('tweet').get :id => 1
-    assert_equal 'pea53', h['_source']['author']
+    h = @index.docs("tweet").get :id => 1
+    assert_equal "pea53", h["_source"]["author"]
 
-    h = @index.docs('book').get :id => 1
-    assert_equal 'John Scalzi', h['_source']['author']
+    h = @index.docs("book").get :id => 1
+    assert_equal "John Scalzi", h["_source"]["author"]
 
 
     h = @index.bulk do |b|
-      b.index '{"author":"Tolkien", "title":"The Silmarillion"}', :_id => 2, :_type => 'book'
-      b.delete :_id => 1, :_type => 'book'
+      b.index '{"author":"Tolkien", "title":"The Silmarillion"}', :_id => 2, :_type => "book"
+      b.delete :_id => 1, :_type => "book"
     end
-    items = h['items']
+    items = h["items"]
 
-    assert_bulk_index h['items'].first, 'expected to index a book'
-    assert_bulk_delete h['items'].last, 'expected to delete a book'
+    assert_bulk_index h["items"].first, "expected to index a book"
+    assert_bulk_delete h["items"].last, "expected to delete a book"
 
     @index.refresh
 
-    h = @index.docs('book').get :id => 1
-    assert !h['exists'], 'was not successfully deleted'
+    h = @index.docs("book").get :id => 1
+    assert !h["exists"], "was not successfully deleted"
 
-    h = @index.docs('book').get :id => 2
-    assert_equal 'Tolkien', h['_source']['author']
+    h = @index.docs("book").get :id => 2
+    assert_equal "Tolkien", h["_source"]["author"]
   end
 
-  it 'executes a bulk API call when a request size is reached' do
+  it "executes a bulk API call when a request size is reached" do
     ary = []
     ary << @index.bulk(:request_size => 300) do |b|
       2.times { |num|
-        document = {:_id => num, :_type => 'tweet', :author => 'pea53', :message => "tweet #{num} is a 100 character request"}
+        document = {:_id => num, :_type => "tweet", :author => "pea53", :message => "tweet #{num} is a 100 character request"}
         ary << b.index(document)
       }
       ary.compact!
       assert_equal 0, ary.length
 
       7.times { |num|
-        document = {:_id => num+2, :_type => 'tweet', :author => 'pea53', :message => "tweet #{num+2} is a 100 character request"}
+        document = {:_id => num+2, :_type => "tweet", :author => "pea53", :message => "tweet #{num+2} is a 100 character request"}
         ary << b.index(document)
       }
       ary.compact!
       assert_equal 3, ary.length
 
-      document = {:_id => 10, :_type => 'tweet', :author => 'pea53', :message => "tweet 10 is a 102 character request"}
+      document = {:_id => 10, :_type => "tweet", :author => "pea53", :message => "tweet 10 is a 102 character request"}
       ary << b.index(document)
     end
     ary.compact!
 
     assert_equal 4, ary.length
-    ary.each { |a| a['items'].each { |b| assert_bulk_index(b) } }
+    ary.each { |a| a["items"].each { |b| assert_bulk_index(b) } }
 
     @index.refresh
-    h = @index.docs.search :q => '*:*', :search_type => 'count'
+    h = @index.docs.search :q => "*:*", :search_type => "count"
 
-    assert_equal 10, h['hits']['total']
+    assert_equal 10, h["hits"]["total"]
   end
 
-  it 'executes a bulk API call when an action count is reached' do
+  it "executes a bulk API call when an action count is reached" do
     ary = []
     ary << @index.bulk(:action_count => 3) do |b|
       2.times { |num|
-        document = {:_id => num, :_type => 'tweet', :author => 'pea53', :message => "this is tweet number #{num}"}
+        document = {:_id => num, :_type => "tweet", :author => "pea53", :message => "this is tweet number #{num}"}
         ary << b.index(document)
       }
       ary.compact!
       assert_equal 0, ary.length
 
       7.times { |num|
-        document = {:_id => num+2, :_type => 'tweet', :author => 'pea53', :message => "this is tweet number #{num+2}"}
+        document = {:_id => num+2, :_type => "tweet", :author => "pea53", :message => "this is tweet number #{num+2}"}
         ary << b.index(document)
       }
       ary.compact!
       assert_equal 3, ary.length
 
-      document = {:_id => 10, :_type => 'tweet', :author => 'pea53', :message => "this is tweet number 10"}
+      document = {:_id => 10, :_type => "tweet", :author => "pea53", :message => "this is tweet number 10"}
       ary << b.index(document)
     end
     ary.compact!
 
     assert_equal 4, ary.length
-    ary.each { |a| a['items'].each { |b| assert_bulk_index(b) } }
+    ary.each { |a| a["items"].each { |b| assert_bulk_index(b) } }
 
     @index.refresh
-    h = @index.docs.search :q => '*:*', :search_type => 'count'
+    h = @index.docs.search :q => "*:*", :search_type => "count"
 
-    assert_equal 10, h['hits']['total']
+    assert_equal 10, h["hits"]["total"]
   end
 
-  it 'uses :id from parameters' do
+  it "uses :id from parameters" do
     response = @index.bulk do |b|
-      document = { :_type => 'tweet', :author => 'pea53', :message => 'just a test tweet' }
-      params = { :id => 'foo' }
+      document = { :_type => "tweet", :author => "pea53", :message => "just a test tweet" }
+      params = { :id => "foo" }
 
       b.index document, params
     end
 
-    assert_instance_of Fixnum, response['took']
+    assert_instance_of Fixnum, response["took"]
 
-    items = response['items']
+    items = response["items"]
     assert_bulk_index(items[0])
 
-    assert_equal 'foo', items[0]['index']['_id']
+    assert_equal "foo", items[0]["index"]["_id"]
   end
 
-  it 'supports symbol and string parameters' do
+  it "supports symbol and string parameters" do
     response = @index.bulk do |b|
-      doc1 = { :author => 'pea53', :message => 'a tweet about foo' }
-      b.index doc1, { :id => 'foo', :type => 'tweet' }
+      doc1 = { :author => "pea53", :message => "a tweet about foo" }
+      b.index doc1, { :id => "foo", :type => "tweet" }
 
-      doc2 = { :author => 'pea53', :message => 'a tweet about bar' }
-      b.index doc2, { 'id' => 'bar', 'type' => 'tweet' }
+      doc2 = { :author => "pea53", :message => "a tweet about bar" }
+      b.index doc2, { "id" => "bar", "type" => "tweet" }
     end
 
-    assert_instance_of Fixnum, response['took']
+    assert_instance_of Fixnum, response["took"]
 
-    items = response['items']
+    items = response["items"]
     assert_bulk_index(items[0])
     assert_bulk_index(items[1])
 
-    assert_equal 'a tweet about foo', @index.docs('tweet').get(:id => 'foo')['_source']['message']
-    assert_equal 'a tweet about bar', @index.docs('tweet').get(:id => 'bar')['_source']['message']
+    assert_equal "a tweet about foo", @index.docs("tweet").get(:id => "foo")["_source"]["message"]
+    assert_equal "a tweet about bar", @index.docs("tweet").get(:id => "bar")["_source"]["message"]
   end
 
   it 'doesn\'t override parameters from the document' do
-    document = { :_id => 1, :_type => 'tweet', :author => 'pea53', :message => 'just a test tweet' }
+    document = { :_id => 1, :_type => "tweet", :author => "pea53", :message => "just a test tweet" }
     params = { :id => 2 }
 
     response = @index.bulk do |b|
       b.index document, params
     end
 
-    assert_instance_of Fixnum, response['took']
+    assert_instance_of Fixnum, response["took"]
 
-    items = response['items']
+    items = response["items"]
     assert_bulk_index(items[0])
 
-    refute_found @index.docs('tweet').get(:id => 1)
-    assert_equal 'just a test tweet', @index.docs('tweet').get(:id => 2)['_source']['message']
+    refute_found @index.docs("tweet").get(:id => 1)
+    assert_equal "just a test tweet", @index.docs("tweet").get(:id => 2)["_source"]["message"]
   end
 
   it 'doesn\'t upgrade non-prefixed keys to parameters' do
-    document = { :id => 1, :type => 'book', :version => 5, :author => 'pea53', :message => 'just a test tweet' }
-    params = { :id => 2, :type => 'tweet' }
+    document = { :id => 1, :type => "book", :version => 5, :author => "pea53", :message => "just a test tweet" }
+    params = { :id => 2, :type => "tweet" }
 
     response = @index.bulk do |b|
       b.index document, params
     end
 
-    assert_instance_of Fixnum, response['took']
+    assert_instance_of Fixnum, response["took"]
 
-    items = response['items']
+    items = response["items"]
     assert_bulk_index(items[0])
 
-    assert_equal '2', items[0]['index']['_id']
-    assert_equal 'tweet', items[0]['index']['_type']
-    assert_equal 1, items[0]['index']['_version']
+    assert_equal "2", items[0]["index"]["_id"]
+    assert_equal "tweet", items[0]["index"]["_type"]
+    assert_equal 1, items[0]["index"]["_version"]
   end
 
-  it 'streams bulk responses' do
+  it "streams bulk responses" do
     ops = [
-      [:index, { :message => 'tweet 1' }, { :_id => 1, :_type => 'book', :_index => @index.name }],
-      [:index, { :message => 'tweet 2' }, { :_id => 2, :_type => 'book', :_index => @index.name }],
-      [:index, { :message => 'tweet 3' }, { :_id => 3, :_type => 'book', :_index => @index.name }]
+      [:index, { :message => "tweet 1" }, { :_id => 1, :_type => "book", :_index => @index.name }],
+      [:index, { :message => "tweet 2" }, { :_id => 2, :_type => "book", :_index => @index.name }],
+      [:index, { :message => "tweet 3" }, { :_id => 3, :_type => "book", :_index => @index.name }]
     ]
     responses = $client.bulk_stream_responses(ops, { :action_count => 2 }).to_a
     assert_equal(2, responses.length)
@@ -307,11 +307,11 @@ describe Elastomer::Client::Bulk do
     assert_bulk_index(responses[1]["items"][0])
   end
 
-  it 'streams bulk items' do
+  it "streams bulk items" do
     ops = [
-      [:index, { :message => 'tweet 1' }, { :_id => 1, :_type => 'book', :_index => @index.name }],
-      [:index, { :message => 'tweet 2' }, { :_id => 2, :_type => 'book', :_index => @index.name }],
-      [:index, { :message => 'tweet 3' }, { :_id => 3, :_type => 'book', :_index => @index.name }]
+      [:index, { :message => "tweet 1" }, { :_id => 1, :_type => "book", :_index => @index.name }],
+      [:index, { :message => "tweet 2" }, { :_id => 2, :_type => "book", :_index => @index.name }],
+      [:index, { :message => "tweet 3" }, { :_id => 3, :_type => "book", :_index => @index.name }]
     ]
     items = []
     stats = $client.bulk_stream_items(ops, { :action_count => 2 }) { |item| items << item }

--- a/test/client/cluster_test.rb
+++ b/test/client/cluster_test.rb
@@ -1,9 +1,9 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Cluster do
 
   before do
-    @name = 'elastomer-cluster-test'
+    @name = "elastomer-cluster-test"
     @index = $client.index @name
     @index.delete if @index.exists?
     @cluster = $client.cluster
@@ -13,49 +13,49 @@ describe Elastomer::Client::Cluster do
     @index.delete if @index.exists?
   end
 
-  it 'gets the cluster health' do
+  it "gets the cluster health" do
     h = @cluster.health
-    assert h.key?('cluster_name'), 'the cluster name is returned'
-    assert h.key?('status'), 'the cluster status is returned'
+    assert h.key?("cluster_name"), "the cluster name is returned"
+    assert h.key?("status"), "the cluster status is returned"
   end
 
-  it 'gets the cluster state' do
+  it "gets the cluster state" do
     h = @cluster.state
-    assert h.key?('cluster_name'), 'the cluster name is returned'
-    assert h.key?('master_node'), 'the master node is returned'
-    assert_instance_of Hash, h['nodes'], 'the node list is returned'
-    assert_instance_of Hash, h['metadata'], 'the metadata are returned'
+    assert h.key?("cluster_name"), "the cluster name is returned"
+    assert h.key?("master_node"), "the master node is returned"
+    assert_instance_of Hash, h["nodes"], "the node list is returned"
+    assert_instance_of Hash, h["metadata"], "the metadata are returned"
   end
 
   if es_version_1_x?
-    it 'filters cluster state by metrics' do
-      h = @cluster.state(:metrics => 'nodes')
-      refute h.key('metadata'), 'expected only nodes state'
-      h = @cluster.state(:metrics => 'metadata')
-      refute h.key('nodes'), 'expected only metadata state'
+    it "filters cluster state by metrics" do
+      h = @cluster.state(:metrics => "nodes")
+      refute h.key("metadata"), "expected only nodes state"
+      h = @cluster.state(:metrics => "metadata")
+      refute h.key("nodes"), "expected only metadata state"
     end
 
-    it 'filters cluster state by indices' do
+    it "filters cluster state by indices" do
       @index.create({}) unless @index.exists?
-      h = @cluster.state(:metrics => 'metadata', :indices => @name)
-      assert [@name], h['metadata']['indices'].keys
+      h = @cluster.state(:metrics => "metadata", :indices => @name)
+      assert [@name], h["metadata"]["indices"].keys
     end
   end
 
-  it 'gets the cluster settings' do
+  it "gets the cluster settings" do
     h = @cluster.get_settings
-    assert_instance_of Hash, h['persistent'], 'the persistent settings are returned'
-    assert_instance_of Hash, h['transient'], 'the transient settings are returned'
+    assert_instance_of Hash, h["persistent"], "the persistent settings are returned"
+    assert_instance_of Hash, h["transient"], "the transient settings are returned"
   end
 
-  it 'gets the cluster settings with .settings' do
+  it "gets the cluster settings with .settings" do
     h = @cluster.settings
-    assert_instance_of Hash, h['persistent'], 'the persistent settings are returned'
-    assert_instance_of Hash, h['transient'], 'the transient settings are returned'
+    assert_instance_of Hash, h["persistent"], "the persistent settings are returned"
+    assert_instance_of Hash, h["transient"], "the transient settings are returned"
   end
 
-  it 'updates the cluster settings' do
-    @cluster.update_settings :transient => { 'indices.ttl.interval' => "30" }
+  it "updates the cluster settings" do
+    @cluster.update_settings :transient => { "indices.ttl.interval" => "30" }
     h = @cluster.settings
 
     #COMPATIBILITY
@@ -65,43 +65,43 @@ describe Elastomer::Client::Cluster do
     # {"indices": {"ttl": {"interval":"30"}}}
 
     # To support both versions, we check for either return format.
-    value = h['transient']['indices.ttl.interval'] ||
-            h['transient']['indices']['ttl']['interval']
+    value = h["transient"]["indices.ttl.interval"] ||
+            h["transient"]["indices"]["ttl"]["interval"]
     assert_equal "30", value
 
-    @cluster.update_settings :transient => { 'indices.ttl.interval' => "60" }
+    @cluster.update_settings :transient => { "indices.ttl.interval" => "60" }
     h = @cluster.settings
 
-    value = h['transient']['indices.ttl.interval'] ||
-            h['transient']['indices']['ttl']['interval']
+    value = h["transient"]["indices.ttl.interval"] ||
+            h["transient"]["indices"]["ttl"]["interval"]
     assert_equal "60", value
   end
 
-  it 'returns cluster stats' do
+  it "returns cluster stats" do
     h = @cluster.stats
     assert_equal %w[cluster_name indices nodes status timestamp], h.keys.sort
   end
 
-  it 'returns a list of pending tasks' do
+  it "returns a list of pending tasks" do
     h = @cluster.pending_tasks
     assert_equal %w[tasks], h.keys.sort
-    assert h['tasks'].is_a?(Array), "the tasks lists is always an Array even if empty"
+    assert h["tasks"].is_a?(Array), "the tasks lists is always an Array even if empty"
   end
 
-  it 'returns the list of indices in the cluster' do
+  it "returns the list of indices in the cluster" do
     @index.create({}) unless @index.exists?
     indices = @cluster.indices
-    assert !indices.empty?, 'expected to see an index'
+    assert !indices.empty?, "expected to see an index"
   end
 
-  it 'returns the list of nodes in the cluster' do
+  it "returns the list of nodes in the cluster" do
     nodes = @cluster.nodes
-    assert !nodes.empty?, 'we have to have some nodes'
+    assert !nodes.empty?, "we have to have some nodes"
   end
 
-  describe 'when working with aliases' do
+  describe "when working with aliases" do
     before do
-      @name = 'elastomer-cluster-test'
+      @name = "elastomer-cluster-test"
       @index = $client.index @name
       @index.create({}) unless @index.exists?
       wait_for_index(@name)
@@ -111,56 +111,56 @@ describe Elastomer::Client::Cluster do
       @index.delete if @index.exists?
     end
 
-    it 'adds and gets an alias' do
+    it "adds and gets an alias" do
       hash = @cluster.get_aliases
       if es_version_always_returns_aliases?
-        assert_empty hash[@name]['aliases']
+        assert_empty hash[@name]["aliases"]
       end
 
       @cluster.update_aliases \
-        :add => {:index => @name, :alias => 'elastomer-test-unikitty'}
+        :add => {:index => @name, :alias => "elastomer-test-unikitty"}
 
       hash = @cluster.get_aliases
-      assert_equal ['elastomer-test-unikitty'], hash[@name]['aliases'].keys
+      assert_equal ["elastomer-test-unikitty"], hash[@name]["aliases"].keys
     end
 
-    it 'adds and gets an alias with .aliases' do
+    it "adds and gets an alias with .aliases" do
       hash = @cluster.aliases
       if es_version_always_returns_aliases?
-        assert_empty hash[@name]['aliases']
+        assert_empty hash[@name]["aliases"]
       end
 
       @cluster.update_aliases \
-        :add => {:index => @name, :alias => 'elastomer-test-unikitty'}
+        :add => {:index => @name, :alias => "elastomer-test-unikitty"}
 
       hash = @cluster.aliases
-      assert_equal ['elastomer-test-unikitty'], hash[@name]['aliases'].keys
+      assert_equal ["elastomer-test-unikitty"], hash[@name]["aliases"].keys
     end
 
-    it 'removes an alias' do
+    it "removes an alias" do
       @cluster.update_aliases \
-        :add => {:index => @name, :alias => 'elastomer-test-unikitty'}
+        :add => {:index => @name, :alias => "elastomer-test-unikitty"}
 
       hash = @cluster.get_aliases
-      assert_equal ['elastomer-test-unikitty'], hash[@name]['aliases'].keys
+      assert_equal ["elastomer-test-unikitty"], hash[@name]["aliases"].keys
 
       @cluster.update_aliases([
-        {:add    => {:index => @name, :alias => 'elastomer-test-SpongeBob-SquarePants'}},
-        {:remove => {:index => @name, :alias => 'elastomer-test-unikitty'}}
+        {:add    => {:index => @name, :alias => "elastomer-test-SpongeBob-SquarePants"}},
+        {:remove => {:index => @name, :alias => "elastomer-test-unikitty"}}
       ])
 
       hash = @cluster.get_aliases
-      assert_equal ['elastomer-test-SpongeBob-SquarePants'], hash[@name]['aliases'].keys
+      assert_equal ["elastomer-test-SpongeBob-SquarePants"], hash[@name]["aliases"].keys
     end
 
-    it 'accepts the full aliases actions hash' do
+    it "accepts the full aliases actions hash" do
       @cluster.update_aliases :actions => [
-        {:add => {:index => @name, :alias => 'elastomer-test-He-Man'}},
-        {:add => {:index => @name, :alias => 'elastomer-test-Skeletor'}}
+        {:add => {:index => @name, :alias => "elastomer-test-He-Man"}},
+        {:add => {:index => @name, :alias => "elastomer-test-Skeletor"}}
       ]
 
       hash = @cluster.get_aliases(:index => @name)
-      assert_equal %w[elastomer-test-He-Man elastomer-test-Skeletor], hash[@name]['aliases'].keys.sort
+      assert_equal %w[elastomer-test-He-Man elastomer-test-Skeletor], hash[@name]["aliases"].keys.sort
     end
   end
 

--- a/test/client/delete_by_query_test.rb
+++ b/test/client/delete_by_query_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::DeleteByQuery do
 
@@ -18,34 +18,34 @@ describe Elastomer::Client::DeleteByQuery do
       wait_for_index(@index_name)
     end
 
-    it 'deletes by query' do
+    it "deletes by query" do
       @docs.index({ :_id => 0, :name => "mittens" })
       @docs.index({ :_id => 1, :name => "luna" })
 
       @index.refresh
       response = @index.delete_by_query(nil, :q => "name:mittens")
       assert_equal({
-        '_all' => {
-          'found' => 1,
-          'deleted' => 1,
-          'missing' => 0,
-          'failed' => 0,
+        "_all" => {
+          "found" => 1,
+          "deleted" => 1,
+          "missing" => 0,
+          "failed" => 0,
         },
         @index.name => {
-          'found' => 1,
-          'deleted' => 1,
-          'missing' => 0,
-          'failed' => 0,
+          "found" => 1,
+          "deleted" => 1,
+          "missing" => 0,
+          "failed" => 0,
         },
-      }, response['_indices'])
+      }, response["_indices"])
 
       @index.refresh
       response = @docs.multi_get :ids => [0, 1]
-      refute_found response['docs'][0]
-      assert_found response['docs'][1]
+      refute_found response["docs"][0]
+      assert_found response["docs"][1]
     end
 
-    it 'respects action_count' do
+    it "respects action_count" do
       @docs.index({ :_id => 0, :name => "mittens" })
       @docs.index({ :_id => 1, :name => "luna" })
       @index.refresh
@@ -55,27 +55,27 @@ describe Elastomer::Client::DeleteByQuery do
       assert_requested(:post, /_bulk/, :times => 2)
 
       assert_equal({
-        '_all' => {
-          'found' => 2,
-          'deleted' => 2,
-          'missing' => 0,
-          'failed' => 0,
+        "_all" => {
+          "found" => 2,
+          "deleted" => 2,
+          "missing" => 0,
+          "failed" => 0,
         },
         @index.name => {
-          'found' => 2,
-          'deleted' => 2,
-          'missing' => 0,
-          'failed' => 0,
+          "found" => 2,
+          "deleted" => 2,
+          "missing" => 0,
+          "failed" => 0,
         },
-      }, response['_indices'])
+      }, response["_indices"])
 
       @index.refresh
       response = @docs.multi_get :ids => [0, 1]
-      refute_found response['docs'][0]
-      refute_found response['docs'][1]
+      refute_found response["docs"][0]
+      refute_found response["docs"][1]
     end
 
-    it 'counts missing documents' do
+    it "counts missing documents" do
       @docs.index({ :_id => 0 })
 
       stub_request(:post, /_bulk/).
@@ -97,22 +97,22 @@ describe Elastomer::Client::DeleteByQuery do
       @index.refresh
       response = @index.delete_by_query(nil, :action_count => 1)
       assert_equal({
-        '_all' => {
-          'found' => 0,
-          'deleted' => 0,
-          'missing' => 1,
-          'failed' => 0,
+        "_all" => {
+          "found" => 0,
+          "deleted" => 0,
+          "missing" => 1,
+          "failed" => 0,
         },
         @index.name => {
-          'found' => 0,
-          'deleted' => 0,
-          'missing' => 1,
-          'failed' => 0,
+          "found" => 0,
+          "deleted" => 0,
+          "missing" => 1,
+          "failed" => 0,
         },
-      }, response['_indices'])
+      }, response["_indices"])
     end
 
-    it 'counts failed operations' do
+    it "counts failed operations" do
       @docs.index({ :_id => 0 })
 
       stub_request(:post, /_bulk/).
@@ -133,19 +133,19 @@ describe Elastomer::Client::DeleteByQuery do
       @index.refresh
       response = @index.delete_by_query(nil, :action_count => 1)
       assert_equal({
-        '_all' => {
-          'found' => 1,
-          'deleted' => 0,
-          'missing' => 0,
-          'failed' => 1,
+        "_all" => {
+          "found" => 1,
+          "deleted" => 0,
+          "missing" => 0,
+          "failed" => 1,
         },
         @index.name => {
-          'found' => 1,
-          'deleted' => 0,
-          'missing' => 0,
-          'failed' => 1,
+          "found" => 1,
+          "deleted" => 0,
+          "missing" => 0,
+          "failed" => 1,
         },
-      }, response['_indices'])
+      }, response["_indices"])
     end
   end
 end

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -598,6 +598,7 @@ describe Elastomer::Client::Docs do
   #
   # docs - An instance of Elastomer::Client::Docs or Elastomer::Client::Bulk. If
   #        nil uses the @docs instance variable.
+  # rubocop:disable Metrics/MethodLength
   def populate!(docs = @docs)
     docs.index \
       :_id    => 1,
@@ -625,5 +626,6 @@ describe Elastomer::Client::Docs do
 
     @index.refresh
   end
+  # rubocop:enable Metrics/MethodLength
 
 end

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -1,27 +1,27 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Docs do
 
   before do
-    @name  = 'elastomer-docs-test'
+    @name  = "elastomer-docs-test"
     @index = $client.index(@name)
 
     unless @index.exists?
       @index.create \
-        :settings => { 'index.number_of_shards' => 1, 'index.number_of_replicas' => 0 },
+        :settings => { "index.number_of_shards" => 1, "index.number_of_replicas" => 0 },
         :mappings => {
           :doc1 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => 'string', :analyzer => 'standard' },
-              :author => { :type => 'string', :index => 'not_analyzed' }
+              :title  => { :type => "string", :analyzer => "standard" },
+              :author => { :type => "string", :index => "not_analyzed" }
             }
           },
           :doc2 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => 'string', :analyzer => 'standard', :term_vector => 'with_positions_offsets' },
-              :author => { :type => 'string', :index => 'not_analyzed' }
+              :title  => { :type => "string", :analyzer => "standard", :term_vector => "with_positions_offsets" },
+              :author => { :type => "string", :index => "not_analyzed" }
             }
           }
         }
@@ -36,68 +36,68 @@ describe Elastomer::Client::Docs do
     @index.delete if @index.exists?
   end
 
-  it 'autogenerates IDs for documents' do
+  it "autogenerates IDs for documents" do
     h = @docs.index \
-          :_type  => 'doc2',
-          :title  => 'the author of logging',
-          :author => 'pea53'
+          :_type  => "doc2",
+          :title  => "the author of logging",
+          :author => "pea53"
 
     assert_created h
-    assert_match %r/^\S{20,22}$/, h['_id']
+    assert_match %r/^\S{20,22}$/, h["_id"]
 
     h = @docs.index \
           :_id    => nil,
-          :_type  => 'doc3',
-          :title  => 'the author of rubber-band',
-          :author => 'grantr'
+          :_type  => "doc3",
+          :title  => "the author of rubber-band",
+          :author => "grantr"
 
     assert_created h
-    assert_match %r/^\S{20,22}$/, h['_id']
+    assert_match %r/^\S{20,22}$/, h["_id"]
 
     h = @docs.index \
-          :_id    => '',
-          :_type  => 'doc4',
-          :title  => 'the author of toml',
-          :author => 'mojombo'
+          :_id    => "",
+          :_type  => "doc4",
+          :title  => "the author of toml",
+          :author => "mojombo"
 
     assert_created h
-    assert_match %r/^\S{20,22}$/, h['_id']
+    assert_match %r/^\S{20,22}$/, h["_id"]
   end
 
-  it 'uses the provided document ID' do
+  it "uses the provided document ID" do
     h = @docs.index \
-          :_id    => '42',
-          :_type  => 'doc2',
-          :title  => 'the author of logging',
-          :author => 'pea53'
+          :_id    => "42",
+          :_type  => "doc2",
+          :title  => "the author of logging",
+          :author => "pea53"
 
     assert_created h
-    assert_equal '42', h['_id']
+    assert_equal "42", h["_id"]
   end
 
-  it 'accepts JSON encoded document strings' do
+  it "accepts JSON encoded document strings" do
     h = @docs.index \
           '{"author":"pea53", "title":"the author of logging"}',
-          :id   => '42',
-          :type => 'doc2'
+          :id   => "42",
+          :type => "doc2"
 
     assert_created h
-    assert_equal '42', h['_id']
+    assert_equal "42", h["_id"]
 
     h = @docs.index \
           '{"author":"grantr", "title":"the author of rubber-band"}',
-          :type => 'doc2'
+          :type => "doc2"
 
     assert_created h
-    assert_match %r/^\S{20,22}$/, h['_id']
+    assert_match %r/^\S{20,22}$/, h["_id"]
   end
 
-  it 'extracts underscore attributes from the document' do
+  it "extracts underscore attributes from the document" do
     doc = {
-      :_id => '12',
-      :_type => 'doc2',
-      :_routing => 'author',
-      '_consistency' => 'all',
+      :_id => "12",
+      :_type => "doc2",
+      :_routing => "author",
+      "_consistency" => "all",
       :title => "The Adventures of Huckleberry Finn",
       :author => "Mark Twain",
       :_unknown => "unknown attribute"
@@ -105,133 +105,133 @@ describe Elastomer::Client::Docs do
 
     h = @docs.index doc
     assert_created h
-    assert_equal '12', h['_id']
+    assert_equal "12", h["_id"]
 
     refute doc.key?(:_id)
     refute doc.key?(:_type)
     refute doc.key?(:_routing)
-    refute doc.key?('_consistency')
+    refute doc.key?("_consistency")
     assert doc.key?(:_unknown)
   end
 
-  it 'gets documents from the search index' do
-    h = @docs.get :id => '1', :type => 'doc1'
+  it "gets documents from the search index" do
+    h = @docs.get :id => "1", :type => "doc1"
     refute_found h
 
     populate!
 
-    h = @docs.get :id => '1', :type => 'doc1'
+    h = @docs.get :id => "1", :type => "doc1"
     assert_found h
-    assert_equal 'mojombo', h['_source']['author']
+    assert_equal "mojombo", h["_source"]["author"]
   end
 
-  it 'checks if documents exist in the search index' do
-    refute @docs.exists?(:id => '1', :type => 'doc1')
+  it "checks if documents exist in the search index" do
+    refute @docs.exists?(:id => "1", :type => "doc1")
     populate!
-    assert @docs.exists?(:id => '1', :type => 'doc1')
+    assert @docs.exists?(:id => "1", :type => "doc1")
   end
 
-  it 'checks if documents exist in the search index with .exist?' do
-    refute @docs.exist?(:id => '1', :type => 'doc1')
+  it "checks if documents exist in the search index with .exist?" do
+    refute @docs.exist?(:id => "1", :type => "doc1")
     populate!
-    assert @docs.exist?(:id => '1', :type => 'doc1')
+    assert @docs.exist?(:id => "1", :type => "doc1")
   end
 
-  it 'gets multiple documents from the search index' do
+  it "gets multiple documents from the search index" do
     populate!
 
     h = @docs.multi_get :docs => [
-      { :_id => 1, :_type => 'doc1' },
-      { :_id => 1, :_type => 'doc2' }
+      { :_id => 1, :_type => "doc1" },
+      { :_id => 1, :_type => "doc2" }
     ]
-    authors = h['docs'].map { |d| d['_source']['author'] }
+    authors = h["docs"].map { |d| d["_source"]["author"] }
     assert_equal %w[mojombo pea53], authors
 
-    h = @docs.multi_get({:ids => [2, 1]}, :type => 'doc1')
-    authors = h['docs'].map { |d| d['_source']['author'] }
+    h = @docs.multi_get({:ids => [2, 1]}, :type => "doc1")
+    authors = h["docs"].map { |d| d["_source"]["author"] }
     assert_equal %w[defunkt mojombo], authors
 
-    h = @index.docs('doc1').multi_get :ids => [1, 2, 3, 4]
-    assert_found h['docs'][0]
-    assert_found h['docs'][1]
-    refute_found h['docs'][2]
-    refute_found h['docs'][3]
+    h = @index.docs("doc1").multi_get :ids => [1, 2, 3, 4]
+    assert_found h["docs"][0]
+    assert_found h["docs"][1]
+    refute_found h["docs"][2]
+    refute_found h["docs"][3]
   end
 
-  it 'gets multiple documents from the search index with .mget' do
+  it "gets multiple documents from the search index with .mget" do
     populate!
 
     h = @docs.mget :docs => [
-      { :_id => 1, :_type => 'doc1' },
-      { :_id => 1, :_type => 'doc2' }
+      { :_id => 1, :_type => "doc1" },
+      { :_id => 1, :_type => "doc2" }
     ]
-    authors = h['docs'].map { |d| d['_source']['author'] }
+    authors = h["docs"].map { |d| d["_source"]["author"] }
     assert_equal %w[mojombo pea53], authors
 
-    h = @docs.mget({:ids => [2, 1]}, :type => 'doc1')
-    authors = h['docs'].map { |d| d['_source']['author'] }
+    h = @docs.mget({:ids => [2, 1]}, :type => "doc1")
+    authors = h["docs"].map { |d| d["_source"]["author"] }
     assert_equal %w[defunkt mojombo], authors
 
-    h = @index.docs('doc1').mget :ids => [1, 2, 3, 4]
-    assert_found h['docs'][0]
-    assert_found h['docs'][1]
-    refute_found h['docs'][2]
-    refute_found h['docs'][3]
+    h = @index.docs("doc1").mget :ids => [1, 2, 3, 4]
+    assert_found h["docs"][0]
+    assert_found h["docs"][1]
+    refute_found h["docs"][2]
+    refute_found h["docs"][3]
   end
 
-  it 'deletes documents from the search index' do
+  it "deletes documents from the search index" do
     populate!
-    @docs = @index.docs('doc2')
+    @docs = @index.docs("doc2")
 
     h = @docs.multi_get :ids => [1, 2]
-    authors = h['docs'].map { |d| d['_source']['author'] }
+    authors = h["docs"].map { |d| d["_source"]["author"] }
     assert_equal %w[pea53 grantr], authors
 
     h = @docs.delete :id => 1
-    assert h['found'], "expected document to be found"
+    assert h["found"], "expected document to be found"
     h = @docs.multi_get :ids => [1, 2]
-    refute_found h['docs'][0]
-    assert_found h['docs'][1]
+    refute_found h["docs"][0]
+    assert_found h["docs"][1]
 
     assert_raises(ArgumentError) { @docs.delete :id => nil }
-    assert_raises(ArgumentError) { @docs.delete :id => '' }
+    assert_raises(ArgumentError) { @docs.delete :id => "" }
     assert_raises(ArgumentError) { @docs.delete :id => "\t" }
   end
 
-  it 'does not care if you delete a document that is not there' do
-    @docs = @index.docs('doc2')
+  it "does not care if you delete a document that is not there" do
+    @docs = @index.docs("doc2")
     h = @docs.delete :id => 42
 
-    refute h['found'], 'expected document to not be found'
+    refute h["found"], "expected document to not be found"
   end
 
-  it 'deletes documents by query' do
+  it "deletes documents by query" do
     populate!
-    @docs = @index.docs('doc2')
+    @docs = @index.docs("doc2")
 
     h = @docs.multi_get :ids => [1, 2]
-    authors = h['docs'].map { |d| d['_source']['author'] }
+    authors = h["docs"].map { |d| d["_source"]["author"] }
     assert_equal %w[pea53 grantr], authors
 
     h = @docs.delete_by_query(:q => "author:grantr")
-    assert_equal(h['_indices'], {
-      '_all' => {
-        'found' => 1,
-        'deleted' => 1,
-        'missing' => 0,
-        'failed' => 0,
+    assert_equal(h["_indices"], {
+      "_all" => {
+        "found" => 1,
+        "deleted" => 1,
+        "missing" => 0,
+        "failed" => 0,
       },
       @name => {
-        'found' => 1,
-        'deleted' => 1,
-        'missing' => 0,
-        'failed' => 0,
+        "found" => 1,
+        "deleted" => 1,
+        "missing" => 0,
+        "failed" => 0,
       },
     })
     @index.refresh
     h = @docs.multi_get :ids => [1, 2]
-    assert_found h['docs'][0]
-    refute_found h['docs'][1]
+    assert_found h["docs"][0]
+    refute_found h["docs"][1]
 
     #COMPATIBILITY
     # ES 1.0 normalized all search APIs to use a :query top level element.
@@ -243,42 +243,42 @@ describe Elastomer::Client::Docs do
             :query => {
               :filtered => {
                 :query => {:match_all => {}},
-                :filter => {:term => {:author => 'pea53'}}
+                :filter => {:term => {:author => "pea53"}}
               }
             }
           )
       @index.refresh
       h = @docs.multi_get :ids => [1, 2]
-      refute_found h['docs'][0]
-      refute_found h['docs'][1]
+      refute_found h["docs"][0]
+      refute_found h["docs"][1]
     end
   end
 
-  it 'searches for documents' do
-    h = @docs.search :q => '*:*'
-    assert_equal 0, h['hits']['total']
+  it "searches for documents" do
+    h = @docs.search :q => "*:*"
+    assert_equal 0, h["hits"]["total"]
 
     populate!
 
-    h = @docs.search :q => '*:*'
-    assert_equal 4, h['hits']['total']
+    h = @docs.search :q => "*:*"
+    assert_equal 4, h["hits"]["total"]
 
-    h = @docs.search :q => '*:*', :type => 'doc1'
-    assert_equal 2, h['hits']['total']
+    h = @docs.search :q => "*:*", :type => "doc1"
+    assert_equal 2, h["hits"]["total"]
 
     h = @docs.search({
       :query => {:match_all => {}},
-      :filter => {:term => {:author => 'defunkt'}}
+      :filter => {:term => {:author => "defunkt"}}
     }, :type => %w[doc1 doc2] )
-    assert_equal 1, h['hits']['total']
+    assert_equal 1, h["hits"]["total"]
 
-    hit = h['hits']['hits'].first
-    assert_equal 'the author of resque', hit['_source']['title']
+    hit = h["hits"]["hits"].first
+    assert_equal "the author of resque", hit["_source"]["title"]
   end
 
-  it 'supports the shards search API' do
+  it "supports the shards search API" do
     if es_version_supports_search_shards?
-      h = @docs.search_shards(:type => 'docs1')
+      h = @docs.search_shards(:type => "docs1")
 
       assert h.key?("nodes"), "response contains \"nodes\" information"
       assert h.key?("shards"), "response contains \"shards\" information"
@@ -286,20 +286,20 @@ describe Elastomer::Client::Docs do
     end
   end
 
-  it 'counts documents' do
-    h = @docs.count :q => '*:*'
-    assert_equal 0, h['count']
+  it "counts documents" do
+    h = @docs.count :q => "*:*"
+    assert_equal 0, h["count"]
 
     populate!
 
-    h = @docs.count :q => '*:*'
-    assert_equal 4, h['count']
+    h = @docs.count :q => "*:*"
+    assert_equal 4, h["count"]
 
-    h = @docs.count :q => '*:*', :type => 'doc1'
-    assert_equal 2, h['count']
+    h = @docs.count :q => "*:*", :type => "doc1"
+    assert_equal 2, h["count"]
 
-    h = @docs.count :q => '*:*', :type => 'doc1,doc2'
-    assert_equal 4, h['count']
+    h = @docs.count :q => "*:*", :type => "doc1,doc2"
+    assert_equal 4, h["count"]
 
     #COMPATIBILITY
     # ES 1.0 normalized all search APIs to use a :query top level element.
@@ -309,7 +309,7 @@ describe Elastomer::Client::Docs do
         :query => {
           :filtered => {
             :query => {:match_all => {}},
-            :filter => {:term => {:author => 'defunkt'}}
+            :filter => {:term => {:author => "defunkt"}}
           }
         }
       }, :type => %w[doc1 doc2] )
@@ -317,30 +317,30 @@ describe Elastomer::Client::Docs do
       h = @docs.count({
         :filtered => {
           :query => {:match_all => {}},
-          :filter => {:term => {:author => 'defunkt'}}
+          :filter => {:term => {:author => "defunkt"}}
         }
       }, :type => %w[doc1 doc2] )
     end
-    assert_equal 1, h['count']
+    assert_equal 1, h["count"]
   end
 
-  it 'searches for more like this' do
+  it "searches for more like this" do
     populate!
 
     # for some reason, if there's no document indexed here all the mlt
     # queries return zero results
     @docs.index \
       :_id    => 3,
-      :_type  => 'doc1',
-      :title  => 'the author of faraday',
-      :author => 'technoweenie'
+      :_type  => "doc1",
+      :title  => "the author of faraday",
+      :author => "technoweenie"
 
     @index.refresh
 
     h = @docs.more_like_this({
-      :type => 'doc1',
+      :type => "doc1",
       :id   => 1,
-      :mlt_fields    => 'title',
+      :mlt_fields    => "title",
       :min_term_freq => 1
     })
     assert_equal 2, h["hits"]["total"]
@@ -354,16 +354,16 @@ describe Elastomer::Client::Docs do
         }
       }
     }, {
-      :type => 'doc1',
+      :type => "doc1",
       :id   => 1,
-      :mlt_fields    => 'title,author',
+      :mlt_fields    => "title,author",
       :min_term_freq => 1
     })
     assert_equal 2, h["hits"]["total"]
     assert_equal 2, h["facets"]["author"]["total"]
   end
 
-  it 'explains scoring' do
+  it "explains scoring" do
     populate!
 
     h = @docs.explain({
@@ -372,17 +372,17 @@ describe Elastomer::Client::Docs do
           "author" => "defunkt"
         }
       }
-    }, :type => 'doc1', :id => 2)
+    }, :type => "doc1", :id => 2)
     assert_equal true, h["matched"]
 
-    h = @docs.explain(:type => 'doc2', :id => 2, :q => "pea53")
+    h = @docs.explain(:type => "doc2", :id => 2, :q => "pea53")
     assert_equal false, h["matched"]
   end
 
-  it 'validates queries' do
+  it "validates queries" do
     populate!
 
-    h = @docs.validate :q => '*:*'
+    h = @docs.validate :q => "*:*"
     assert_equal true, h["valid"]
 
     #COMPATIBILITY
@@ -393,7 +393,7 @@ describe Elastomer::Client::Docs do
         :query => {
           :filtered => {
             :query => {:match_all => {}},
-            :filter => {:term => {:author => 'defunkt'}}
+            :filter => {:term => {:author => "defunkt"}}
           }
         }
       }, :type => %w[doc1 doc2] )
@@ -401,125 +401,125 @@ describe Elastomer::Client::Docs do
       h = @docs.validate({
         :filtered => {
           :query => {:match_all => {}},
-          :filter => {:term => {:author => 'defunkt'}}
+          :filter => {:term => {:author => "defunkt"}}
         }
       }, :type => %w[doc1 doc2] )
     end
     assert_equal true, h["valid"]
   end
 
-  it 'updates documents' do
+  it "updates documents" do
     populate!
 
-    h = @docs.get :id => '1', :type => 'doc1'
+    h = @docs.get :id => "1", :type => "doc1"
     assert_found h
-    assert_equal 'mojombo', h['_source']['author']
+    assert_equal "mojombo", h["_source"]["author"]
 
     @docs.update({
-      :_id   => '1',
-      :_type => 'doc1',
-      :doc   => {:author => 'TwP'}
+      :_id   => "1",
+      :_type => "doc1",
+      :doc   => {:author => "TwP"}
     })
-    h = @docs.get :id => '1', :type => 'doc1'
+    h = @docs.get :id => "1", :type => "doc1"
     assert_found h
-    assert_equal 'TwP', h['_source']['author']
+    assert_equal "TwP", h["_source"]["author"]
 
     if $client.version >= "0.90"
       @docs.update({
-        :_id   => '42',
-        :_type => 'doc1',
+        :_id   => "42",
+        :_type => "doc1",
         :doc   => {
-          :author => 'TwP',
-          :title  => 'the ineffable beauty of search'
+          :author => "TwP",
+          :title  => "the ineffable beauty of search"
         },
         :doc_as_upsert => true
       })
 
-      h = @docs.get :id => '42', :type => 'doc1'
+      h = @docs.get :id => "42", :type => "doc1"
       assert_found h
-      assert_equal 'TwP', h['_source']['author']
-      assert_equal 'the ineffable beauty of search', h['_source']['title']
+      assert_equal "TwP", h["_source"]["author"]
+      assert_equal "the ineffable beauty of search", h["_source"]["title"]
     end
   end
 
-  it 'supports bulk operations with the same parameters as docs' do
+  it "supports bulk operations with the same parameters as docs" do
     response = @docs.bulk do |b|
       populate!(b)
     end
 
-    assert_instance_of Fixnum, response['took']
+    assert_instance_of Fixnum, response["took"]
 
-    response = @docs.get(:id => 1, :type => 'doc1')
+    response = @docs.get(:id => 1, :type => "doc1")
     assert_found response
-    assert_equal 'mojombo', response['_source']['author']
+    assert_equal "mojombo", response["_source"]["author"]
   end
 
   if es_version_1_x?
-    it 'provides access to term vector statistics' do
+    it "provides access to term vector statistics" do
       populate!
 
-      response = @docs.termvector :type => 'doc2', :id => 1, :fields => 'title'
+      response = @docs.termvector :type => "doc2", :id => 1, :fields => "title"
 
-      assert response['term_vectors']['title']
-      assert response['term_vectors']['title']['field_statistics']
-      assert response['term_vectors']['title']['terms']
-      assert_equal %w[author logging of the], response['term_vectors']['title']['terms'].keys
+      assert response["term_vectors"]["title"]
+      assert response["term_vectors"]["title"]["field_statistics"]
+      assert response["term_vectors"]["title"]["terms"]
+      assert_equal %w[author logging of the], response["term_vectors"]["title"]["terms"].keys
     end
 
-    it 'provides access to term vector statistics with .termvectors' do
+    it "provides access to term vector statistics with .termvectors" do
       populate!
 
-      response = @docs.termvectors :type => 'doc2', :id => 1, :fields => 'title'
+      response = @docs.termvectors :type => "doc2", :id => 1, :fields => "title"
 
-      assert response['term_vectors']['title']
-      assert response['term_vectors']['title']['field_statistics']
-      assert response['term_vectors']['title']['terms']
-      assert_equal %w[author logging of the], response['term_vectors']['title']['terms'].keys
+      assert response["term_vectors"]["title"]
+      assert response["term_vectors"]["title"]["field_statistics"]
+      assert response["term_vectors"]["title"]["terms"]
+      assert_equal %w[author logging of the], response["term_vectors"]["title"]["terms"].keys
     end
 
-    it 'provides access to term vector statistics with .term_vector' do
+    it "provides access to term vector statistics with .term_vector" do
       populate!
 
-      response = @docs.term_vector :type => 'doc2', :id => 1, :fields => 'title'
+      response = @docs.term_vector :type => "doc2", :id => 1, :fields => "title"
 
-      assert response['term_vectors']['title']
-      assert response['term_vectors']['title']['field_statistics']
-      assert response['term_vectors']['title']['terms']
-      assert_equal %w[author logging of the], response['term_vectors']['title']['terms'].keys
+      assert response["term_vectors"]["title"]
+      assert response["term_vectors"]["title"]["field_statistics"]
+      assert response["term_vectors"]["title"]["terms"]
+      assert_equal %w[author logging of the], response["term_vectors"]["title"]["terms"].keys
     end
 
-    it 'provides access to term vector statistics with .term_vectors' do
+    it "provides access to term vector statistics with .term_vectors" do
       populate!
 
-      response = @docs.term_vectors :type => 'doc2', :id => 1, :fields => 'title'
+      response = @docs.term_vectors :type => "doc2", :id => 1, :fields => "title"
 
-      assert response['term_vectors']['title']
-      assert response['term_vectors']['title']['field_statistics']
-      assert response['term_vectors']['title']['terms']
-      assert_equal %w[author logging of the], response['term_vectors']['title']['terms'].keys
+      assert response["term_vectors"]["title"]
+      assert response["term_vectors"]["title"]["field_statistics"]
+      assert response["term_vectors"]["title"]["terms"]
+      assert_equal %w[author logging of the], response["term_vectors"]["title"]["terms"].keys
     end
 
-    it 'provides access to multi term vector statistics' do
+    it "provides access to multi term vector statistics" do
       populate!
 
-      response = @docs.multi_termvectors({:ids => [1, 2]}, :type => 'doc2', :fields => 'title', :term_statistics => true)
-      docs = response['docs']
+      response = @docs.multi_termvectors({:ids => [1, 2]}, :type => "doc2", :fields => "title", :term_statistics => true)
+      docs = response["docs"]
 
       assert docs
-      assert_equal(%w[1 2], docs.map { |h| h['_id'] }.sort)
+      assert_equal(%w[1 2], docs.map { |h| h["_id"] }.sort)
     end
 
-    it 'provides access to multi term vector statistics with .multi_term_vectors' do
+    it "provides access to multi term vector statistics with .multi_term_vectors" do
       populate!
 
-      response = @docs.multi_term_vectors({:ids => [1, 2]}, :type => 'doc2', :fields => 'title', :term_statistics => true)
-      docs = response['docs']
+      response = @docs.multi_term_vectors({:ids => [1, 2]}, :type => "doc2", :fields => "title", :term_statistics => true)
+      docs = response["docs"]
 
       assert docs
-      assert_equal(%w[1 2], docs.map { |h| h['_id'] }.sort)
+      assert_equal(%w[1 2], docs.map { |h| h["_id"] }.sort)
     end
 
-    it 'percolates a given document' do
+    it "percolates a given document" do
       populate!
 
       percolator1 = @index.percolator "1"
@@ -534,7 +534,7 @@ describe Elastomer::Client::Docs do
       assert_equal "1", response["matches"][0]["_id"]
     end
 
-    it 'percolates an existing document' do
+    it "percolates an existing document" do
       populate!
 
       percolator1 = @index.percolator "1"
@@ -549,7 +549,7 @@ describe Elastomer::Client::Docs do
       assert_equal "1", response["matches"][0]["_id"]
     end
 
-    it 'counts the matches for percolating a given document' do
+    it "counts the matches for percolating a given document" do
       populate!
 
       percolator1 = @index.percolator "1"
@@ -563,7 +563,7 @@ describe Elastomer::Client::Docs do
       assert_equal 1, count
     end
 
-    it 'counts the matches for percolating an existing document' do
+    it "counts the matches for percolating an existing document" do
       populate!
 
       percolator1 = @index.percolator "1"
@@ -577,7 +577,7 @@ describe Elastomer::Client::Docs do
       assert_equal 1, count
     end
 
-    it 'performs multi percolate queries' do
+    it "performs multi percolate queries" do
       @index.percolator("1").create :query => { :match_all => { } }
       @index.percolator("2").create :query => { :match => { :author => "pea53" } }
 
@@ -602,27 +602,27 @@ describe Elastomer::Client::Docs do
   def populate!(docs = @docs)
     docs.index \
       :_id    => 1,
-      :_type  => 'doc1',
-      :title  => 'the author of gravatar',
-      :author => 'mojombo'
+      :_type  => "doc1",
+      :title  => "the author of gravatar",
+      :author => "mojombo"
 
     docs.index \
       :_id    => 2,
-      :_type  => 'doc1',
-      :title  => 'the author of resque',
-      :author => 'defunkt'
+      :_type  => "doc1",
+      :title  => "the author of resque",
+      :author => "defunkt"
 
     docs.index \
       :_id    => 1,
-      :_type  => 'doc2',
-      :title  => 'the author of logging',
-      :author => 'pea53'
+      :_type  => "doc2",
+      :title  => "the author of logging",
+      :author => "pea53"
 
     docs.index \
       :_id    => 2,
-      :_type  => 'doc2',
-      :title  => 'the author of rubber-band',
-      :author => 'grantr'
+      :_type  => "doc2",
+      :title  => "the author of rubber-band",
+      :author => "grantr"
 
     @index.refresh
   end

--- a/test/client/errors_test.rb
+++ b/test/client/errors_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Error do
 

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -1,9 +1,9 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Index do
 
   before do
-    @name  = 'elastomer-index-test'
+    @name  = "elastomer-index-test"
     @index = $client.index @name
     @index.delete if @index.exists?
   end
@@ -12,28 +12,28 @@ describe Elastomer::Client::Index do
     @index.delete if @index.exists?
   end
 
-  it 'does not require an index name' do
+  it "does not require an index name" do
     index = $client.index
     assert_nil index.name
   end
 
-  it 'determines if an index exists' do
-    assert !@index.exists?, 'the index should not yet exist'
+  it "determines if an index exists" do
+    assert !@index.exists?, "the index should not yet exist"
   end
 
-  it 'determines if an index exists with .exist?' do
-    assert !@index.exist?, 'the index should not yet exist'
+  it "determines if an index exists with .exist?" do
+    assert !@index.exist?, "the index should not yet exist"
   end
 
-  describe 'when creating an index' do
-    it 'creates an index' do
+  describe "when creating an index" do
+    it "creates an index" do
       @index.create({})
-      assert @index.exists?, 'the index should now exist'
+      assert @index.exists?, "the index should now exist"
     end
 
-    it 'creates an index with settings' do
+    it "creates an index with settings" do
       @index.create :settings => { :number_of_shards => 3, :number_of_replicas => 0 }
-      settings = @index.get_settings[@name]['settings']
+      settings = @index.get_settings[@name]["settings"]
 
       # COMPATIBILITY
       # ES 1.0 changed the default return format of index settings to always
@@ -42,17 +42,17 @@ describe Elastomer::Client::Index do
       # {"index": {"number_of_replicas":"1"}}
 
       # To support both versions, we check for either return format.
-      value = settings['index.number_of_shards'] ||
-              settings['index']['number_of_shards']
-      assert_equal '3', value
-      value = settings['index.number_of_replicas'] ||
-              settings['index']['number_of_replicas']
-      assert_equal '0', value
+      value = settings["index.number_of_shards"] ||
+              settings["index"]["number_of_shards"]
+      assert_equal "3", value
+      value = settings["index.number_of_replicas"] ||
+              settings["index"]["number_of_replicas"]
+      assert_equal "0", value
     end
 
-    it 'creates an index with settings with .settings' do
+    it "creates an index with settings with .settings" do
       @index.create :settings => { :number_of_shards => 3, :number_of_replicas => 0 }
-      settings = @index.settings[@name]['settings']
+      settings = @index.settings[@name]["settings"]
 
       # COMPATIBILITY
       # ES 1.0 changed the default return format of index settings to always
@@ -61,15 +61,15 @@ describe Elastomer::Client::Index do
       # {"index": {"number_of_replicas":"1"}}
 
       # To support both versions, we check for either return format.
-      value = settings['index.number_of_shards'] ||
-              settings['index']['number_of_shards']
-      assert_equal '3', value
-      value = settings['index.number_of_replicas'] ||
-              settings['index']['number_of_replicas']
-      assert_equal '0', value
+      value = settings["index.number_of_shards"] ||
+              settings["index"]["number_of_shards"]
+      assert_equal "3", value
+      value = settings["index.number_of_replicas"] ||
+              settings["index"]["number_of_replicas"]
+      assert_equal "0", value
     end
 
-    it 'adds mappings for document types' do
+    it "adds mappings for document types" do
       @index.create(
         :settings => { :number_of_shards => 1, :number_of_replicas => 0 },
         :mappings => {
@@ -77,18 +77,18 @@ describe Elastomer::Client::Index do
             :_source => { :enabled => false },
             :_all    => { :enabled => false },
             :properties => {
-              :title  => { :type => 'string', :analyzer => 'standard' },
-              :author => { :type => 'string', :index => 'not_analyzed' }
+              :title  => { :type => "string", :analyzer => "standard" },
+              :author => { :type => "string", :index => "not_analyzed" }
             }
           }
         }
       )
 
-      assert @index.exists?, 'the index should now exist'
-      assert_mapping_exists @index.get_mapping[@name], 'doco'
+      assert @index.exists?, "the index should now exist"
+      assert_mapping_exists @index.get_mapping[@name], "doco"
     end
 
-    it 'adds mappings for document types with .mapping' do
+    it "adds mappings for document types with .mapping" do
       @index.create(
         :settings => { :number_of_shards => 1, :number_of_replicas => 0 },
         :mappings => {
@@ -96,23 +96,23 @@ describe Elastomer::Client::Index do
             :_source => { :enabled => false },
             :_all    => { :enabled => false },
             :properties => {
-              :title  => { :type => 'string', :analyzer => 'standard' },
-              :author => { :type => 'string', :index => 'not_analyzed' }
+              :title  => { :type => "string", :analyzer => "standard" },
+              :author => { :type => "string", :index => "not_analyzed" }
             }
           }
         }
       )
 
-      assert @index.exists?, 'the index should now exist'
-      assert_mapping_exists @index.mapping[@name], 'doco'
+      assert @index.exists?, "the index should now exist"
+      assert_mapping_exists @index.mapping[@name], "doco"
     end
   end
 
-  it 'updates index settings' do
+  it "updates index settings" do
     @index.create :settings => { :number_of_shards => 1, :number_of_replicas => 0 }
 
-    @index.update_settings 'index.number_of_replicas' => 1
-    settings = @index.settings[@name]['settings']
+    @index.update_settings "index.number_of_replicas" => 1
+    settings = @index.settings[@name]["settings"]
 
     # COMPATIBILITY
     # ES 1.0 changed the default return format of index settings to always
@@ -121,12 +121,12 @@ describe Elastomer::Client::Index do
     # {"index": {"number_of_replicas":"1"}}
 
     # To support both versions, we check for either return format.
-    value = settings['index.number_of_replicas'] ||
-            settings['index']['number_of_replicas']
-    assert_equal '1', value
+    value = settings["index.number_of_replicas"] ||
+            settings["index"]["number_of_replicas"]
+    assert_equal "1", value
   end
 
-  it 'updates document mappings' do
+  it "updates document mappings" do
     unless es_version_supports_update_mapping_with__all_disabled?
       skip "Mapping Update API is broken in this ES version."
     end
@@ -136,28 +136,28 @@ describe Elastomer::Client::Index do
         :doco => {
           :_source => { :enabled => false },
           :_all    => { :enabled => false },
-          :properties => {:title  => { :type => 'string', :analyzer => 'standard' }}
+          :properties => {:title  => { :type => "string", :analyzer => "standard" }}
         }
       }
     )
 
-    assert_property_exists @index.mapping[@name], 'doco', 'title'
+    assert_property_exists @index.mapping[@name], "doco", "title"
 
-    @index.update_mapping 'doco', { :doco => { :properties => {
-      :author => { :type => 'string', :index => 'not_analyzed' }
+    @index.update_mapping "doco", { :doco => { :properties => {
+      :author => { :type => "string", :index => "not_analyzed" }
     }}}
 
-    assert_property_exists @index.mapping[@name], 'doco', 'author'
-    assert_property_exists @index.mapping[@name], 'doco', 'title'
+    assert_property_exists @index.mapping[@name], "doco", "author"
+    assert_property_exists @index.mapping[@name], "doco", "title"
 
-    @index.update_mapping 'mux_mool', { :mux_mool => { :properties => {
-      :song => { :type => 'string', :index => 'not_analyzed' }
+    @index.update_mapping "mux_mool", { :mux_mool => { :properties => {
+      :song => { :type => "string", :index => "not_analyzed" }
     }}}
 
-    assert_property_exists @index.mapping[@name], 'mux_mool', 'song'
+    assert_property_exists @index.mapping[@name], "mux_mool", "song"
   end
 
-  it 'updates document mappings with .put_mapping' do
+  it "updates document mappings with .put_mapping" do
     unless es_version_supports_update_mapping_with__all_disabled?
       skip "Mapping Update API is broken in this ES version."
     end
@@ -167,40 +167,40 @@ describe Elastomer::Client::Index do
         :doco => {
           :_source => { :enabled => false },
           :_all    => { :enabled => false },
-          :properties => {:title  => { :type => 'string', :analyzer => 'standard' }}
+          :properties => {:title  => { :type => "string", :analyzer => "standard" }}
         }
       }
     )
 
-    assert_property_exists @index.mapping[@name], 'doco', 'title'
+    assert_property_exists @index.mapping[@name], "doco", "title"
 
-    @index.put_mapping 'doco', { :doco => { :properties => {
-      :author => { :type => 'string', :index => 'not_analyzed' }
+    @index.put_mapping "doco", { :doco => { :properties => {
+      :author => { :type => "string", :index => "not_analyzed" }
     }}}
 
-    assert_property_exists @index.mapping[@name], 'doco', 'author'
-    assert_property_exists @index.mapping[@name], 'doco', 'title'
+    assert_property_exists @index.mapping[@name], "doco", "author"
+    assert_property_exists @index.mapping[@name], "doco", "title"
 
-    @index.put_mapping 'mux_mool', { :mux_mool => { :properties => {
-      :song => { :type => 'string', :index => 'not_analyzed' }
+    @index.put_mapping "mux_mool", { :mux_mool => { :properties => {
+      :song => { :type => "string", :index => "not_analyzed" }
     }}}
 
-    assert_property_exists @index.mapping[@name], 'mux_mool', 'song'
+    assert_property_exists @index.mapping[@name], "mux_mool", "song"
   end
 
-  it 'deletes document mappings' do
+  it "deletes document mappings" do
     @index.create(
       :mappings => {
         :doco => {
           :_source => { :enabled => false },
           :_all    => { :enabled => false },
-          :properties => {:title  => { :type => 'string', :analyzer => 'standard' }}
+          :properties => {:title  => { :type => "string", :analyzer => "standard" }}
         }
       }
     )
-    assert_mapping_exists @index.mapping[@name], 'doco'
+    assert_mapping_exists @index.mapping[@name], "doco"
 
-    response = @index.delete_mapping 'doco'
+    response = @index.delete_mapping "doco"
     assert_acknowledged response
 
     mapping = @index.get_mapping
@@ -210,26 +210,26 @@ describe Elastomer::Client::Index do
     assert_empty mapping, "no mappings are present"
   end
 
-  it 'lists all aliases to the index' do
+  it "lists all aliases to the index" do
     @index.create(nil)
 
     if es_version_always_returns_aliases?
-      assert_equal({@name => {'aliases' => {}}}, @index.get_aliases)
+      assert_equal({@name => {"aliases" => {}}}, @index.get_aliases)
     else
       assert_equal({@name => {}}, @index.get_aliases)
     end
 
-    $client.cluster.update_aliases :add => {:index => @name, :alias => 'foofaloo'}
-    assert_equal({@name => {'aliases' => {'foofaloo' => {}}}}, @index.get_aliases)
+    $client.cluster.update_aliases :add => {:index => @name, :alias => "foofaloo"}
+    assert_equal({@name => {"aliases" => {"foofaloo" => {}}}}, @index.get_aliases)
 
     if es_version_1_x?
-      assert_equal({@name => {'aliases' => {'foofaloo' => {}}}}, @index.get_alias("f*"))
+      assert_equal({@name => {"aliases" => {"foofaloo" => {}}}}, @index.get_alias("f*"))
       assert_equal({}, @index.get_alias("r*"))
     end
   end
 
   if es_version_1_x?
-    it 'adds and deletes aliases to the index' do
+    it "adds and deletes aliases to the index" do
       @index.create(nil)
       assert_empty @index.get_alias("*")
 
@@ -249,9 +249,9 @@ describe Elastomer::Client::Index do
   # COMPATIBILITY ES 1.x removed English stopwords from the default analyzers,
   # so create a custom one with the English stopwords added.
   if es_version_1_x?
-    it 'analyzes text and returns tokens' do
-      tokens = @index.analyze 'Just a few words to analyze.', :analyzer => 'standard', :index => nil
-      tokens = tokens['tokens'].map { |h| h['token'] }
+    it "analyzes text and returns tokens" do
+      tokens = @index.analyze "Just a few words to analyze.", :analyzer => "standard", :index => nil
+      tokens = tokens["tokens"].map { |h| h["token"] }
       assert_equal %w[just a few words to analyze], tokens
 
       @index.create(
@@ -270,18 +270,18 @@ describe Elastomer::Client::Index do
       )
       wait_for_index(@name)
 
-      tokens = @index.analyze 'Just a few words to analyze.', :analyzer => 'english_standard'
-      tokens = tokens['tokens'].map { |h| h['token'] }
+      tokens = @index.analyze "Just a few words to analyze.", :analyzer => "english_standard"
+      tokens = tokens["tokens"].map { |h| h["token"] }
       assert_equal %w[just few words analyze], tokens
     end
   else
-    it 'analyzes text and returns tokens' do
-      tokens = @index.analyze 'Just a few words to analyze.', :index => nil
-      tokens = tokens['tokens'].map { |h| h['token'] }
+    it "analyzes text and returns tokens" do
+      tokens = @index.analyze "Just a few words to analyze.", :index => nil
+      tokens = tokens["tokens"].map { |h| h["token"] }
       assert_equal %w[just few words analyze], tokens
 
-      tokens = @index.analyze 'Just a few words to analyze.', :analyzer => 'simple', :index => nil
-      tokens = tokens['tokens'].map { |h| h['token'] }
+      tokens = @index.analyze "Just a few words to analyze.", :analyzer => "simple", :index => nil
+      tokens = tokens["tokens"].map { |h| h["token"] }
       assert_equal %w[just a few words to analyze], tokens
     end
   end
@@ -293,119 +293,119 @@ describe Elastomer::Client::Index do
     end
 
     #TODO assert this only hits the desired index
-    it 'deletes' do
+    it "deletes" do
       response = @index.delete
       assert_acknowledged response
     end
 
-    it 'opens' do
+    it "opens" do
       response = @index.open
       assert_acknowledged response
     end
 
-    it 'closes' do
+    it "closes" do
       response = @index.close
       assert_acknowledged response
     end
 
-    it 'refreshes' do
+    it "refreshes" do
       response = @index.refresh
       assert_equal 0, response["_shards"]["failed"]
     end
 
-    it 'flushes' do
+    it "flushes" do
       response = @index.flush
       assert_equal 0, response["_shards"]["failed"]
     end
 
-    it 'optimizes' do
+    it "optimizes" do
       response = @index.optimize
       assert_equal 0, response["_shards"]["failed"]
     end
 
     # COMPATIBILITY ES 1.2 removed support for the gateway snapshot API.
     if es_version_supports_gateway_snapshots?
-      it 'snapshots' do
+      it "snapshots" do
         response = @index.snapshot
         assert_equal 0, response["_shards"]["failed"]
       end
     end
 
     if es_version_1_x?
-      it 'recovery' do
+      it "recovery" do
         response = @index.recovery
         assert_includes response, "elastomer-index-test"
       end
     end
 
-    it 'clears caches' do
+    it "clears caches" do
       response = @index.clear_cache
       assert_equal 0, response["_shards"]["failed"]
     end
 
-    it 'gets stats' do
+    it "gets stats" do
       response = @index.stats
-      if response.key? 'indices'
+      if response.key? "indices"
         assert_includes response["indices"], "elastomer-index-test"
       else
         assert_includes response["_all"]["indices"], "elastomer-index-test"
       end
     end
 
-    it 'gets status' do
+    it "gets status" do
       response = @index.status
       assert_includes response["indices"], "elastomer-index-test"
     end
 
-    it 'gets segments' do
-      @index.docs('foo').index("foo" => "bar")
+    it "gets segments" do
+      @index.docs("foo").index("foo" => "bar")
       response = @index.segments
       assert_includes response["indices"], "elastomer-index-test"
     end
 
-    it 'deletes by query' do
-      @index.docs('foo').index("foo" => "bar")
+    it "deletes by query" do
+      @index.docs("foo").index("foo" => "bar")
       @index.refresh
-      r = @index.delete_by_query(:q => '*')
+      r = @index.delete_by_query(:q => "*")
       assert_equal({
-        '_all' => {
-          'found' => 1,
-          'deleted' => 1,
-          'missing' => 0,
-          'failed' => 0,
+        "_all" => {
+          "found" => 1,
+          "deleted" => 1,
+          "missing" => 0,
+          "failed" => 0,
         },
         @name => {
-          'found' => 1,
-          'deleted' => 1,
-          'missing' => 0,
-          'failed' => 0,
+          "found" => 1,
+          "deleted" => 1,
+          "missing" => 0,
+          "failed" => 0,
         }
-      }, r['_indices'])
+      }, r["_indices"])
     end
 
-    it 'creates a Percolator' do
+    it "creates a Percolator" do
       id = "1"
       percolator = @index.percolator id
       assert_equal id, percolator.id
     end
 
-    it 'performs multi percolate queries' do
+    it "performs multi percolate queries" do
       @index.docs.index \
         :_id    => 1,
-        :_type  => 'doc2',
-        :title  => 'the author of logging',
-        :author => 'pea53'
+        :_type  => "doc2",
+        :title  => "the author of logging",
+        :author => "pea53"
 
       @index.docs.index \
         :_id    => 2,
-        :_type  => 'doc2',
-        :title  => 'the author of rubber-band',
-        :author => 'grantr'
+        :_type  => "doc2",
+        :title  => "the author of rubber-band",
+        :author => "grantr"
 
       @index.percolator("1").create :query => { :match_all => { } }
       @index.percolator("2").create :query => { :match => { :author => "pea53" } }
 
-      h = @index.multi_percolate(:type => 'doc2') do |m|
+      h = @index.multi_percolate(:type => "doc2") do |m|
         m.percolate :author => "pea53"
         m.percolate :author => "grantr"
         m.count({}, { :author => "grantr" })

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -91,6 +91,7 @@ describe Elastomer::Client::MultiPercolate do
     assert_equal 2, response3["total"]
   end
 
+  # rubocop:disable Metrics/MethodLength
   def populate!
     @docs.index \
       :_id    => 1,
@@ -125,4 +126,5 @@ describe Elastomer::Client::MultiPercolate do
 
     @index.refresh
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -1,27 +1,27 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::MultiPercolate do
 
   before do
-    @name  = 'elastomer-mpercolate-test'
+    @name  = "elastomer-mpercolate-test"
     @index = $client.index(@name)
 
     unless @index.exists?
       @index.create \
-        :settings => { 'index.number_of_shards' => 1, 'index.number_of_replicas' => 0 },
+        :settings => { "index.number_of_shards" => 1, "index.number_of_replicas" => 0 },
         :mappings => {
           :doc1 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => 'string', :analyzer => 'standard' },
-              :author => { :type => 'string', :index => 'not_analyzed' }
+              :title  => { :type => "string", :analyzer => "standard" },
+              :author => { :type => "string", :index => "not_analyzed" }
             }
           },
           :doc2 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => 'string', :analyzer => 'standard' },
-              :author => { :type => 'string', :index => 'not_analyzed' }
+              :title  => { :type => "string", :analyzer => "standard" },
+              :author => { :type => "string", :index => "not_analyzed" }
             }
           }
         }
@@ -36,7 +36,7 @@ describe Elastomer::Client::MultiPercolate do
     @index.delete if @index.exists?
   end
 
-  it 'performs multi percolate queries' do
+  it "performs multi percolate queries" do
     populate!
 
     body = [
@@ -56,7 +56,7 @@ describe Elastomer::Client::MultiPercolate do
     assert_equal 2, response3["total"]
   end
 
-  it 'performs multi percolate queries with .mpercolate' do
+  it "performs multi percolate queries with .mpercolate" do
     populate!
 
     body = [
@@ -76,10 +76,10 @@ describe Elastomer::Client::MultiPercolate do
     assert_equal 2, response3["total"]
   end
 
-  it 'supports a nice block syntax' do
+  it "supports a nice block syntax" do
     populate!
 
-    h = $client.multi_percolate(:index => @name, :type => 'doc2') do |m|
+    h = $client.multi_percolate(:index => @name, :type => "doc2") do |m|
       m.percolate :author => "pea53"
       m.percolate :author => "grantr"
       m.count({ :author => "grantr" })
@@ -95,27 +95,27 @@ describe Elastomer::Client::MultiPercolate do
   def populate!
     @docs.index \
       :_id    => 1,
-      :_type  => 'doc1',
-      :title  => 'the author of gravatar',
-      :author => 'mojombo'
+      :_type  => "doc1",
+      :title  => "the author of gravatar",
+      :author => "mojombo"
 
     @docs.index \
       :_id    => 2,
-      :_type  => 'doc1',
-      :title  => 'the author of resque',
-      :author => 'defunkt'
+      :_type  => "doc1",
+      :title  => "the author of resque",
+      :author => "defunkt"
 
     @docs.index \
       :_id    => 1,
-      :_type  => 'doc2',
-      :title  => 'the author of logging',
-      :author => 'pea53'
+      :_type  => "doc2",
+      :title  => "the author of logging",
+      :author => "pea53"
 
     @docs.index \
       :_id    => 2,
-      :_type  => 'doc2',
-      :title  => 'the author of rubber-band',
-      :author => 'grantr'
+      :_type  => "doc2",
+      :title  => "the author of rubber-band",
+      :author => "grantr"
 
     percolator1 = @index.percolator "1"
     percolator1.create :query => { :match_all => { } }

--- a/test/client/multi_search_test.rb
+++ b/test/client/multi_search_test.rb
@@ -128,6 +128,7 @@ describe Elastomer::Client::MultiSearch do
     assert_equal 1, response2["hits"]["total"]
   end
 
+  # rubocop:disable Metrics/MethodLength
   def populate!
     @docs.index \
       :_id    => 1,
@@ -155,4 +156,5 @@ describe Elastomer::Client::MultiSearch do
 
     @index.refresh
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/test/client/multi_search_test.rb
+++ b/test/client/multi_search_test.rb
@@ -1,27 +1,27 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::MultiSearch do
 
   before do
-    @name  = 'elastomer-msearch-test'
+    @name  = "elastomer-msearch-test"
     @index = $client.index(@name)
 
     unless @index.exists?
       @index.create \
-        :settings => { 'index.number_of_shards' => 1, 'index.number_of_replicas' => 0 },
+        :settings => { "index.number_of_shards" => 1, "index.number_of_replicas" => 0 },
         :mappings => {
           :doc1 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => 'string', :analyzer => 'standard' },
-              :author => { :type => 'string', :index => 'not_analyzed' }
+              :title  => { :type => "string", :analyzer => "standard" },
+              :author => { :type => "string", :index => "not_analyzed" }
             }
           },
           :doc2 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => 'string', :analyzer => 'standard' },
-              :author => { :type => 'string', :index => 'not_analyzed' }
+              :title  => { :type => "string", :analyzer => "standard" },
+              :author => { :type => "string", :index => "not_analyzed" }
             }
           }
         }
@@ -36,7 +36,7 @@ describe Elastomer::Client::MultiSearch do
     @index.delete if @index.exists?
   end
 
-  it 'performs multisearches' do
+  it "performs multisearches" do
     populate!
 
     body = [
@@ -54,7 +54,7 @@ describe Elastomer::Client::MultiSearch do
     assert_equal "2", response2["hits"]["hits"][0]["_id"]
 
     body = [
-      '{}',
+      "{}",
       '{"query" : {"match": {"author" : "grantr"}}}',
       nil
     ]
@@ -65,7 +65,7 @@ describe Elastomer::Client::MultiSearch do
     assert_equal "2", response1["hits"]["hits"][0]["_id"]
   end
 
-  it 'performs multisearches with .msearch' do
+  it "performs multisearches with .msearch" do
     populate!
 
     body = [
@@ -83,7 +83,7 @@ describe Elastomer::Client::MultiSearch do
     assert_equal "2", response2["hits"]["hits"][0]["_id"]
 
     body = [
-      '{}',
+      "{}",
       '{"query" : {"match": {"author" : "grantr"}}}',
       nil
     ]
@@ -94,12 +94,12 @@ describe Elastomer::Client::MultiSearch do
     assert_equal "2", response1["hits"]["hits"][0]["_id"]
   end
 
-  it 'supports a nice block syntax' do
+  it "supports a nice block syntax" do
     populate!
 
     h = $client.multi_search do |m|
       m.search({:query => { :match_all => {}}}, :index => @name, :search_type => :count)
-      m.search({:query => { :match => { "title" => "author" }}}, :index => @name, :type => 'doc2')
+      m.search({:query => { :match => { "title" => "author" }}}, :index => @name, :type => "doc2")
     end
 
     response1, response2 = h["responses"]
@@ -109,7 +109,7 @@ describe Elastomer::Client::MultiSearch do
 
     h = @index.multi_search do |m|
       m.search({:query => { :match_all => {}}}, :search_type => :count)
-      m.search({:query => { :match => { "title" => "author" }}}, :type => 'doc2')
+      m.search({:query => { :match => { "title" => "author" }}}, :type => "doc2")
     end
 
     response1, response2 = h["responses"]
@@ -117,9 +117,9 @@ describe Elastomer::Client::MultiSearch do
     assert_equal 4, response1["hits"]["total"]
     assert_equal 2, response2["hits"]["total"]
 
-    h = @index.docs('doc1').multi_search do |m|
+    h = @index.docs("doc1").multi_search do |m|
       m.search({:query => { :match_all => {}}}, :search_type => :count)
-      m.search({:query => { :match => { "title" => "logging" }}}, :type => 'doc2')
+      m.search({:query => { :match => { "title" => "logging" }}}, :type => "doc2")
     end
 
     response1, response2 = h["responses"]
@@ -132,27 +132,27 @@ describe Elastomer::Client::MultiSearch do
   def populate!
     @docs.index \
       :_id    => 1,
-      :_type  => 'doc1',
-      :title  => 'the author of gravatar',
-      :author => 'mojombo'
+      :_type  => "doc1",
+      :title  => "the author of gravatar",
+      :author => "mojombo"
 
     @docs.index \
       :_id    => 2,
-      :_type  => 'doc1',
-      :title  => 'the author of resque',
-      :author => 'defunkt'
+      :_type  => "doc1",
+      :title  => "the author of resque",
+      :author => "defunkt"
 
     @docs.index \
       :_id    => 1,
-      :_type  => 'doc2',
-      :title  => 'the author of logging',
-      :author => 'pea53'
+      :_type  => "doc2",
+      :title  => "the author of logging",
+      :author => "pea53"
 
     @docs.index \
       :_id    => 2,
-      :_type  => 'doc2',
-      :title  => 'the author of rubber-band',
-      :author => 'grantr'
+      :_type  => "doc2",
+      :title  => "the author of rubber-band",
+      :author => "grantr"
 
     @index.refresh
   end

--- a/test/client/nodes_test.rb
+++ b/test/client/nodes_test.rb
@@ -1,57 +1,57 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Nodes do
 
-  it 'gets info for the node(s)' do
+  it "gets info for the node(s)" do
     h = $client.nodes.info
-    assert h.key?('cluster_name'), 'the cluster name is returned'
-    assert_instance_of Hash, h['nodes'], 'the node list is returned'
+    assert h.key?("cluster_name"), "the cluster name is returned"
+    assert_instance_of Hash, h["nodes"], "the node list is returned"
   end
 
-  it 'gets stats for the node(s)' do
+  it "gets stats for the node(s)" do
     h = $client.nodes.stats
-    assert_instance_of Hash, h['nodes'], 'the node list is returned'
+    assert_instance_of Hash, h["nodes"], "the node list is returned"
 
-    node = h['nodes'].values.first
-    assert node.key?('indices'), 'indices stats are returned'
+    node = h["nodes"].values.first
+    assert node.key?("indices"), "indices stats are returned"
   end
 
   if es_version_1_x?
-    it 'fitlers node info' do
-      h = $client.nodes.info(:info => 'os')
-      node = h['nodes'].values.first
-      assert node.key?('os'), 'expected os info to be present'
-      assert !node.key?('jvm'), 'expected jvm info to be absent'
+    it "fitlers node info" do
+      h = $client.nodes.info(:info => "os")
+      node = h["nodes"].values.first
+      assert node.key?("os"), "expected os info to be present"
+      assert !node.key?("jvm"), "expected jvm info to be absent"
 
       h = $client.nodes.info(:info => %w[jvm process])
-      node = h['nodes'].values.first
-      assert node.key?('jvm'), 'expected jvm info to be present'
-      assert node.key?('process'), 'expected process info to be present'
-      assert !node.key?('network'), 'expected network info to be absent'
+      node = h["nodes"].values.first
+      assert node.key?("jvm"), "expected jvm info to be present"
+      assert node.key?("process"), "expected process info to be present"
+      assert !node.key?("network"), "expected network info to be absent"
     end
 
-    it 'filters node stats' do
-      h = $client.nodes.stats(:stats => 'http')
-      node = h['nodes'].values.first
-      assert node.key?('http'), 'expected http stats to be present'
-      assert !node.key?('indices'), 'expected indices stats to be absent'
+    it "filters node stats" do
+      h = $client.nodes.stats(:stats => "http")
+      node = h["nodes"].values.first
+      assert node.key?("http"), "expected http stats to be present"
+      assert !node.key?("indices"), "expected indices stats to be absent"
     end
   end
 
-  it 'gets the hot threads for the node(s)' do
+  it "gets the hot threads for the node(s)" do
     str = $client.nodes.hot_threads :read_timeout => 2
     assert_instance_of String, str
     assert_match %r/cpu usage by thread/, str
   end
 
-  it 'can be scoped to a single node' do
-    h = $client.nodes('node-with-no-name').info
-    assert_empty h['nodes']
+  it "can be scoped to a single node" do
+    h = $client.nodes("node-with-no-name").info
+    assert_empty h["nodes"]
   end
 
-  it 'can be scoped to multiple nodes' do
+  it "can be scoped to multiple nodes" do
     h = $client.nodes(%w[node1 node2 node3]).info
-    assert_empty h['nodes']
+    assert_empty h["nodes"]
   end
 
 end

--- a/test/client/percolator_test.rb
+++ b/test/client/percolator_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Percolator do
 
@@ -18,34 +18,34 @@ describe Elastomer::Client::Percolator do
       wait_for_index(@index_name)
     end
 
-    it 'creates a query' do
+    it "creates a query" do
       percolator = @index.percolator "1"
       response = percolator.create :query => { :match_all => { } }
       assert response["created"], "Couldn't create the percolator query"
     end
 
-    it 'gets a query' do
+    it "gets a query" do
       percolator = @index.percolator "1"
       percolator.create :query => { :match_all => { } }
       response = percolator.get
       assert response["found"], "Couldn't find the percolator query"
     end
 
-    it 'deletes a query' do
+    it "deletes a query" do
       percolator = @index.percolator "1"
       percolator.create :query => { :match_all => { } }
       response = percolator.delete
       assert response["found"], "Couldn't find the percolator query"
     end
 
-    it 'checks for the existence of a query' do
+    it "checks for the existence of a query" do
       percolator = @index.percolator "1"
       refute percolator.exists?, "Percolator query exists"
       percolator.create :query => { :match_all => { } }
       assert percolator.exists?, "Percolator query does not exist"
     end
 
-    it 'cannot delete all percolators by providing a nil id' do
+    it "cannot delete all percolators by providing a nil id" do
       assert_raises(ArgumentError) { percolator = @index.percolator nil }
     end
   end

--- a/test/client/repository_test.rb
+++ b/test/client/repository_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Repository do
 
@@ -9,11 +9,11 @@ describe Elastomer::Client::Repository do
         skip "To enable snapshot tests, add a path.repo setting to your elasticsearch.yml file."
       end
 
-      @name = 'elastomer-repository-test'
+      @name = "elastomer-repository-test"
       @repo = $client.repository(@name)
     end
 
-    it 'determines if a repo exists' do
+    it "determines if a repo exists" do
       assert_equal false, @repo.exists?
       assert_equal false, @repo.exist?
       with_tmp_repo(@name) do
@@ -21,63 +21,63 @@ describe Elastomer::Client::Repository do
       end
     end
 
-    it 'creates repos' do
+    it "creates repos" do
       response = create_repo(@name)
       assert_equal true, response["acknowledged"]
       delete_repo(@name)
     end
 
-    it 'cannot create a repo without a name' do
+    it "cannot create a repo without a name" do
       lambda {
         create_repo(nil)
       }.must_raise ArgumentError
     end
 
-    it 'gets repos' do
+    it "gets repos" do
       with_tmp_repo do |repo|
         response = repo.get
         refute_nil response[repo.name]
       end
     end
 
-    it 'gets all repos' do
+    it "gets all repos" do
       with_tmp_repo do |repo|
         response = $client.repository.get
         refute_nil response[repo.name]
       end
     end
 
-    it 'gets repo status' do
+    it "gets repo status" do
       with_tmp_repo do |repo|
         response = repo.status
         assert_equal [], response["snapshots"]
       end
     end
 
-    it 'gets status of all repos' do
+    it "gets status of all repos" do
       response = $client.repository.status
       assert_equal [], response["snapshots"]
     end
 
-    it 'updates repos' do
+    it "updates repos" do
       with_tmp_repo do |repo|
-        settings = repo.get[repo.name]['settings']
-        response = repo.update(:type => 'fs', :settings => settings.merge('compress' => true))
+        settings = repo.get[repo.name]["settings"]
+        response = repo.update(:type => "fs", :settings => settings.merge("compress" => true))
         assert_equal true, response["acknowledged"]
         assert_equal "true", repo.get[repo.name]["settings"]["compress"]
       end
     end
 
-    it 'cannot update a repo without a name' do
+    it "cannot update a repo without a name" do
       with_tmp_repo do |repo|
         lambda {
-          settings = repo.get[repo.name]['settings']
-          $client.repository.update(:type => 'fs', :settings => settings.merge('compress' => true))
+          settings = repo.get[repo.name]["settings"]
+          $client.repository.update(:type => "fs", :settings => settings.merge("compress" => true))
         }.must_raise ArgumentError
       end
     end
 
-    it 'deletes repos' do
+    it "deletes repos" do
       with_tmp_repo do |repo|
         response = repo.delete
         assert_equal true, response["acknowledged"]
@@ -85,26 +85,26 @@ describe Elastomer::Client::Repository do
       end
     end
 
-    it 'cannot delete a repo without a name' do
+    it "cannot delete a repo without a name" do
       lambda {
         $client.repository.delete
       }.must_raise ArgumentError
     end
 
-    it 'gets snapshots' do
+    it "gets snapshots" do
       with_tmp_repo do |repo|
         response = repo.snapshots.get
         assert_equal [], response["snapshots"]
 
-        create_snapshot(repo, 'test-snapshot')
+        create_snapshot(repo, "test-snapshot")
         response = repo.snapshot.get
-        assert_equal ['test-snapshot'], response["snapshots"].collect { |info| info["snapshot"] }
+        assert_equal ["test-snapshot"], response["snapshots"].collect { |info| info["snapshot"] }
 
-        snapshot2 = create_snapshot(repo, 'test-snapshot2')
+        snapshot2 = create_snapshot(repo, "test-snapshot2")
         response  = repo.snapshots.get
         snapshot_names = response["snapshots"].collect { |info| info["snapshot"] }
-        assert_includes snapshot_names, 'test-snapshot'
-        assert_includes snapshot_names, 'test-snapshot2'
+        assert_includes snapshot_names, "test-snapshot"
+        assert_includes snapshot_names, "test-snapshot2"
       end
     end
   end

--- a/test/client/scroller_test.rb
+++ b/test/client/scroller_test.rb
@@ -1,29 +1,29 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Scroller do
 
   before do
-    @name  = 'elastomer-scroller-test'
+    @name  = "elastomer-scroller-test"
     @index = $client.index(@name)
 
     unless @index.exists?
       @index.create \
-        :settings => { 'index.number_of_shards' => 1, 'index.number_of_replicas' => 0 },
+        :settings => { "index.number_of_shards" => 1, "index.number_of_replicas" => 0 },
         :mappings => {
           :tweet => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :message => { :type => 'string', :analyzer => 'standard' },
-              :author  => { :type => 'string', :index => 'not_analyzed' },
-              :sorter  => { :type => 'integer' }
+              :message => { :type => "string", :analyzer => "standard" },
+              :author  => { :type => "string", :index => "not_analyzed" },
+              :sorter  => { :type => "integer" }
             }
           },
           :book => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => 'string', :analyzer => 'standard' },
-              :author => { :type => 'string', :index => 'not_analyzed' },
-              :sorter  => { :type => 'integer' }
+              :title  => { :type => "string", :analyzer => "standard" },
+              :author => { :type => "string", :index => "not_analyzed" },
+              :sorter  => { :type => "integer" }
             }
           }
         }
@@ -37,76 +37,76 @@ describe Elastomer::Client::Scroller do
     @index.delete if @index.exists?
   end
 
-  it 'scans over all documents in an index' do
+  it "scans over all documents in an index" do
     scan = @index.scan '{"query":{"match_all":{}}}', :size => 10
 
-    counts = {'tweet' => 0, 'book' => 0}
-    scan.each_document { |h| counts[h['_type']] += 1 }
+    counts = {"tweet" => 0, "book" => 0}
+    scan.each_document { |h| counts[h["_type"]] += 1 }
 
-    assert_equal 50, counts['tweet']
-    assert_equal 25, counts['book']
+    assert_equal 50, counts["tweet"]
+    assert_equal 25, counts["book"]
   end
 
-  it 'restricts the scan to a single document type' do
-    scan = @index.scan '{"query":{"match_all":{}}}', :type => 'book'
+  it "restricts the scan to a single document type" do
+    scan = @index.scan '{"query":{"match_all":{}}}', :type => "book"
 
-    counts = {'tweet' => 0, 'book' => 0}
-    scan.each_document { |h| counts[h['_type']] += 1 }
+    counts = {"tweet" => 0, "book" => 0}
+    scan.each_document { |h| counts[h["_type"]] += 1 }
 
-    assert_equal 0, counts['tweet']
-    assert_equal 25, counts['book']
+    assert_equal 0, counts["tweet"]
+    assert_equal 25, counts["book"]
   end
 
-  it 'limits results by query' do
+  it "limits results by query" do
     scan = @index.scan :query => { :bool => { :should => [
-      {:match => {:author => 'pea53'}},
-      {:match => {:title => '17'}}
+      {:match => {:author => "pea53"}},
+      {:match => {:title => "17"}}
     ]}}
 
-    counts = {'tweet' => 0, 'book' => 0}
-    scan.each_document { |h| counts[h['_type']] += 1 }
+    counts = {"tweet" => 0, "book" => 0}
+    scan.each_document { |h| counts[h["_type"]] += 1 }
 
-    assert_equal 50, counts['tweet']
-    assert_equal 1, counts['book']
+    assert_equal 50, counts["tweet"]
+    assert_equal 1, counts["book"]
   end
 
-  it 'scrolls and sorts over all documents' do
+  it "scrolls and sorts over all documents" do
     scroll = @index.scroll({
       :query => {:match_all => {}},
       :sort => {:sorter => {:order => :asc}}
-    }, :type => 'tweet')
+    }, :type => "tweet")
 
     tweets = []
-    scroll.each_document { |h| tweets << h['_id'].to_i }
+    scroll.each_document { |h| tweets << h["_id"].to_i }
 
     expected = (0...50).to_a.reverse
     assert_equal expected, tweets
   end
 
-  it 'propagates URL query strings' do
-    scan = @index.scan(nil, { :q => 'author:pea53 || title:17' })
+  it "propagates URL query strings" do
+    scan = @index.scan(nil, { :q => "author:pea53 || title:17" })
 
-    counts = {'tweet' => 0, 'book' => 0}
-    scan.each_document { |h| counts[h['_type']] += 1 }
+    counts = {"tweet" => 0, "book" => 0}
+    scan.each_document { |h| counts[h["_type"]] += 1 }
 
-    assert_equal 50, counts['tweet']
-    assert_equal 1, counts['book']
+    assert_equal 50, counts["tweet"]
+    assert_equal 1, counts["book"]
   end
 
   def populate!
     h = @index.bulk do |b|
       50.times { |num|
-        b.index %Q({"author":"pea53","message":"this is tweet number #{num}","sorter":#{50-num}}), :_id => num, :_type => 'tweet'
+        b.index %Q({"author":"pea53","message":"this is tweet number #{num}","sorter":#{50-num}}), :_id => num, :_type => "tweet"
       }
     end
-    h['items'].each {|item| assert_bulk_index(item) }
+    h["items"].each {|item| assert_bulk_index(item) }
 
     h = @index.bulk do |b|
       25.times { |num|
-        b.index %Q({"author":"Pratchett","title":"DiscWorld Book #{num}","sorter":#{25-num}}), :_id => num, :_type => 'book'
+        b.index %Q({"author":"Pratchett","title":"DiscWorld Book #{num}","sorter":#{25-num}}), :_id => num, :_type => "book"
       }
     end
-    h['items'].each {|item| assert_bulk_index(item) }
+    h["items"].each {|item| assert_bulk_index(item) }
 
     @index.refresh
   end

--- a/test/client/snapshot_test.rb
+++ b/test/client/snapshot_test.rb
@@ -1,5 +1,5 @@
 
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Snapshot do
   if es_version_1_x?
@@ -8,16 +8,16 @@ describe Elastomer::Client::Snapshot do
         skip "To enable snapshot tests, add a path.repo setting to your elasticsearch.yml file."
       end
 
-      @index_name = 'elastomer-snapshot-test-index'
+      @index_name = "elastomer-snapshot-test-index"
       @index = $client.index(@index_name)
-      @name = 'elastomer-test'
+      @name = "elastomer-test"
     end
 
     after do
       @index.delete if @index && @index.exists?
     end
 
-    it 'determines if a snapshot exists' do
+    it "determines if a snapshot exists" do
       with_tmp_repo do |repo|
         snapshot = repo.snapshot(@name)
         assert_equal false, snapshot.exists?
@@ -27,14 +27,14 @@ describe Elastomer::Client::Snapshot do
       end
     end
 
-    it 'creates snapshots' do
+    it "creates snapshots" do
       with_tmp_repo do |repo|
         response = repo.snapshot(@name).create({}, :wait_for_completion => true)
         assert_equal @name, response["snapshot"]["snapshot"]
       end
     end
 
-    it 'creates snapshots with options' do
+    it "creates snapshots with options" do
       @index.create(:number_of_shards => 1, :number_of_replicas => 0)
       with_tmp_repo do |repo|
         response = repo.snapshot(@name).create({:indices => [@index_name]}, :wait_for_completion => true)
@@ -43,7 +43,7 @@ describe Elastomer::Client::Snapshot do
       end
     end
 
-    it 'gets snapshot info for one and all' do
+    it "gets snapshot info for one and all" do
       with_tmp_snapshot do |snapshot, repo|
         response = snapshot.get
         assert_equal snapshot.name, response["snapshots"][0]["snapshot"]
@@ -52,7 +52,7 @@ describe Elastomer::Client::Snapshot do
       end
     end
 
-    it 'gets snapshot status for one and all' do
+    it "gets snapshot status for one and all" do
       @index.create(:number_of_shards => 1, :number_of_replicas => 0)
       with_tmp_repo do |repo|
         repo.snapshot(@name).create({:indices => [@index_name]}, :wait_for_completion => true)
@@ -61,7 +61,7 @@ describe Elastomer::Client::Snapshot do
       end
     end
 
-    it 'gets status of snapshots in progress' do
+    it "gets status of snapshots in progress" do
       # we can't reliably get status of an in-progress snapshot in tests, so
       # check for an empty result instead
       with_tmp_repo do |repo|
@@ -72,19 +72,19 @@ describe Elastomer::Client::Snapshot do
       end
     end
 
-    it 'disallows nil repo name with non-nil snapshot name' do
-      assert_raises(ArgumentError) { $client.repository.snapshot('snapshot') }
-      assert_raises(ArgumentError) { $client.snapshot(nil, 'snapshot') }
+    it "disallows nil repo name with non-nil snapshot name" do
+      assert_raises(ArgumentError) { $client.repository.snapshot("snapshot") }
+      assert_raises(ArgumentError) { $client.snapshot(nil, "snapshot") }
     end
 
-    it 'deletes snapshots' do
+    it "deletes snapshots" do
       with_tmp_snapshot do |snapshot|
         response = snapshot.delete
         assert_equal true, response["acknowledged"]
       end
     end
 
-    it 'restores snapshots' do
+    it "restores snapshots" do
       @index.create(:number_of_shards => 1, :number_of_replicas => 0)
       wait_for_index(@index_name)
       with_tmp_repo do |repo|
@@ -106,7 +106,7 @@ describe Elastomer::Client::Snapshot do
         @restored_index.delete if @restored_index && @restored_index.exists?
       end
 
-      it 'restores snapshots with options' do
+      it "restores snapshots with options" do
         @index.create(:number_of_shards => 1, :number_of_replicas => 0)
         wait_for_index(@index_name)
         with_tmp_repo do |repo|

--- a/test/client/stubbed_client_test.rb
+++ b/test/client/stubbed_client_test.rb
@@ -1,40 +1,40 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
-describe 'stubbed client tests' do
+describe "stubbed client tests" do
   before do
     @stubs  = Faraday::Adapter.lookup_middleware(:test)::Stubs.new
     @client = Elastomer::Client.new :adapter => [:test, @stubs]
   end
 
   describe Elastomer::Client::Cluster do
-    it 'reroutes shards' do
-      @stubs.post '/_cluster/reroute?dry_run=true' do |env|
+    it "reroutes shards" do
+      @stubs.post "/_cluster/reroute?dry_run=true" do |env|
         assert_match %r/^\{"commands":\[\{"move":\{[^\{\}]+\}\}\]\}$/, env[:body]
-        [200, {'Content-Type' => 'application/json'}, '{"acknowledged" : true}']
+        [200, {"Content-Type" => "application/json"}, '{"acknowledged" : true}']
       end
 
-      commands = { :move => { :index => 'test', :shard => 0, :from_node => 'node1', :to_node => 'node2' }}
+      commands = { :move => { :index => "test", :shard => 0, :from_node => "node1", :to_node => "node2" }}
       h = @client.cluster.reroute commands, :dry_run => true
       assert_acknowledged h
     end
 
-    it 'performs a shutdown of the cluster' do
-      @stubs.post('/_shutdown') { [200, {'Content-Type' => 'application/json'}, '{"cluster_name":"elasticsearch"}'] }
+    it "performs a shutdown of the cluster" do
+      @stubs.post("/_shutdown") { [200, {"Content-Type" => "application/json"}, '{"cluster_name":"elasticsearch"}'] }
       h = @client.cluster.shutdown
-      assert_equal "elasticsearch", h['cluster_name']
+      assert_equal "elasticsearch", h["cluster_name"]
     end
   end
 
   describe Elastomer::Client::Nodes do
-    it 'performs a shutdown of the node(s)' do
-      @stubs.post('/_cluster/nodes/_all/_shutdown')  { [200, {'Content-Type' => 'application/json'}, '{"nodes":{"1":{"name":"Node1"}}}'] }
-      @stubs.post('/_cluster/nodes/node2/_shutdown') { [200, {'Content-Type' => 'application/json'}, '{"nodes":{"2":{"name":"Node2"}}}'] }
+    it "performs a shutdown of the node(s)" do
+      @stubs.post("/_cluster/nodes/_all/_shutdown")  { [200, {"Content-Type" => "application/json"}, '{"nodes":{"1":{"name":"Node1"}}}'] }
+      @stubs.post("/_cluster/nodes/node2/_shutdown") { [200, {"Content-Type" => "application/json"}, '{"nodes":{"2":{"name":"Node2"}}}'] }
 
       h = @client.nodes("_all").shutdown
-      assert_equal "Node1", h['nodes']['1']['name']
+      assert_equal "Node1", h["nodes"]["1"]["name"]
 
-      h = @client.nodes('node2').shutdown
-      assert_equal 'Node2', h['nodes']['2']['name']
+      h = @client.nodes("node2").shutdown
+      assert_equal "Node2", h["nodes"]["2"]["name"]
     end
   end
 end

--- a/test/client/template_test.rb
+++ b/test/client/template_test.rb
@@ -1,9 +1,9 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Cluster do
 
   before do
-    @name = 'elastomer-template-test'
+    @name = "elastomer-template-test"
     @template = $client.template @name
   end
 
@@ -11,29 +11,29 @@ describe Elastomer::Client::Cluster do
     @template.delete if @template.exists?
   end
 
-  it 'lists templates in the cluster' do
-    @template.create({:template => 'test-elastomer*'})
+  it "lists templates in the cluster" do
+    @template.create({:template => "test-elastomer*"})
     templates = $client.cluster.templates
     assert !templates.empty?, "expected to see a template"
   end
 
-  it 'creates a template' do
-    assert !@template.exists?, 'the template should not exist'
+  it "creates a template" do
+    assert !@template.exists?, "the template should not exist"
 
     @template.create({
-      :template => 'test-elastomer*',
+      :template => "test-elastomer*",
       :settings => { :number_of_shards => 3 },
       :mappings => {
         :doco => { :_source => { :enabled => false }}
       }
     })
 
-    assert @template.exists?, ' we now have a cluster-test template'
+    assert @template.exists?, " we now have a cluster-test template"
 
     template = @template.get
     assert_equal [@name], template.keys
-    assert_equal 'test-elastomer*', template[@name]['template']
-    assert_equal '3', template[@name]['settings']['index.number_of_shards']
+    assert_equal "test-elastomer*", template[@name]["template"]
+    assert_equal "3", template[@name]["settings"]["index.number_of_shards"]
   end
 
 end

--- a/test/client/warmer_test.rb
+++ b/test/client/warmer_test.rb
@@ -1,19 +1,19 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Warmer do
   before do
-    @name  = 'elastomer-warmer-test'
+    @name  = "elastomer-warmer-test"
     @index = $client.index(@name)
 
     unless @index.exists?
       @index.create(
-        :settings => { 'index.number_of_shards' => 1, 'index.number_of_replicas' => 0 },
+        :settings => { "index.number_of_shards" => 1, "index.number_of_replicas" => 0 },
         :mappings => {
           :tweet => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :message => { :type => 'string', :analyzer => 'standard' },
-              :author  => { :type => 'string', :index => 'not_analyzed' }
+              :message => { :type => "string", :analyzer => "standard" },
+              :author  => { :type => "string", :index => "not_analyzed" }
             }
           }
         }
@@ -26,31 +26,31 @@ describe Elastomer::Client::Warmer do
     @index.delete if @index.exists?
   end
 
-  it 'creates warmers' do
-    h = @index.warmer('test1').create(:query => { :match_all => {}})
+  it "creates warmers" do
+    h = @index.warmer("test1").create(:query => { :match_all => {}})
     assert_acknowledged h
   end
 
-  it 'deletes warmers' do
-    @index.warmer('test1').create(:query => { :match_all => {}})
+  it "deletes warmers" do
+    @index.warmer("test1").create(:query => { :match_all => {}})
 
-    h = @index.warmer('test1').delete
+    h = @index.warmer("test1").delete
     assert_acknowledged h
   end
 
-  it 'gets warmers' do
+  it "gets warmers" do
     body = { "query" => {"match_all" => {}}}
-    @index.warmer('test1').create(body)
+    @index.warmer("test1").create(body)
 
-    h = @index.warmer('test1').get
+    h = @index.warmer("test1").get
     assert_equal body, h[@name]["warmers"]["test1"]["source"]
   end
 
-  it 'knows when warmers exist' do
-    assert_equal false, @index.warmer('test1').exists?
-    assert_equal false, @index.warmer('test1').exist?
+  it "knows when warmers exist" do
+    assert_equal false, @index.warmer("test1").exists?
+    assert_equal false, @index.warmer("test1").exist?
 
-    h = @index.warmer('test1').create(:query => { :match_all => {}})
-    assert_equal true, @index.warmer('test1').exists?
+    h = @index.warmer("test1").create(:query => { :match_all => {}})
+    assert_equal true, @index.warmer("test1").exists?
   end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,8 +1,8 @@
-require File.expand_path('../test_helper', __FILE__)
+require File.expand_path("../test_helper", __FILE__)
 
 describe Elastomer::Client do
 
-  it 'uses the adapter specified at creation' do
+  it "uses the adapter specified at creation" do
     c = Elastomer::Client.new(:adapter => :test)
     assert_includes c.connection.builder.handlers, Faraday::Adapter::Test
   end
@@ -13,50 +13,50 @@ describe Elastomer::Client do
     assert_includes c.connection.builder.handlers, adapter
   end
 
-  it 'uses the same connection for all requests' do
+  it "uses the same connection for all requests" do
     c = $client.connection
     assert_same c, $client.connection
   end
 
-  it 'raises an error for unknown HTTP request methods' do
-    assert_raises(ArgumentError) { $client.request :foo, '/', {} }
+  it "raises an error for unknown HTTP request methods" do
+    assert_raises(ArgumentError) { $client.request :foo, "/", {} }
   end
 
-  it 'raises an error on 4XX responses with an `error` field' do
+  it "raises an error on 4XX responses with an `error` field" do
     begin
-      $client.get '/non-existent-index/_search?q=*:*'
-      assert false, 'exception was not raised when it should have been'
+      $client.get "/non-existent-index/_search?q=*:*"
+      assert false, "exception was not raised when it should have been"
     rescue Elastomer::Client::Error => err
       assert_equal 404, err.status
-      assert_equal 'IndexMissingException[[non-existent-index] missing]', err.message
+      assert_equal "IndexMissingException[[non-existent-index] missing]", err.message
     end
   end
 
-  it 'handles path expansions' do
-    uri = $client.expand_path '/{foo}/{bar}', :foo => '_cluster', :bar => 'health'
-    assert_equal '/_cluster/health', uri
+  it "handles path expansions" do
+    uri = $client.expand_path "/{foo}/{bar}", :foo => "_cluster", :bar => "health"
+    assert_equal "/_cluster/health", uri
 
-    uri = $client.expand_path '{/foo}{/baz}{/bar}', :foo => '_cluster', :bar => 'state'
-    assert_equal '/_cluster/state', uri
+    uri = $client.expand_path "{/foo}{/baz}{/bar}", :foo => "_cluster", :bar => "state"
+    assert_equal "/_cluster/state", uri
   end
 
-  it 'handles query parameters' do
-    uri = $client.expand_path '/_cluster/health', :level => 'shards'
-    assert_equal '/_cluster/health?level=shards', uri
+  it "handles query parameters" do
+    uri = $client.expand_path "/_cluster/health", :level => "shards"
+    assert_equal "/_cluster/health?level=shards", uri
   end
 
-  it 'validates path expansions' do
+  it "validates path expansions" do
     assert_raises(ArgumentError) {
-      $client.expand_path '/{foo}/{bar}', :foo => '_cluster', :bar => nil
+      $client.expand_path "/{foo}/{bar}", :foo => "_cluster", :bar => nil
     }
 
     assert_raises(ArgumentError) {
-      $client.expand_path '/{foo}/{bar}', :foo => '_cluster', :bar => ''
+      $client.expand_path "/{foo}/{bar}", :foo => "_cluster", :bar => ""
     }
   end
 
-  describe 'when extracting and converting :body params' do
-    it 'deletes the :body from the params (or it gets the hose)' do
+  describe "when extracting and converting :body params" do
+    it "deletes the :body from the params (or it gets the hose)" do
       params = { :body => nil, :q => "what what?" }
       body = $client.extract_body params
 
@@ -64,27 +64,27 @@ describe Elastomer::Client do
       assert_equal({:q => "what what?"}, params)
     end
 
-    it 'leaves String values unchanged' do
+    it "leaves String values unchanged" do
       body = $client.extract_body :body => '{"query":{"match_all":{}}}'
       assert_equal '{"query":{"match_all":{}}}', body
 
-      body = $client.extract_body :body => 'not a JSON string, but who cares!'
-      assert_equal 'not a JSON string, but who cares!', body
+      body = $client.extract_body :body => "not a JSON string, but who cares!"
+      assert_equal "not a JSON string, but who cares!", body
     end
 
-    it 'joins Array values' do
+    it "joins Array values" do
       body = $client.extract_body :body => %w[foo bar baz]
       assert_equal "foo\nbar\nbaz\n", body
 
       body = $client.extract_body :body => [
-        'the first entry',
-        'the second entry',
+        "the first entry",
+        "the second entry",
         nil
       ]
       assert_equal "the first entry\nthe second entry\n", body
     end
 
-    it 'converts values to JSON' do
+    it "converts values to JSON" do
       body = $client.extract_body :body => true
       assert_equal "true", body
 
@@ -93,61 +93,61 @@ describe Elastomer::Client do
     end
   end
 
-  describe 'when validating parameters' do
-    it 'rejects nil values' do
+  describe "when validating parameters" do
+    it "rejects nil values" do
       assert_raises(ArgumentError) { $client.assert_param_presence nil }
     end
 
-    it 'rejects empty strings' do
+    it "rejects empty strings" do
       assert_raises(ArgumentError) { $client.assert_param_presence "" }
       assert_raises(ArgumentError) { $client.assert_param_presence " " }
       assert_raises(ArgumentError) { $client.assert_param_presence " \t \r \n " }
     end
 
-    it 'rejects empty strings and nil values found in arrays' do
-      assert_raises(ArgumentError) { $client.assert_param_presence ['foo', nil, 'bar'] }
-      assert_raises(ArgumentError) { $client.assert_param_presence ['baz', " \t \r \n "] }
+    it "rejects empty strings and nil values found in arrays" do
+      assert_raises(ArgumentError) { $client.assert_param_presence ["foo", nil, "bar"] }
+      assert_raises(ArgumentError) { $client.assert_param_presence ["baz", " \t \r \n "] }
     end
 
-    it 'strips whitespace from strings' do
-      assert_equal 'foo', $client.assert_param_presence("  foo  \t")
+    it "strips whitespace from strings" do
+      assert_equal "foo", $client.assert_param_presence("  foo  \t")
     end
 
-    it 'joins array values into a string' do
-      assert_equal 'foo,bar', $client.assert_param_presence(%w[foo bar])
+    it "joins array values into a string" do
+      assert_equal "foo,bar", $client.assert_param_presence(%w[foo bar])
     end
 
-    it 'flattens arrays' do
-      assert_equal 'foo,bar,baz,buz', $client.assert_param_presence(["  foo  \t", %w[bar baz buz]])
+    it "flattens arrays" do
+      assert_equal "foo,bar,baz,buz", $client.assert_param_presence(["  foo  \t", %w[bar baz buz]])
     end
 
-    it 'allows strings' do
-      assert_equal 'foo', $client.assert_param_presence("foo")
+    it "allows strings" do
+      assert_equal "foo", $client.assert_param_presence("foo")
     end
 
-    it 'converts numbers and symbols to strings' do
-      assert_equal 'foo', $client.assert_param_presence(:foo)
-      assert_equal '9', $client.assert_param_presence(9)
+    it "converts numbers and symbols to strings" do
+      assert_equal "foo", $client.assert_param_presence(:foo)
+      assert_equal "9", $client.assert_param_presence(9)
     end
   end
 
-  describe 'top level actions' do
-    it 'pings the cluster' do
+  describe "top level actions" do
+    it "pings the cluster" do
       assert_equal true, $client.ping
       assert_equal true, $client.available?
     end
 
-    it 'gets cluster info' do
+    it "gets cluster info" do
       h = $client.info
-      assert h.key?('name'), 'expected cluster name to be returned'
-      assert h.key?('status'), 'expected cluster info status to be returned'
+      assert h.key?("name"), "expected cluster name to be returned"
+      assert h.key?("status"), "expected cluster info status to be returned"
     end
 
-    it 'gets cluster version' do
+    it "gets cluster version" do
       assert_match /[\d\.]+/, $client.version
     end
 
-    it 'gets semantic version' do
+    it "gets semantic version" do
       version_string = $client.version
       assert_equal Semantic::Version.new(version_string), $client.semantic_version
     end

--- a/test/core_ext/time_test.rb
+++ b/test/core_ext/time_test.rb
@@ -1,20 +1,20 @@
-require File.expand_path('../../test_helper', __FILE__)
-require 'elastomer/core_ext/time'
+require File.expand_path("../../test_helper", __FILE__)
+require "elastomer/core_ext/time"
 
-describe 'JSON conversions for Time' do
+describe "JSON conversions for Time" do
   before do
-    @name  = 'elastomer-time-test'
+    @name  = "elastomer-time-test"
     @index = $client.index(@name)
 
     unless @index.exists?
       @index.create \
-        :settings => { 'index.number_of_shards' => 1, 'index.number_of_replicas' => 0 },
+        :settings => { "index.number_of_shards" => 1, "index.number_of_replicas" => 0 },
         :mappings => {
           :doc1 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title      => { :type => 'string', :index => 'not_analyzed' },
-              :created_at => { :type => 'date' }
+              :title      => { :type => "string", :index => "not_analyzed" },
+              :created_at => { :type => "date" }
             }
           }
         }
@@ -29,18 +29,18 @@ describe 'JSON conversions for Time' do
     @index.delete if @index.exists?
   end
 
-  it 'generates ISO8601 formatted time strings' do
+  it "generates ISO8601 formatted time strings" do
     time = Time.utc(2013, 5, 3, 10, 1, 31)
     assert_equal '"2013-05-03T10:01:31Z"', MultiJson.encode(time)
   end
 
-  it 'indexes time fields' do
+  it "indexes time fields" do
     time = Time.utc(2013, 5, 3, 10, 1, 31)
-    h = @docs.index({:title => 'test document', :created_at => time}, :type => 'doc1')
+    h = @docs.index({:title => "test document", :created_at => time}, :type => "doc1")
 
     assert_created(h)
 
-    doc = @docs.get(:type => 'doc1', :id => h['_id'])
-    assert_equal '2013-05-03T10:01:31Z', doc['_source']['created_at']
+    doc = @docs.get(:type => "doc1", :id => h["_id"])
+    assert_equal "2013-05-03T10:01:31Z", doc["_source"]["created_at"]
   end
 end

--- a/test/middleware/encode_json_test.rb
+++ b/test/middleware/encode_json_test.rb
@@ -1,53 +1,53 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Middleware::EncodeJson do
   let(:middleware) { Elastomer::Middleware::EncodeJson.new(lambda {|env| env})}
 
   def process(body, content_type = nil)
     env = { :body => body, :request_headers => Faraday::Utils::Headers.new }
-    env[:request_headers]['content-type'] = content_type if content_type
+    env[:request_headers]["content-type"] = content_type if content_type
     middleware.call(env)
   end
 
-  it 'handles no body' do
+  it "handles no body" do
     result = process(nil)
     assert_nil result[:body]
-    assert_nil result[:request_headers]['content-type']
+    assert_nil result[:request_headers]["content-type"]
   end
 
-  it 'handles empty body' do
-    result = process('')
+  it "handles empty body" do
+    result = process("")
     assert_empty result[:body]
-    assert_nil result[:request_headers]['content-type']
+    assert_nil result[:request_headers]["content-type"]
   end
 
-  it 'handles string body' do
+  it "handles string body" do
     result = process('{"a":1}')
     assert_equal '{"a":1}', result[:body]
-    assert_equal 'application/json', result[:request_headers]['content-type']
+    assert_equal "application/json", result[:request_headers]["content-type"]
   end
 
-  it 'handles object body' do
+  it "handles object body" do
     result = process({:a => 1})
     assert_equal '{"a":1}', result[:body]
-    assert_equal 'application/json', result[:request_headers]['content-type']
+    assert_equal "application/json", result[:request_headers]["content-type"]
   end
 
-  it 'handles empty object body' do
+  it "handles empty object body" do
     result = process({})
-    assert_equal '{}', result[:body]
-    assert_equal 'application/json', result[:request_headers]['content-type']
+    assert_equal "{}", result[:body]
+    assert_equal "application/json", result[:request_headers]["content-type"]
   end
 
-  it 'handles object body with json type' do
-    result = process({:a => 1}, 'application/json; charset=utf-8')
+  it "handles object body with json type" do
+    result = process({:a => 1}, "application/json; charset=utf-8")
     assert_equal '{"a":1}', result[:body]
-    assert_equal 'application/json; charset=utf-8', result[:request_headers]['content-type']
+    assert_equal "application/json; charset=utf-8", result[:request_headers]["content-type"]
   end
 
-  it 'handles object body with incompatible type' do
-    result = process({:a => 1}, 'application/xml; charset=utf-8')
+  it "handles object body with incompatible type" do
+    result = process({:a => 1}, "application/xml; charset=utf-8")
     assert_equal({:a => 1}, result[:body])
-    assert_equal 'application/xml; charset=utf-8', result[:request_headers]['content-type']
+    assert_equal "application/xml; charset=utf-8", result[:request_headers]["content-type"]
   end
 end

--- a/test/middleware/opaque_id_test.rb
+++ b/test/middleware/opaque_id_test.rb
@@ -1,25 +1,25 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Middleware::OpaqueId do
 
   before do
     stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-      stub.get('/_cluster/health') { |env|
+      stub.get("/_cluster/health") { |env|
         [ 200,
 
-          { 'X-Opaque-Id'    => env[:request_headers]['X-Opaque-Id'],
-            'Content-Type'   => 'application/json; charset=UTF-8',
-            'Content-Length' => '49' },
+          { "X-Opaque-Id"    => env[:request_headers]["X-Opaque-Id"],
+            "Content-Type"   => "application/json; charset=UTF-8",
+            "Content-Length" => "49" },
 
           %q[{"cluster_name":"elasticsearch","status":"green"}]
         ]
       }
 
-      stub.get('/') { |env|
-        [ 200, {}, {'version' => {'number' => '1.0.0'}}  ]
+      stub.get("/") { |env|
+        [ 200, {}, {"version" => {"number" => "1.0.0"}}  ]
       }
-      stub.get('/_cluster/state') { |env|
-        [ 200, {'X-Opaque-Id' => "00000000-0000-0000-0000-000000000000"}, %q[{"foo":"bar"}] ]
+      stub.get("/_cluster/state") { |env|
+        [ 200, {"X-Opaque-Id" => "00000000-0000-0000-0000-000000000000"}, %q[{"foo":"bar"}] ]
       }
     end
 
@@ -35,7 +35,7 @@ describe Elastomer::Middleware::OpaqueId do
     assert_equal({"cluster_name" => "elasticsearch", "status" => "green"}, health)
   end
 
-  it 'raises an exception on conflicting headers' do
+  it "raises an exception on conflicting headers" do
     assert_raises(Elastomer::Client::OpaqueIdError) { @client.cluster.state }
   end
 

--- a/test/middleware/parse_json_test.rb
+++ b/test/middleware/parse_json_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../../test_helper', __FILE__)
+require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Middleware::ParseJson do
   let(:middleware) { Elastomer::Middleware::ParseJson.new(lambda {|env| Faraday::Response.new(env)})}
@@ -6,7 +6,7 @@ describe Elastomer::Middleware::ParseJson do
 
   def process(body, content_type = nil)
     env = { :body => body, :response_headers => Faraday::Utils::Headers.new(headers) }
-    env[:response_headers]['content-type'] = content_type if content_type
+    env[:response_headers]["content-type"] = content_type if content_type
     middleware.call(env)
   end
 
@@ -15,34 +15,34 @@ describe Elastomer::Middleware::ParseJson do
     assert_nil response.body
   end
 
-  it 'nullifies empty body' do
+  it "nullifies empty body" do
     response = process("")
     assert_nil response.body
   end
 
-  it 'nullifies blank body' do
+  it "nullifies blank body" do
     response = process(" ")
     assert_nil response.body
   end
 
-  it 'parses json body with empty type' do
+  it "parses json body with empty type" do
     response = process('{"a":1}')
-    assert_equal({'a' => 1}, response.body)
+    assert_equal({"a" => 1}, response.body)
   end
 
-  it 'parses json body of correct type' do
-    response = process('{"a":1}', 'application/json; charset=utf-8')
-    assert_equal({'a' => 1}, response.body)
+  it "parses json body of correct type" do
+    response = process('{"a":1}', "application/json; charset=utf-8")
+    assert_equal({"a" => 1}, response.body)
   end
 
-  it 'ignores json body if incorrect type' do
-    response = process('{"a":1}', 'application/xml; charset=utf-8')
+  it "ignores json body if incorrect type" do
+    response = process('{"a":1}', "application/xml; charset=utf-8")
     assert_equal('{"a":1}', response.body)
   end
 
-  it 'chokes on invalid json' do
-    assert_raises(Faraday::Error::ParsingError) { process '{!'      }
-    assert_raises(Faraday::Error::ParsingError) { process 'invalid' }
+  it "chokes on invalid json" do
+    assert_raises(Faraday::Error::ParsingError) { process "{!"      }
+    assert_raises(Faraday::Error::ParsingError) { process "invalid" }
 
     # surprisingly these are all valid according to MultiJson
     #

--- a/test/notifications_test.rb
+++ b/test/notifications_test.rb
@@ -1,9 +1,9 @@
-require File.expand_path('../test_helper', __FILE__)
-require 'elastomer/notifications'
+require File.expand_path("../test_helper", __FILE__)
+require "elastomer/notifications"
 
 describe Elastomer::Notifications do
   before do
-    @name = 'elastomer-notifications-test'
+    @name = "elastomer-notifications-test"
     @index = $client.index @name
     @index.delete if @index.exists?
     @events = []
@@ -20,51 +20,51 @@ describe Elastomer::Notifications do
   it "instruments timeouts" do
     $client.stub :connection, lambda { raise Faraday::Error::TimeoutError } do
       assert_raises(Elastomer::Client::TimeoutError) { $client.info }
-      event = @events.detect { |e| e.payload[:action] == 'cluster.info' }
+      event = @events.detect { |e| e.payload[:action] == "cluster.info" }
       exception = event.payload[:exception]
-      assert_equal 'Elastomer::Client::TimeoutError', exception[0]
-      assert_match 'timeout', exception[1]
+      assert_equal "Elastomer::Client::TimeoutError", exception[0]
+      assert_match "timeout", exception[1]
     end
   end
 
-  it 'instruments cluster actions' do
-    $client.ping; assert_action_event('cluster.ping')
-    $client.info; assert_action_event('cluster.info')
+  it "instruments cluster actions" do
+    $client.ping; assert_action_event("cluster.ping")
+    $client.info; assert_action_event("cluster.info")
   end
 
-  it 'instruments node actions' do
+  it "instruments node actions" do
     nodes = $client.nodes
-    nodes.info; assert_action_event('nodes.info')
-    nodes.stats; assert_action_event('nodes.stats')
-    nodes.hot_threads; assert_action_event('nodes.hot_threads')
+    nodes.info; assert_action_event("nodes.info")
+    nodes.stats; assert_action_event("nodes.stats")
+    nodes.hot_threads; assert_action_event("nodes.hot_threads")
   end
 
-  it 'instruments node shutdown' do
-    client = stub_client(:post, '/_cluster/nodes/_shutdown')
-    client.nodes.shutdown; assert_action_event('nodes.shutdown')
+  it "instruments node shutdown" do
+    client = stub_client(:post, "/_cluster/nodes/_shutdown")
+    client.nodes.shutdown; assert_action_event("nodes.shutdown")
   end
 
-  it 'instruments index actions' do
-    @index.exists?; assert_action_event('index.exists')
-    @index.create('number_of_replicas' => 0)
-    assert_action_event('index.create')
-    @index.get_settings; assert_action_event('index.get_settings')
-    @index.update_settings('number_of_replicas' => 0)
-    assert_action_event('index.get_settings')
-    @index.close; assert_action_event('index.close')
-    @index.open; assert_action_event('index.open')
-    @index.delete; assert_action_event('index.delete')
+  it "instruments index actions" do
+    @index.exists?; assert_action_event("index.exists")
+    @index.create("number_of_replicas" => 0)
+    assert_action_event("index.create")
+    @index.get_settings; assert_action_event("index.get_settings")
+    @index.update_settings("number_of_replicas" => 0)
+    assert_action_event("index.get_settings")
+    @index.close; assert_action_event("index.close")
+    @index.open; assert_action_event("index.open")
+    @index.delete; assert_action_event("index.delete")
   end
 
-  it 'includes the response body in the payload' do
-    @index.create('number_of_replicas' => 0)
-    event = @events.detect { |e| e.payload[:action] == 'index.create' }
+  it "includes the response body in the payload" do
+    @index.create("number_of_replicas" => 0)
+    event = @events.detect { |e| e.payload[:action] == "index.create" }
     assert event.payload[:response_body]
   end
 
-  it 'includes the request body in the payload' do
-    @index.create('number_of_replicas' => 0)
-    event = @events.detect { |e| e.payload[:action] == 'index.create' }
+  it "includes the request body in the payload" do
+    @index.create("number_of_replicas" => 0)
+    event = @events.detect { |e| e.payload[:action] == "index.create" }
 
     payload = event.payload
     assert payload[:response_body]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,30 +1,30 @@
-require 'webmock/minitest'
+require "webmock/minitest"
 WebMock.allow_net_connect!
 
-require 'securerandom'
-require 'rubygems' unless defined? Gem
-require 'bundler'
+require "securerandom"
+require "rubygems" unless defined? Gem
+require "bundler"
 Bundler.require(:default, :development)
 
-if ENV['COVERAGE'] == 'true'
-  require 'simplecov'
+if ENV["COVERAGE"] == "true"
+  require "simplecov"
   SimpleCov.start do
     add_filter "/test/"
     add_filter "/vendor/"
   end
 end
 
-require 'minitest/spec'
-require 'minitest/autorun'
+require "minitest/spec"
+require "minitest/autorun"
 
 # push the lib folder onto the load path
-$LOAD_PATH.unshift 'lib'
-require 'elastomer/client'
+$LOAD_PATH.unshift "lib"
+require "elastomer/client"
 
 # we are going to use the same client instance everywhere!
 # the client should always be stateless
 $client_params = {
-  :port => ENV['BOXEN_ELASTICSEARCH_PORT'] || 9200,
+  :port => ENV["BOXEN_ELASTICSEARCH_PORT"] || 9200,
   :read_timeout => 2,
   :open_timeout => 1,
   :opaque_id => false
@@ -50,7 +50,7 @@ MiniTest::Unit.after_tests do
 end
 
 # add custom assertions
-require File.expand_path('../assertions', __FILE__)
+require File.expand_path("../assertions", __FILE__)
 
 # require 'elastomer/notifications'
 # require 'pp'
@@ -75,11 +75,11 @@ require File.expand_path('../assertions', __FILE__)
 # Returns the cluster health response.
 # Raises Elastomer::Client::TimeoutError if requested status is not achieved
 # within 5 seconds.
-def wait_for_index(name, status='yellow')
+def wait_for_index(name, status="yellow")
   $client.cluster.health(
     :index           => name,
     :wait_for_status => status,
-    :timeout         => '5s'
+    :timeout         => "5s"
   )
 end
 
@@ -89,7 +89,7 @@ end
 #
 # Returns true if Elasticsearch version is 1.x.
 def es_version_1_x?
-  $client.semantic_version >= '1.0.0'
+  $client.semantic_version >= "1.0.0"
 end
 
 # Elasticsearch 1.4 changed the response body for interacting with index
@@ -98,20 +98,20 @@ end
 #
 # Returns `true` if the response contains an "aliases" key.
 def es_version_always_returns_aliases?
-  $client.semantic_version <  '1.4.0' ||
-  $client.semantic_version >= '1.4.3'
+  $client.semantic_version <  "1.4.0" ||
+  $client.semantic_version >= "1.4.3"
 end
 
 # ElasticSearch 1.3 added the `search_shards` API endpoint.
 def es_version_supports_search_shards?
-  $client.semantic_version >= '1.3.0'
+  $client.semantic_version >= "1.3.0"
 end
 
 # Elasticsearch 1.2 removed support for gateway snapshots.
 #
 # Returns true if Elasticsearch version supports gateway snapshots.
 def es_version_supports_gateway_snapshots?
-  $client.semantic_version <= '1.2.0'
+  $client.semantic_version <= "1.2.0"
 end
 
 # Elasticsearch 1.4.0 had a bug in its handling of the Mapping API where it
@@ -120,13 +120,13 @@ end
 #
 # See: https://github.com/elastic/elasticsearch/pull/8426
 def es_version_supports_update_mapping_with__all_disabled?
-  $client.semantic_version != '1.4.0'
+  $client.semantic_version != "1.4.0"
 end
 
 # Elasticsearch 1.6 requires the repo.path setting when creating
 # FS repositories.
 def es_version_requires_repo_path?
-  $client.semantic_version >= '1.6.0'
+  $client.semantic_version >= "1.6.0"
 end
 
 def run_snapshot_tests?
@@ -146,8 +146,8 @@ def run_snapshot_tests?
 end
 
 def create_repo(name, settings = {})
-  location = File.join(*[ENV['SNAPSHOT_DIR'], name].compact)
-  default_settings = {:type => 'fs', :settings => {:location => location}}
+  location = File.join(*[ENV["SNAPSHOT_DIR"], name].compact)
+  default_settings = {:type => "fs", :settings => {:location => location}}
   $client.repository(name).create(default_settings.merge(settings))
 end
 


### PR DESCRIPTION
This commit sets up style checking with [RuboCop](https://github.com/bbatsov/rubocop) and uses [Overcommit](https://github.com/brigade/overcommit) to manage hooks.

These are automatically set up by running `script/bootstrap`, so a new contributor doesn't need to run any extra commands to get started.

The purpose of `.rubocop_todo.yml` is to ignore for now offenses that will be resolved later (see https://github.com/bbatsov/rubocop#automatically-generated-configuration for the workflow).

Overcommit installs some hooks by default (e.g. max commit subject length) which we might want to disable, but I left them as-is because the ones I ran into are reasonable and simply result in warnings.

@TwP and @grantr: Please pull this branch down locally, run `script/bootstrap`, modify a random Ruby file, and make sure you can still commit. You can also try removing some of the entries in `.rubocop_todo.yml` to see what offenses are reported.

Whether or not RuboCop should be run as a branch check (like a Travis build) is an open question.

See the associated "Style guide cleanup" issue: #110.