### PR TITLE
Streaming bulk operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0 (2015-09-18)
+- Add streaming bulk functionality via `bulk_stream_items`
+- Make Delete by Query compatible with Elasticsearch 2.0
+
 ## 0.6.0 (2015-09-11)
 - Support all URL parameters when using `Client.#scroll`
 - BREAKING: Moved some `Scroller` reader methods into `Scroller.opts`

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -81,7 +81,8 @@ module Elastomer
       item.values.first["status"].between?(200, 299)
     end
 
-    # Stream bulk actions from an Enumerator and passes them to the given block.
+    # Stream bulk actions from an Enumerator and passes the response items to
+    # the given block.
     #
     # Examples
     #
@@ -100,6 +101,18 @@ module Elastomer
     #   #   "errors" => false,
     #   #   "success" => 3,
     #   #   "failure" => 0
+    #   # }
+    #
+    #   # sample response item:
+    #   # {
+    #   #   "delete": {
+    #   #     "_index": "foo",
+    #   #     "_type": "bar",
+    #   #     "_id": "42",
+    #   #     "_version": 3,
+    #   #     "status": 200,
+    #   #     "found": true
+    #   #   }
     #   # }
     #
     # Returns a Hash of stats about items from the responses.

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -381,8 +381,8 @@ module Elastomer
       # size, then a bulk API call will be performed. After the call the
       # actions list is cleared and we'll start accumulating actions again.
       #
-      # action - The bulk action (as a Hash) to perform
-      # document  - Optional document for the action as a Hash or JSON encoded String
+      # action   - The bulk action (as a Hash) to perform
+      # document - Optional document for the action as a Hash or JSON encoded String
       #
       # Returns the response from the bulk call if one was made or nil.
       def add_to_actions( action, document = nil )

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -52,7 +52,7 @@ module Elastomer
     #     Bulk::index(document2, params2),
     #     Bulk::delete(params3),
     #   ]
-    #   bulk(ops, :index => 'default-index').each do |response|
+    #   bulk_stream_responses(ops, :index => 'default-index').each do |response|
     #     puts response
     #   end
     #

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -156,7 +156,7 @@ module Elastomer
       end
 
       # Add an update action to the list of bulk actions to be performed when
-      # the bulk API call is made. Parameters can be provided in the parameters 
+      # the bulk API call is made. Parameters can be provided in the parameters
       # hash (underscore prefix optional) or in the document hash (underscore
       # prefix required).
       #
@@ -178,7 +178,7 @@ module Elastomer
       # the bulk API call is made.
       #
       # params - Parameters for the delete action (as a Hash)
-      #      
+      #
       # Examples
       #   delete(:_id => 1, :_type => 'foo')
       #

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -216,7 +216,7 @@ module Elastomer
       #
       # Returns the response from the bulk call if one was made or nil.
       def index( document, params = {} )
-        params = Bulk::prepare_params(document, params)
+        params = prepare_params(document, params)
         add_to_actions({:index => params}, document)
       end
 
@@ -235,7 +235,7 @@ module Elastomer
       #
       # Returns the response from the bulk call if one was made or nil.
       def create( document, params )
-        params = Bulk::prepare_params(document, params)
+        params = prepare_params(document, params)
         add_to_actions({:create => params}, document)
       end
 
@@ -254,7 +254,7 @@ module Elastomer
       #
       # Returns the response from the bulk call if one was made or nil.
       def update( document, params )
-        params = Bulk::prepare_params(document, params)
+        params = prepare_params(document, params)
         add_to_actions({:update => params}, document)
       end
 
@@ -268,7 +268,7 @@ module Elastomer
       #
       # Returns the response from the bulk call if one was made or nil.
       def delete( params )
-        params = Bulk::prepare_params(nil, params)
+        params = prepare_params(nil, params)
         add_to_actions({:delete => params})
       end
 
@@ -295,7 +295,7 @@ module Elastomer
 
       # Internal: convert special key parameters to their wire representation
       # and apply any override document parameters.
-      def self.prepare_params(document, params)
+      def prepare_params(document, params)
         params = convert_special_keys(params)
         if document.is_a? Hash
           params = from_document(document).merge(params)
@@ -311,7 +311,7 @@ module Elastomer
       # document - The document Hash
       #
       # Returns extracted key/value pairs as a Hash.
-      def self.from_document( document )
+      def from_document( document )
         opts = {}
 
         SPECIAL_KEYS_HASH.values.each do |field|
@@ -333,7 +333,7 @@ module Elastomer
       # params - Hash.
       #
       # Returns a new params Hash with the special keys replaced.
-      def self.convert_special_keys(params)
+      def convert_special_keys(params)
         new_params = params.dup
 
         SPECIAL_KEYS_HASH.each do |k1, k2|

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -43,6 +43,48 @@ module Elastomer
       end
     end
 
+    # Stream bulk actions from an Enumerator.
+    #
+    # Examples
+    #
+    #   ops = [
+    #     Bulk::index(document1, :_type => 'default-type', :_id => 1),
+    #     Bulk::index(document2, params2),
+    #     Bulk::delete(params3),
+    #   ]
+    #   bulk(ops, :index => 'default-index').each do |response|
+    #     puts response
+    #   end
+    #
+    # Returns an Enumerator of responses.
+    def bulk_stream_responses(ops, params = {})
+      bulk_obj = Bulk.new(self, params)
+
+      Enumerator.new do |yielder|
+        ops.each do |op|
+          response = bulk_obj.add_to_actions *op
+          yielder.yield response unless response.nil?
+        end
+
+        response = bulk_obj.call
+        yielder.yield response unless response.nil?
+      end
+    end
+
+    # Stream bulk actions from an Enumerator.
+    #
+    # See Client#bulk_stream_responses for more information.
+    #
+    # Returns an Enumerator of items from the responses.
+    def bulk_stream_items(ops, params = {})
+      Enumerator.new do |yielder|
+        bulk_stream_responses(ops, params).each do |response|
+          response["items"].each do |item|
+            yielder.yield item
+          end
+        end
+      end
+    end
 
     # The Bulk class provides some abstractions and helper methods for working
     # with the ElasticSearch bulk API command. Instances of the Bulk class
@@ -132,7 +174,7 @@ module Elastomer
       #
       # Returns the response from the bulk call if one was made or nil.
       def index( document, params = {} )
-        params = prepare_params(document, params)
+        params = Bulk::prepare_params(document, params)
         add_to_actions({:index => params}, document)
       end
 
@@ -151,7 +193,7 @@ module Elastomer
       #
       # Returns the response from the bulk call if one was made or nil.
       def create( document, params )
-        params = prepare_params(document, params)
+        params = Bulk::prepare_params(document, params)
         add_to_actions({:create => params}, document)
       end
 
@@ -170,7 +212,7 @@ module Elastomer
       #
       # Returns the response from the bulk call if one was made or nil.
       def update( document, params )
-        params = prepare_params(document, params)
+        params = Bulk::prepare_params(document, params)
         add_to_actions({:update => params}, document)
       end
 
@@ -184,8 +226,79 @@ module Elastomer
       #
       # Returns the response from the bulk call if one was made or nil.
       def delete( params )
-        params = prepare_params(nil, params)
+        params = Bulk::prepare_params(nil, params)
         add_to_actions({:delete => params})
+      end
+
+      # Construct a bulk action which indexes a document. Parameters can be
+      # provided in the parameters hash (underscore prefix optional) or in the
+      # document hash (underscore prefix required).
+      #
+      # document - The document to index as a Hash or JSON encoded String
+      # params   - Parameters for the index action (as a Hash) (optional)
+      #
+      # Examples
+      #   index({"foo" => "bar"}, {:_id => 1, :_type => "foo", :_index => "foo"})
+      #   index({"foo" => "bar"}, {:id => 1, :type => "foo", :_index => "foo"})
+      #   index("foo" => "bar", "_id" => 1, "_type" => "foo", "_index" => "foo")
+      #   # => [{:index => {"_id" => 1, "_type" => "foo", "_index" => "foo"}}, {"foo" => "bar"}]
+      #
+      # Returns an Array representing the rows of the action in a bulk call
+      def self.op_index( document, params = {} )
+        [{:index => prepare_params(document, params)}, document]
+      end
+
+      # Construct a bulk action which creates a document. Parameters can be
+      # provided in the parameters hash (underscore prefix optional) or in the
+      # document hash (underscore prefix required).
+      #
+      # document - The document to create as a Hash or JSON encoded String
+      # params   - Parameters for the create action (as a Hash) (optional)
+      #
+      # Examples
+      #   create({"foo" => "bar"}, {:_id => 1, :_type => "foo", :_index => "foo"})
+      #   create({"foo" => "bar"}, {:id => 1, :type => "foo", :_index => "foo"})
+      #   create("foo" => "bar", "_id" => 1, "_type" => "foo", "_index" => "foo")
+      #   # => [{:create => {"_id" => 1, "_type" => "foo", "_index" => "foo"}}, {"foo" => "bar"}]
+      #
+      # Returns an Array representing the rows of the action in a bulk call
+      def self.op_create( document, params )
+        [{:create => prepare_params(document, params)}, document]
+      end
+
+      # Construct a bulk action which updates a document. Parameters can be
+      # provided in the parameters hash (underscore prefix optional) or in the
+      # document hash (underscore prefix required).
+      #
+      # document - The document to update as a Hash or JSON encoded String
+      # params   - Parameters for the update action (as a Hash) (optional)
+      #
+      # Examples
+      #   update({"foo" => "bar"}, {:_id => 1, :_type => "foo", :_index => "foo"})
+      #   update({"foo" => "bar"}, {:id => 1, :type => "foo", :_index => "foo"})
+      #   update("foo" => "bar", "_id" => 1, "_type" => "foo", "_index" => "foo")
+      #   # => [{:update => {"_id" => 1, "_type" => "foo", "_index" => "foo"}}, {"foo" => "bar"}]
+      #
+      # Returns an Array representing the rows of the action in a bulk call
+      def self.op_update( document, params )
+        [{:update => prepare_params(document, params)}, document]
+      end
+
+      # Construct a bulk action which deletes a document. Parameters can be
+      # provided in the parameters hash (underscore prefix optional) or in the
+      # document hash (underscore prefix required).
+      #
+      # params - Parameters for the delete action (as a Hash)
+      #
+      # Examples
+      #   delete({"foo" => "bar"}, {:_id => 1, :_type => "foo", :_index => "foo"})
+      #   delete({"foo" => "bar"}, {:id => 1, :type => "foo", :_index => "foo"})
+      #   delete("foo" => "bar", "_id" => 1, "_type" => "foo", "_index" => "foo")
+      #   # => [{:delete => {"_id" => 1, "_type" => "foo", "_index" => "foo"}}, {"foo" => "bar"}]
+      #
+      # Returns an Array representing the rows of the action in a bulk call
+      def self.op_delete( params )
+        [{:delete => prepare_params(nil, params)}]
       end
 
       # Immediately execute a bulk API call with the currently accumulated
@@ -211,7 +324,7 @@ module Elastomer
 
       # Internal: convert special key parameters to their wire representation
       # and apply any override document parameters.
-      def prepare_params(document, params)
+      def self.prepare_params(document, params)
         params = convert_special_keys(params)
         if document.is_a? Hash
           params = from_document(document).merge(params)
@@ -227,7 +340,7 @@ module Elastomer
       # document - The document Hash
       #
       # Returns extracted key/value pairs as a Hash.
-      def from_document( document )
+      def self.from_document( document )
         opts = {}
 
         SPECIAL_KEYS_HASH.values.each do |field|
@@ -249,7 +362,7 @@ module Elastomer
       # params - Hash.
       #
       # Returns a new params Hash with the special keys replaced.
-      def convert_special_keys(params)
+      def self.convert_special_keys(params)
         new_params = params.dup
 
         SPECIAL_KEYS_HASH.each do |k1, k2|
@@ -268,8 +381,8 @@ module Elastomer
       # size, then a bulk API call will be performed. After the call the
       # actions list is cleared and we'll start accumulating actions again.
       #
-      # action   - The bulk action (as a Hash) to perform
-      # document - Optional document for the action as a Hash or JSON encoded String
+      # action - The bulk action (as a Hash) to perform
+      # document  - Optional document for the action as a Hash or JSON encoded String
       #
       # Returns the response from the bulk call if one was made or nil.
       def add_to_actions( action, document = nil )

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -106,7 +106,7 @@ module Elastomer
       def execute
         ops = Enumerator.new do |yielder|
           @client.scan(@query, @params).each_document do |hit|
-            yielder.yield(Elastomer::Client::Bulk::op_delete(_id: hit["_id"], _type: hit["_type"], _index: hit["_index"]))
+            yielder.yield([:delete, { _id: hit["_id"], _type: hit["_type"], _index: hit["_index"] }])
           end
         end
 

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -110,7 +110,7 @@ module Elastomer
       def execute
         ops = Enumerator.new do |yielder|
           @client.scan(@query, @params).each_document do |hit|
-            yielder.yield(Elastomer::Client::Bulk::op_delete(hit))
+            yielder.yield(Elastomer::Client::Bulk::op_delete(_id: hit["_id"], _type: hit["_type"], _index: hit["_index"]))
           end
         end
 

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -110,7 +110,7 @@ module Elastomer
       def execute
         ops = Enumerator.new do |yielder|
           @client.scan(@query, @params).each_document do |hit|
-            yielder.yield(Elastomer::Client::Bulk::op_delete(_id: hit["_id"], _type: hit["_type"], _index: hit["_index"]))
+            yielder.yield(Elastomer::Client::Bulk::op_delete(hit))
           end
         end
 

--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,5 +1,5 @@
 module Elastomer
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 
   def self.version
     VERSION

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -296,9 +296,9 @@ describe Elastomer::Client::Bulk do
 
   it 'streams bulk responses' do
     ops = [
-      Elastomer::Client::Bulk::op_index({ :message => 'tweet 1' }, { :_id => 1, :_type => 'book', :_index => @index.name }),
-      Elastomer::Client::Bulk::op_index({ :message => 'tweet 2' }, { :_id => 2, :_type => 'book', :_index => @index.name }),
-      Elastomer::Client::Bulk::op_index({ :message => 'tweet 3' }, { :_id => 3, :_type => 'book', :_index => @index.name })
+      [:index, { :message => 'tweet 1' }, { :_id => 1, :_type => 'book', :_index => @index.name }],
+      [:index, { :message => 'tweet 2' }, { :_id => 2, :_type => 'book', :_index => @index.name }],
+      [:index, { :message => 'tweet 3' }, { :_id => 3, :_type => 'book', :_index => @index.name }]
     ]
     responses = $client.bulk_stream_responses(ops, { :action_count => 2 }).to_a
     assert_equal(2, responses.length)
@@ -309,9 +309,9 @@ describe Elastomer::Client::Bulk do
 
   it 'streams bulk items' do
     ops = [
-      Elastomer::Client::Bulk::op_index({ :message => 'tweet 1' }, { :_id => 1, :_type => 'book', :_index => @index.name }),
-      Elastomer::Client::Bulk::op_index({ :message => 'tweet 2' }, { :_id => 2, :_type => 'book', :_index => @index.name }),
-      Elastomer::Client::Bulk::op_index({ :message => 'tweet 3' }, { :_id => 3, :_type => 'book', :_index => @index.name })
+      [:index, { :message => 'tweet 1' }, { :_id => 1, :_type => 'book', :_index => @index.name }],
+      [:index, { :message => 'tweet 2' }, { :_id => 2, :_type => 'book', :_index => @index.name }],
+      [:index, { :message => 'tweet 3' }, { :_id => 3, :_type => 'book', :_index => @index.name }]
     ]
     items = []
     stats = $client.bulk_stream_items(ops, { :action_count => 2 }) { |item| items << item }

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -293,4 +293,30 @@ describe Elastomer::Client::Bulk do
     assert_equal 'tweet', items[0]['index']['_type']
     assert_equal 1, items[0]['index']['_version']
   end
+
+  it 'streams bulk responses' do
+    ops = [
+      Elastomer::Client::Bulk::op_index({ :message => 'tweet 1' }, { :_id => 1, :_type => 'book', :_index => @index.name }),
+      Elastomer::Client::Bulk::op_index({ :message => 'tweet 2' }, { :_id => 2, :_type => 'book', :_index => @index.name }),
+      Elastomer::Client::Bulk::op_index({ :message => 'tweet 3' }, { :_id => 3, :_type => 'book', :_index => @index.name })
+    ]
+    responses = $client.bulk_stream_responses(ops, { :action_count => 2 }).to_a
+    assert_equal(2, responses.length)
+    assert_bulk_index(responses[0]["items"][0])
+    assert_bulk_index(responses[0]["items"][1])
+    assert_bulk_index(responses[1]["items"][0])
+  end
+
+  it 'streams bulk items' do
+    ops = [
+      Elastomer::Client::Bulk::op_index({ :message => 'tweet 1' }, { :_id => 1, :_type => 'book', :_index => @index.name }),
+      Elastomer::Client::Bulk::op_index({ :message => 'tweet 2' }, { :_id => 2, :_type => 'book', :_index => @index.name }),
+      Elastomer::Client::Bulk::op_index({ :message => 'tweet 3' }, { :_id => 3, :_type => 'book', :_index => @index.name })
+    ]
+    items = $client.bulk_stream_items(ops, { :action_count => 2 }).to_a
+    assert_equal(3, items.length)
+    assert_bulk_index(items[0])
+    assert_bulk_index(items[1])
+    assert_bulk_index(items[2])
+  end
 end

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -313,7 +313,8 @@ describe Elastomer::Client::Bulk do
       Elastomer::Client::Bulk::op_index({ :message => 'tweet 2' }, { :_id => 2, :_type => 'book', :_index => @index.name }),
       Elastomer::Client::Bulk::op_index({ :message => 'tweet 3' }, { :_id => 3, :_type => 'book', :_index => @index.name })
     ]
-    items = $client.bulk_stream_items(ops, { :action_count => 2 }).to_a
+    items = []
+    stats = $client.bulk_stream_items(ops, { :action_count => 2 }) { |item| items << item }
     assert_equal(3, items.length)
     assert_bulk_index(items[0])
     assert_bulk_index(items[1])


### PR DESCRIPTION
This adds streaming bulk functionality via Ruby's Enumerators.

This does not to alter any of the existing methods in backwards incompatible ways so that a conversation about making the API more consistent could take place later. Because of that, some of the small operation methods had to be nearly duplicated.

This solves #92.

/cc @TwP @grantr