### PR TITLE
Implement the percolate API

### DIFF
--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -267,7 +267,7 @@ module Elastomer
       #
       # Examples
       #
-      #   index.register_percolator_query 1, :query => { :match => { :author => "pea53" } }
+      #   index.percolator(1).create :query => { :match => { :author => "pea53" } }
       #   docs.percolate :doc => { :author => "pea53" }
       #   docs.percolate nil, :id => 3
       #

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -261,17 +261,19 @@ module Elastomer
         @client.delete_by_query(query, update_params(params))
       end
 
-      # Matches a document to the queries stored in the percolator for the given
-      # index.
+      # Matches a provided or existing document to the stored percolator
+      # queries. To match an existing document, pass `nil` as the body and
+      # include `:id` in the params.
       #
       # Examples
       #
       #   index.register_percolator_query 1, :query => { :match => { :author => "pea53" } }
       #   docs.percolate :doc => { :author => "pea53" }
+      #   docs.percolate nil, :id => 3
       #
       # Returns the response body as a Hash
-      def percolate(body, params = {})
-        response = client.get '/{index}/{type}/_percolate', update_params(params, :body => body, :action => 'percolator.percolate')
+      def percolate(body = nil, params = {})
+        response = client.get '/{index}/{type}{/id}/_percolate', update_params(params, :body => body, :action => 'percolator.percolate')
         response.body
       end
 

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -519,6 +519,31 @@ Percolate
         client.multi_search params, &block
       end
 
+      # Execute an array of percolate actions in bulk. Results are returned in
+      # an array in the order the actions were sent. The current index name and
+      # type will be passed to the API call as part of the request parameters.
+      #
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-percolate.html#_multi_percolate_api
+      #
+      # params - Optional request parameters as a Hash
+      # block  - Passed to a MultiPercolate instance which assembles the
+      #          percolate actions into a single request.
+      #
+      # Examples
+      #
+      #   # block form
+      #   multi_percolate() do |m|
+      #     m.percolate({}, { :author => "pea53" })
+      #     m.count({}, { :author => "grantr" })
+      #     ...
+      #   end
+      #
+      # Returns the response body as a Hash
+      def multi_percolate(params = {}, &block)
+        params = { :index => self.name, :type => self.type }.merge params
+        client.multi_percolate(params, &block)
+      end
+
       SPECIAL_KEYS = %w[index type id version version_type op_type routing parent timestamp ttl consistency replication refresh].freeze
       SPECIAL_KEYS_HASH = SPECIAL_KEYS.inject({}) { |h, k| h[k.to_sym] = "_#{k}"; h }.freeze
 

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -272,7 +272,7 @@ module Elastomer
       #   docs.percolate nil, :id => 3
       #
       # Returns the response body as a Hash
-      def percolate(body = nil, params = {})
+      def percolate(body, params = {})
         response = client.get '/{index}/{type}{/id}/_percolate', update_params(params, :body => body, :action => 'percolator.percolate')
         response.body
       end
@@ -288,7 +288,7 @@ module Elastomer
       #   docs.percolate_count nil, :id => 3
       #
       # Returns the count
-      def percolate_count(body = nil, params = {})
+      def percolate_count(body, params = {})
         response = client.get '/{index}/{type}{/id}/_percolate/count', update_params(params, :body => body, :action => 'percolator.percolate_count')
         response.body["total"]
       end

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -532,7 +532,7 @@ Percolate
       # Examples
       #
       #   # block form
-      #   multi_percolate() do |m|
+      #   multi_percolate do |m|
       #     m.percolate(:author => "pea53")
       #     m.count(:author => "grantr")
       #     ...

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -261,6 +261,21 @@ module Elastomer
         @client.delete_by_query(query, update_params(params))
       end
 
+      # Matches a document to the queries stored in the percolator for the given
+      # index. Type is required.
+      #
+      # Examples
+      #
+      #   index.register_percolator_query 1, { :query => { :match => { :author => "pea53" } } }
+      #   index.docs(type).percolate({ :doc => { :author => "pea53" } })
+      #
+      # Returns the response body as a Hash
+      def percolate(body, params = {})
+        raise 'percolate requires document type' if type.nil?
+        response = client.get '/{index}/{type}/_percolate', update_params(params, :body => body, :action => 'percolator.percolate')
+        response.body
+      end
+
       # Returns information and statistics on terms in the fields of a
       # particular document as stored in the index. The :id is provided as part
       # of the params hash.

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -533,8 +533,8 @@ Percolate
       #
       #   # block form
       #   multi_percolate() do |m|
-      #     m.percolate({}, { :author => "pea53" })
-      #     m.count({}, { :author => "grantr" })
+      #     m.percolate(:author => "pea53")
+      #     m.count(:author => "grantr")
       #     ...
       #   end
       #

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -540,7 +540,7 @@ Percolate
       #
       # Returns the response body as a Hash
       def multi_percolate(params = {}, &block)
-        params = { :index => self.name, :type => self.type }.merge params
+        params = defaults.merge params
         client.multi_percolate(params, &block)
       end
 

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -262,12 +262,12 @@ module Elastomer
       end
 
       # Matches a document to the queries stored in the percolator for the given
-      # index. Type is required.
+      # index.
       #
       # Examples
       #
-      #   index.register_percolator_query 1, { :query => { :match => { :author => "pea53" } } }
-      #   index.docs(type).percolate({ :doc => { :author => "pea53" } })
+      #   index.register_percolator_query 1, :query => { :match => { :author => "pea53" } }
+      #   docs.percolate :doc => { :author => "pea53" }
       #
       # Returns the response body as a Hash
       def percolate(body, params = {})

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -271,7 +271,6 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def percolate(body, params = {})
-        raise 'percolate requires document type' if type.nil?
         response = client.get '/{index}/{type}/_percolate', update_params(params, :body => body, :action => 'percolator.percolate')
         response.body
       end

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -277,6 +277,22 @@ module Elastomer
         response.body
       end
 
+      # Counts the queries that match a provided or existing document. To count
+      # matches for an existing document, pass `nil` as the body and include
+      # `:id` in the params.
+      #
+      # Examples
+      #
+      #   index.register_percolator_query 1, :query => { :match => { :author => "pea53" } }
+      #   docs.percolate_count :doc => { :author => "pea53" }
+      #   docs.percolate_count nil, :id => 3
+      #
+      # Returns the count
+      def percolate_count(body = nil, params = {})
+        response = client.get '/{index}/{type}{/id}/_percolate/count', update_params(params, :body => body, :action => 'percolator.percolate_count')
+        response.body["total"]
+      end
+
       # Returns information and statistics on terms in the fields of a
       # particular document as stored in the index. The :id is provided as part
       # of the params hash.

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -541,7 +541,7 @@ module Elastomer
       #
       # Returns a Percolator
       def percolator(id)
-        Percolator.new(@client, @name, id)
+        Percolator.new(client, name, id)
       end
 
       # Internal: Add default parameters to the `params` Hash and then apply

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -514,7 +514,7 @@ module Elastomer
       # Examples
       #
       #   # block form
-      #   multi_percolate() do |m|
+      #   multi_percolate do |m|
       #     m.percolate({ :author => "pea53" }, { :type => 'default-type' })
       #     m.count({ :author => "pea53" }, { :type => 'type2' })
       #     ...

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -522,7 +522,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def multi_percolate(params = {}, &block)
-        params = { :index => self.name }.merge params
+        params = defaults.merge params
         client.multi_percolate(params, &block)
       end
 

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -515,8 +515,8 @@ module Elastomer
       #
       #   # block form
       #   multi_percolate() do |m|
-      #     m.percolate({ :type => 'default-type' }, { :author => "pea53" })
-      #     m.count({ :type => 'type2' }, { :author => "pea53" })
+      #     m.percolate({ :author => "pea53" }, { :type => 'default-type' })
+      #     m.count({ :author => "pea53" }, { :type => 'type2' })
       #     ...
       #   end
       #

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -533,16 +533,15 @@ module Elastomer
         docs.delete_by_query(query, params)
       end
 
-      # Registers a query in the percolator for this index.
+      # Constructs a Percolator with the given id on this index.
       #
       # Examples
       #
-      #   index.register_percolator_query 1, { :query => { :match => { :author => "pea53" } } }
+      #   index.percolator "1"
       #
-      # Returns the response body as a Hash
-      def register_percolator_query(id, body, params = {})
-        response = client.put "/{index}/.percolator/#{id}", update_params(params, :body => body, :action => 'percolator.register')
-        response.body
+      # Returns a Percolator
+      def percolator(id)
+        Percolator.new(@client, @name, id)
       end
 
       # Internal: Add default parameters to the `params` Hash and then apply

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -533,6 +533,18 @@ module Elastomer
         docs.delete_by_query(query, params)
       end
 
+      # Registers a query in the percolator for this index.
+      #
+      # Examples
+      #
+      #   index.register_percolator_query 1, { :query => { :match => { :author => "pea53" } } }
+      #
+      # Returns the response body as a Hash
+      def register_percolator_query(id, body, params = {})
+        response = client.put "/{index}/.percolator/#{id}", update_params(params, :body => body, :action => 'percolator.register')
+        response.body
+      end
+
       # Internal: Add default parameters to the `params` Hash and then apply
       # `overrides` to the params if any are given.
       #

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -501,6 +501,31 @@ module Elastomer
         client.multi_search params, &block
       end
 
+      # Execute an array of percolate actions in bulk. Results are returned in
+      # an array in the order the actions were sent. The current index name will
+      # be passed to the API call as part of the request parameters.
+      #
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-percolate.html#_multi_percolate_api
+      #
+      # params - Optional request parameters as a Hash
+      # block  - Passed to a MultiPercolate instance which assembles the
+      #          percolate actions into a single request.
+      #
+      # Examples
+      #
+      #   # block form
+      #   multi_percolate() do |m|
+      #     m.percolate({ :type => 'default-type' }, { :author => "pea53" })
+      #     m.count({ :type => 'type2' }, { :author => "pea53" })
+      #     ...
+      #   end
+      #
+      # Returns the response body as a Hash
+      def multi_percolate(params = {}, &block)
+        params = { :index => self.name }.merge params
+        client.multi_percolate(params, &block)
+      end
+
       # Provides access to warmer API commands. Index warmers run search
       # requests to warm up the index before it is available for
       # searching. Warmers are useful for searches that require heavy

--- a/lib/elastomer/client/multi_percolate.rb
+++ b/lib/elastomer/client/multi_percolate.rb
@@ -40,7 +40,7 @@ module Elastomer
         raise 'multi_percolate request body cannot be nil' if body.nil?
         params ||= {}
 
-        response = self.post '/_mpercolate', params.merge(:body => body)
+        response = self.post '{/index}{/type}/_mpercolate', params.merge(:body => body)
         response.body
       end
     end

--- a/lib/elastomer/client/multi_percolate.rb
+++ b/lib/elastomer/client/multi_percolate.rb
@@ -1,0 +1,127 @@
+module Elastomer
+  class Client
+
+    # Execute an array of percolate actions in bulk. Results are returned in an
+    # array in the order the actions were sent.
+    #
+    # The `multi_percolate` method can be used in two ways. Without a block
+    # the method will perform an API call, and it requires a bulk request
+    # body and optional request parameters.
+    #
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-percolate.html#_multi_percolate_api
+    #
+    # body   - Request body as a String (required if a block is not given)
+    # params - Optional request parameters as a Hash
+    # block  - Passed to a MultiPercolate instance which assembles the
+    #          percolate actions into a single request.
+    #
+    # Examples
+    #
+    #   # index and type in request body
+    #   multi_percolate(request_body)
+    #
+    #   # index in URI
+    #   multi_percolate(request_body, :index => 'default-index')
+    #
+    #   # block form
+    #   multi_percolate(:index => 'default-index') do |m|
+    #     m.percolate({ :type => 'default-type' }, { :author => "pea53" })
+    #     m.count({ :type => 'type2' }, { :author => "pea53" })
+    #     ...
+    #   end
+    #
+    # Returns the response body as a Hash
+    def multi_percolate(body = nil, params = nil)
+      if block_given?
+        params, body = (body || {}), nil
+        yield mpercolate_obj = MultiPercolate.new(self, params)
+        mpercolate_obj.call
+      else
+        raise 'multi_percolate request body cannot be nil' if body.nil?
+        params ||= {}
+
+        response = self.post '/_mpercolate', params.merge(:body => body)
+        response.body
+      end
+    end
+    alias_method :mpercolate, :multi_percolate
+
+    # The MultiPercolate class is a helper for accumulating and submitting
+    # multi_percolate API requests. Instances of the MultiPercolate class
+    # accumulate percolate actions and then issue a single API request to
+    # Elasticsearch, which runs all accumulated percolate actions in parallel
+    # and returns each result hash aggregated into an array of result
+    # hashes.
+    #
+    # Instead of instantiating this class directly, use
+    # the block form of Client#multi_percolate.
+    #
+    class MultiPercolate
+
+      # Create a new MultiPercolate instance for accumulating percolate actions
+      # and submitting them all as a single request.
+      #
+      # client - Elastomer::Client used for HTTP requests to the server
+      # params - Parameters Hash to pass to the Client#multi_percolate method
+      def initialize(client, params = {})
+        @client  = client
+        @params  = params
+
+        @actions = []
+      end
+
+      attr_reader :client
+
+      # Add a percolate action to the multi percolate request. This percolate
+      # action will not be executed until the multi_percolate API call is made.
+      #
+      # header - A Hash of the index and type, if not provided in the params
+      # doc    - A Hash of the document
+      #
+      # Returns this MultiPercolate instance.
+      def percolate(header, doc)
+        add_to_actions(:percolate => header)
+        add_to_actions(:doc => doc)
+      end
+
+      # Add a percolate acount action to the multi percolate request. This
+      # percolate count action will not be executed until the multi_percolate
+      # API call is made.
+      #
+      # header - A Hash of the index and type, if not provided in the params
+      # doc    - A Hash of the document
+      #
+      # Returns this MultiPercolate instance.
+      def count(header, doc)
+        add_to_actions(:count => header)
+        add_to_actions(:doc => doc)
+      end
+
+      # Execute the multi_percolate call with the accumulated percolate actions.
+      # If the accumulated actions list is empty then no action is taken.
+      #
+      # Returns the response body Hash.
+      def call
+        return if @actions.empty?
+
+        body = @actions.join("\n") + "\n"
+        client.multi_percolate(body, @params)
+      ensure
+        @actions.clear
+      end
+
+      # Internal: Add an action to the pending request. Actions can be
+      # either headers or bodies. The first action must be a percolate header,
+      # followed by a body, then alternating headers and bodies.
+      #
+      # action - the Hash (header or body) to add to the pending request
+      #
+      # Returns this MultiPercolate instance.
+      def add_to_actions(action)
+        action = MultiJson.dump action
+        @actions << action
+        self
+      end
+    end
+  end
+end

--- a/lib/elastomer/client/multi_percolate.rb
+++ b/lib/elastomer/client/multi_percolate.rb
@@ -92,7 +92,7 @@ module Elastomer
       # doc    - A Hash of the document
       #
       # Returns this MultiPercolate instance.
-      def count(header, doc)
+      def count(doc, header = {})
         add_to_actions(:count => header)
         add_to_actions(:doc => doc)
       end

--- a/lib/elastomer/client/multi_percolate.rb
+++ b/lib/elastomer/client/multi_percolate.rb
@@ -25,8 +25,8 @@ module Elastomer
     #
     #   # block form
     #   multi_percolate(:index => 'default-index') do |m|
-    #     m.percolate({ :type => 'default-type' }, { :author => "pea53" })
-    #     m.count({ :type => 'type2' }, { :author => "pea53" })
+    #     m.percolate({ :author => "pea53" }, { :type => 'default-type' })
+    #     m.count({ :author => "pea53" }, { :type => 'type2' })
     #     ...
     #   end
     #
@@ -79,7 +79,7 @@ module Elastomer
       # doc    - A Hash of the document
       #
       # Returns this MultiPercolate instance.
-      def percolate(header, doc)
+      def percolate(doc, header = {})
         add_to_actions(:percolate => header)
         add_to_actions(:doc => doc)
       end

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -25,7 +25,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create(body, params = {})
-        response = client.put("/#{@index}/.percolator/#{@id}", params.merge(:body => body, :action => 'percolator.create'))
+        response = client.put("/{index}/.percolator/{id}", defaults.merge(params.merge(:body => body, :action => 'percolator.create')))
         response.body
       end
 
@@ -38,7 +38,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get(params = {})
-        response = client.get("/#{@index}/.percolator/#{@id}", params.merge(:action => 'percolator.get'))
+        response = client.get("/{index}/.percolator/{id}", defaults.merge(params.merge(:action => 'percolator.get')))
         response.body
       end
 
@@ -51,7 +51,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete(params = {})
-        response = client.delete("/#{@index}/.percolator/#{@id}", params.merge(:action => 'percolator.delete'))
+        response = client.delete("/{index}/.percolator/{id}", defaults.merge(params.merge(:action => 'percolator.delete')))
         response.body
       end
 
@@ -65,6 +65,11 @@ module Elastomer
       # Returns a boolean
       def exists?(params = {})
         get(params)["found"]
+      end
+
+      # Internal: Returns a Hash containing default parameters.
+      def defaults
+        {:index => index_name, :id => id}
       end
 
     end  # Percolator

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -1,0 +1,72 @@
+module Elastomer
+  class Client
+
+    class Percolator
+
+      # Create a new Percolator for managing a query.
+      #
+      # client - Elastomer::Client used for HTTP requests to the server
+      # index  - The index name
+      # id     - The _id for the query
+      def initialize(client, index, id)
+        @client = client
+        @index = index
+        @id = id
+      end
+
+      attr_reader :client, :index, :id
+
+      # Create a percolator query.
+      #
+      # Examples
+      #
+      #   percolator = $client.index("default-index").percolator "1"
+      #   percolator.create :query => { :match_all => { } }
+      #
+      # Returns the response body as a Hash
+      def create(body, params = {})
+        response = client.put("/#{@index}/.percolator/#{@id}", params.merge(:body => body, :action => 'percolator.create'))
+        response.body
+      end
+
+      # Gets a percolator query.
+      #
+      # Examples
+      #
+      #   percolator = $client.index("default-index").percolator "1"
+      #   percolator.get
+      #
+      # Returns the response body as a Hash
+      def get(params = {})
+        response = client.get("/#{@index}/.percolator/#{@id}", params.merge(:action => 'percolator.get'))
+        response.body
+      end
+
+      # Delete a percolator query.
+      #
+      # Examples
+      #
+      #   percolator = $client.index("default-index").percolator "1"
+      #   percolator.delete
+      #
+      # Returns the response body as a Hash
+      def delete(params = {})
+        response = client.delete("/#{@index}/.percolator/#{@id}", params.merge(:action => 'percolator.delete'))
+        response.body
+      end
+
+      # Checks for the existence of a percolator query.
+      #
+      # Examples
+      #
+      #   percolator = $client.index("default-index").percolator "1"
+      #   percolator.exists?
+      #
+      # Returns a boolean
+      def exists?(params = {})
+        get(params)["found"]
+      end
+
+    end  # Percolator
+  end  # Client
+end  # Elastomer

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -11,7 +11,7 @@ module Elastomer
       def initialize(client, index_name, id)
         @client = client
         @index_name = client.assert_param_presence(index_name, 'index name')
-        @id = id
+        @id = client.assert_param_presence(id, 'id')
       end
 
       attr_reader :client, :index_name, :id

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -5,16 +5,16 @@ module Elastomer
 
       # Create a new Percolator for managing a query.
       #
-      # client - Elastomer::Client used for HTTP requests to the server
-      # index  - The index name
-      # id     - The _id for the query
-      def initialize(client, index, id)
+      # client     - Elastomer::Client used for HTTP requests to the server
+      # index_name - The index name
+      # id         - The _id for the query
+      def initialize(client, index_name, id)
         @client = client
-        @index = index
+        @index_name = index_name
         @id = id
       end
 
-      attr_reader :client, :index, :id
+      attr_reader :client, :index_name, :id
 
       # Create a percolator query.
       #

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -10,7 +10,7 @@ module Elastomer
       # id         - The _id for the query
       def initialize(client, index_name, id)
         @client = client
-        @index_name = index_name
+        @index_name = client.assert_param_presence(index_name, 'index name')
         @id = id
       end
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -519,7 +519,7 @@ describe Elastomer::Client::Docs do
       assert_equal(%w[1 2], docs.map { |h| h['_id'] }.sort)
     end
 
-    it 'percolates' do
+    it 'percolates a given document' do
       populate!
 
       percolator1 = @index.percolator "1"
@@ -529,7 +529,22 @@ describe Elastomer::Client::Docs do
       response = percolator2.create :query => { :match => { :author => "defunkt" } }
       assert response["created"], "Couldn't create the percolator query"
 
-      response = @index.docs("docs1").percolate(:doc => { :author => "pea53" })
+      response = @index.docs("doc1").percolate(:doc => { :author => "pea53" })
+      assert_equal 1, response["matches"].length
+      assert_equal "1", response["matches"][0]["_id"]
+    end
+
+    it 'percolates an existing document' do
+      populate!
+
+      percolator1 = @index.percolator "1"
+      response = percolator1.create :query => { :match => { :author => "pea53" } }
+      assert response["created"], "Couldn't create the percolator query"
+      percolator2 = @index.percolator "2"
+      response = percolator2.create :query => { :match => { :author => "defunkt" } }
+      assert response["created"], "Couldn't create the percolator query"
+
+      response = @index.docs("doc2").percolate(nil, :id => "1")
       assert_equal 1, response["matches"].length
       assert_equal "1", response["matches"][0]["_id"]
     end

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -581,7 +581,7 @@ describe Elastomer::Client::Docs do
       @index.percolator("1").create :query => { :match_all => { } }
       @index.percolator("2").create :query => { :match => { :author => "pea53" } }
 
-      h = @index.docs("doc2").multi_percolate() do |m|
+      h = @index.docs("doc2").multi_percolate do |m|
         m.percolate :author => "pea53"
         m.percolate :author => "grantr"
         m.count({}, { :author => "grantr" })

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -548,6 +548,34 @@ describe Elastomer::Client::Docs do
       assert_equal 1, response["matches"].length
       assert_equal "1", response["matches"][0]["_id"]
     end
+
+    it 'counts the matches for percolating a given document' do
+      populate!
+
+      percolator1 = @index.percolator "1"
+      response = percolator1.create :query => { :match => { :author => "pea53" } }
+      assert response["created"], "Couldn't create the percolator query"
+      percolator2 = @index.percolator "2"
+      response = percolator2.create :query => { :match => { :author => "defunkt" } }
+      assert response["created"], "Couldn't create the percolator query"
+
+      count = @index.docs("doc1").percolate_count :doc => { :author => "pea53" }
+      assert_equal 1, count
+    end
+
+    it 'counts the matches for percolating an existing document' do
+      populate!
+
+      percolator1 = @index.percolator "1"
+      response = percolator1.create :query => { :match => { :author => "pea53" } }
+      assert response["created"], "Couldn't create the percolator query"
+      percolator2 = @index.percolator "2"
+      response = percolator2.create :query => { :match => { :author => "defunkt" } }
+      assert response["created"], "Couldn't create the percolator query"
+
+      count = @index.docs("doc2").percolate_count(nil, :id => "1")
+      assert_equal 1, count
+    end
   end
 
   # Create/index multiple documents.

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -578,6 +578,9 @@ describe Elastomer::Client::Docs do
     end
 
     it 'runs multi percolate queries' do
+      @index.percolator("1").create :query => { :match_all => { } }
+      @index.percolator("2").create :query => { :match => { :author => "pea53" } }
+
       h = @index.docs("doc2").multi_percolate() do |m|
         m.percolate({}, { :author => "pea53" })
         m.percolate({}, { :author => "grantr" })
@@ -585,8 +588,8 @@ describe Elastomer::Client::Docs do
       end
 
       response1, response2, response3 = h["responses"]
-      assert ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
-      assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
+      assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+      assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
     end
   end
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -577,7 +577,7 @@ describe Elastomer::Client::Docs do
       assert_equal 1, count
     end
 
-    it 'runs multi percolate queries' do
+    it 'performs multi percolate queries' do
       @index.percolator("1").create :query => { :match_all => { } }
       @index.percolator("2").create :query => { :match => { :author => "pea53" } }
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -523,9 +523,9 @@ describe Elastomer::Client::Docs do
       populate!
 
       response = @index.register_percolator_query "1", { :query => { :match => { :author => "pea53" } } }
-      assert response["created"]
+      assert response["created"], "Couldn't register the percolator query"
       response = @index.register_percolator_query "2", { :query => { :match => { :author => "defunkt" } } }
-      assert response["created"]
+      assert response["created"], "Couldn't register the percolator query"
 
       response = @index.docs("docs1").percolate({ :doc => { :author => "pea53" } })
       assert_equal 1, response["matches"].length

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -522,12 +522,14 @@ describe Elastomer::Client::Docs do
     it 'percolates' do
       populate!
 
-      response = @index.register_percolator_query "1", { :query => { :match => { :author => "pea53" } } }
-      assert response["created"], "Couldn't register the percolator query"
-      response = @index.register_percolator_query "2", { :query => { :match => { :author => "defunkt" } } }
-      assert response["created"], "Couldn't register the percolator query"
+      percolator1 = @index.percolator "1"
+      response = percolator1.create :query => { :match => { :author => "pea53" } }
+      assert response["created"], "Couldn't create the percolator query"
+      percolator2 = @index.percolator "2"
+      response = percolator2.create :query => { :match => { :author => "defunkt" } }
+      assert response["created"], "Couldn't create the percolator query"
 
-      response = @index.docs("docs1").percolate({ :doc => { :author => "pea53" } })
+      response = @index.docs("docs1").percolate(:doc => { :author => "pea53" })
       assert_equal 1, response["matches"].length
       assert_equal "1", response["matches"][0]["_id"]
     end

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -518,6 +518,19 @@ describe Elastomer::Client::Docs do
       assert docs
       assert_equal(%w[1 2], docs.map { |h| h['_id'] }.sort)
     end
+
+    it 'percolates' do
+      populate!
+
+      response = @index.register_percolator_query "1", { :query => { :match => { :author => "pea53" } } }
+      assert response["created"]
+      response = @index.register_percolator_query "2", { :query => { :match => { :author => "defunkt" } } }
+      assert response["created"]
+
+      response = @index.docs("docs1").percolate({ :doc => { :author => "pea53" } })
+      assert_equal 1, response["matches"].length
+      assert_equal "1", response["matches"][0]["_id"]
+    end
   end
 
   # Create/index multiple documents.

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -582,8 +582,8 @@ describe Elastomer::Client::Docs do
       @index.percolator("2").create :query => { :match => { :author => "pea53" } }
 
       h = @index.docs("doc2").multi_percolate() do |m|
-        m.percolate({}, { :author => "pea53" })
-        m.percolate({}, { :author => "grantr" })
+        m.percolate :author => "pea53"
+        m.percolate :author => "grantr"
         m.count({}, { :author => "grantr" })
       end
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -590,6 +590,7 @@ describe Elastomer::Client::Docs do
       response1, response2, response3 = h["responses"]
       assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
       assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
+      assert_equal 1, response3["total"]
     end
   end
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -576,6 +576,18 @@ describe Elastomer::Client::Docs do
       count = @index.docs("doc2").percolate_count(nil, :id => "1")
       assert_equal 1, count
     end
+
+    it 'runs multi percolate queries' do
+      h = @index.docs("doc2").multi_percolate() do |m|
+        m.percolate({}, { :author => "pea53" })
+        m.percolate({}, { :author => "grantr" })
+        m.count({}, { :author => "grantr" })
+      end
+
+      response1, response2, response3 = h["responses"]
+      assert ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+      assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
+    end
   end
 
   # Create/index multiple documents.

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -383,9 +383,10 @@ describe Elastomer::Client::Index do
       }, r['_indices'])
     end
 
-    it 'registers percolator queries' do
-      response = @index.register_percolator_query "1", { :query => { :match_all => {} } }
-      assert response["created"]
+    it 'can create a Percolator' do
+      id = "1"
+      percolator = @index.percolator id
+      assert_equal id, percolator.id
     end
   end
 end

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -383,7 +383,7 @@ describe Elastomer::Client::Index do
       }, r['_indices'])
     end
 
-    it 'can create a Percolator' do
+    it 'creates a Percolator' do
       id = "1"
       percolator = @index.percolator id
       assert_equal id, percolator.id

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -406,8 +406,8 @@ describe Elastomer::Client::Index do
       @index.percolator("2").create :query => { :match => { :author => "pea53" } }
 
       h = @index.multi_percolate(:type => 'doc2') do |m|
-        m.percolate({}, { :author => "pea53" })
-        m.percolate({}, { :author => "grantr" })
+        m.percolate :author => "pea53"
+        m.percolate :author => "grantr"
         m.count({}, { :author => "grantr" })
       end
 

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -389,7 +389,7 @@ describe Elastomer::Client::Index do
       assert_equal id, percolator.id
     end
 
-    it 'runs multi percolate queries' do
+    it 'performs multi percolate queries' do
       @index.docs.index \
         :_id    => 1,
         :_type  => 'doc2',

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -382,5 +382,10 @@ describe Elastomer::Client::Index do
         }
       }, r['_indices'])
     end
+
+    it 'registers percolator queries' do
+      response = @index.register_percolator_query "1", { :query => { :match_all => {} } }
+      assert response["created"]
+    end
   end
 end

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -388,5 +388,29 @@ describe Elastomer::Client::Index do
       percolator = @index.percolator id
       assert_equal id, percolator.id
     end
+
+    it 'runs multi percolate queries' do
+      @index.docs.index \
+        :_id    => 1,
+        :_type  => 'doc2',
+        :title  => 'the author of logging',
+        :author => 'pea53'
+
+      @index.docs.index \
+        :_id    => 2,
+        :_type  => 'doc2',
+        :title  => 'the author of rubber-band',
+        :author => 'grantr'
+
+      h = @index.multi_percolate(:type => 'doc2') do |m|
+        m.percolate({}, { :author => "pea53" })
+        m.percolate({}, { :author => "grantr" })
+        m.count({}, { :author => "grantr" })
+      end
+
+      response1, response2, response3 = h["responses"]
+      assert ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+      assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
+    end
   end
 end

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -402,6 +402,9 @@ describe Elastomer::Client::Index do
         :title  => 'the author of rubber-band',
         :author => 'grantr'
 
+      @index.percolator("1").create :query => { :match_all => { } }
+      @index.percolator("2").create :query => { :match => { :author => "pea53" } }
+
       h = @index.multi_percolate(:type => 'doc2') do |m|
         m.percolate({}, { :author => "pea53" })
         m.percolate({}, { :author => "grantr" })
@@ -409,8 +412,8 @@ describe Elastomer::Client::Index do
       end
 
       response1, response2, response3 = h["responses"]
-      assert ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
-      assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
+      assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+      assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
     end
   end
 end

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -414,6 +414,7 @@ describe Elastomer::Client::Index do
       response1, response2, response3 = h["responses"]
       assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
       assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
+      assert_equal 1, response3["total"]
     end
   end
 end

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -55,7 +55,7 @@ describe Elastomer::Client::MultiPercolate do
     assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
   end
 
-  it 'performs multipercolatees with .mpercolate' do
+  it 'performs multipercolates with .mpercolate' do
     populate!
 
     body = [

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -51,8 +51,8 @@ describe Elastomer::Client::MultiPercolate do
     body = body.join "\n"
     h = $client.multi_percolate body
     response1, response2, response3 = h["responses"]
-    assert ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
-    assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
+    assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+    assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
   end
 
   it 'performs multipercolates with .mpercolate' do
@@ -70,8 +70,8 @@ describe Elastomer::Client::MultiPercolate do
     body = body.join "\n"
     h = $client.mpercolate body
     response1, response2, response3 = h["responses"]
-    assert ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
-    assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
+    assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+    assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
   end
 
   it 'supports a nice block syntax' do
@@ -84,8 +84,8 @@ describe Elastomer::Client::MultiPercolate do
     end
 
     response1, response2, response3 = h["responses"]
-    assert ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
-    assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
+    assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+    assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
   end
 
   def populate!

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -80,8 +80,8 @@ describe Elastomer::Client::MultiPercolate do
     populate!
 
     h = $client.multi_percolate(:index => @name, :type => 'doc2') do |m|
-      m.percolate({}, { :author => "pea53" })
-      m.percolate({}, { :author => "grantr" })
+      m.percolate :author => "pea53"
+      m.percolate :author => "grantr"
       m.count({}, { :author => "grantr" })
     end
 

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -52,8 +52,8 @@ describe Elastomer::Client::MultiPercolate do
     h = $client.multi_percolate body
     response1, response2, response3 = h["responses"]
     assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
-    assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
-    assert_equal 1, response3["total"]
+    assert_equal ["1", "3"], response2["matches"].map { |match| match["_id"] }.sort
+    assert_equal 2, response3["total"]
   end
 
   it 'performs multi percolate queries with .mpercolate' do
@@ -72,8 +72,8 @@ describe Elastomer::Client::MultiPercolate do
     h = $client.mpercolate body
     response1, response2, response3 = h["responses"]
     assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
-    assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
-    assert_equal 1, response3["total"]
+    assert_equal ["1", "3"], response2["matches"].map { |match| match["_id"] }.sort
+    assert_equal 2, response3["total"]
   end
 
   it 'supports a nice block syntax' do
@@ -82,13 +82,13 @@ describe Elastomer::Client::MultiPercolate do
     h = $client.multi_percolate(:index => @name, :type => 'doc2') do |m|
       m.percolate :author => "pea53"
       m.percolate :author => "grantr"
-      m.count({}, { :author => "grantr" })
+      m.count({ :author => "grantr" })
     end
 
     response1, response2, response3 = h["responses"]
     assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
-    assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
-    assert_equal 1, response3["total"]
+    assert_equal ["1", "3"], response2["matches"].map { |match| match["_id"] }.sort
+    assert_equal 2, response3["total"]
   end
 
   def populate!
@@ -120,6 +120,8 @@ describe Elastomer::Client::MultiPercolate do
     percolator1.create :query => { :match_all => { } }
     percolator2 = @index.percolator "2"
     percolator2.create :query => { :match => { :author => "pea53" } }
+    percolator2 = @index.percolator "3"
+    percolator2.create :query => { :match => { :author => "grantr" } }
 
     @index.refresh
   end

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -51,12 +51,8 @@ describe Elastomer::Client::MultiPercolate do
     body = body.join "\n"
     h = $client.multi_percolate body
     response1, response2, response3 = h["responses"]
-    assert_equal 2, response1["total"]
-    assert_equal 1, response2["total"]
-    assert_equal 1, response3["total"]
-    assert_equal "1", response1["matches"][0]["_id"]
-    assert_equal "2", response1["matches"][1]["_id"]
-    assert_equal "1", response2["matches"][0]["_id"]
+    assert ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+    assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
   end
 
   it 'performs multipercolatees with .mpercolate' do
@@ -74,12 +70,8 @@ describe Elastomer::Client::MultiPercolate do
     body = body.join "\n"
     h = $client.mpercolate body
     response1, response2, response3 = h["responses"]
-    assert_equal 2, response1["total"]
-    assert_equal 1, response2["total"]
-    assert_equal 1, response3["total"]
-    assert_equal "1", response1["matches"][0]["_id"]
-    assert_equal "2", response1["matches"][1]["_id"]
-    assert_equal "1", response2["matches"][0]["_id"]
+    assert ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+    assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
   end
 
   it 'supports a nice block syntax' do
@@ -92,12 +84,8 @@ describe Elastomer::Client::MultiPercolate do
     end
 
     response1, response2, response3 = h["responses"]
-    assert_equal 2, response1["total"]
-    assert_equal 1, response2["total"]
-    assert_equal 1, response3["total"]
-    assert_equal "1", response1["matches"][0]["_id"]
-    assert_equal "2", response1["matches"][1]["_id"]
-    assert_equal "1", response2["matches"][0]["_id"]
+    assert ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+    assert ["1"], response2["matches"].map { |match| match["_id"] }.sort
   end
 
   def populate!

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -36,7 +36,7 @@ describe Elastomer::Client::MultiPercolate do
     @index.delete if @index.exists?
   end
 
-  it 'performs multipercolates' do
+  it 'performs multi percolate queries' do
     populate!
 
     body = [
@@ -55,7 +55,7 @@ describe Elastomer::Client::MultiPercolate do
     assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
   end
 
-  it 'performs multipercolates with .mpercolate' do
+  it 'performs multi percolate queries with .mpercolate' do
     populate!
 
     body = [

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -53,6 +53,7 @@ describe Elastomer::Client::MultiPercolate do
     response1, response2, response3 = h["responses"]
     assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
     assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
+    assert_equal 1, response3["total"]
   end
 
   it 'performs multi percolate queries with .mpercolate' do
@@ -72,6 +73,7 @@ describe Elastomer::Client::MultiPercolate do
     response1, response2, response3 = h["responses"]
     assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
     assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
+    assert_equal 1, response3["total"]
   end
 
   it 'supports a nice block syntax' do
@@ -86,6 +88,7 @@ describe Elastomer::Client::MultiPercolate do
     response1, response2, response3 = h["responses"]
     assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
     assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
+    assert_equal 1, response3["total"]
   end
 
   def populate!

--- a/test/client/percolator_test.rb
+++ b/test/client/percolator_test.rb
@@ -1,0 +1,48 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+describe Elastomer::Client::Percolator do
+
+  before do
+    @index = $client.index "elastomer-percolator-test"
+    @index.delete if @index.exists?
+    @docs = @index.docs("docs")
+  end
+
+  after do
+    @index.delete if @index.exists?
+  end
+
+  describe "when an index exists" do
+    before do
+      @index.create(nil)
+      wait_for_index(@index_name)
+    end
+
+    it 'creates a query' do
+      percolator = @index.percolator "1"
+      response = percolator.create :query => { :match_all => { } }
+      assert response["created"], "Couldn't create the percolator query"
+    end
+
+    it 'gets a query' do
+      percolator = @index.percolator "1"
+      percolator.create :query => { :match_all => { } }
+      response = percolator.get
+      assert response["found"], "Couldn't find the percolator query"
+    end
+
+    it 'deletes a query' do
+      percolator = @index.percolator "1"
+      percolator.create :query => { :match_all => { } }
+      response = percolator.delete
+      assert response["found"], "Couldn't find the percolator query"
+    end
+
+    it 'checks for the existence of a query' do
+      percolator = @index.percolator "1"
+      refute percolator.exists?, "Percolator query exists"
+      percolator.create :query => { :match_all => { } }
+      assert percolator.exists?, "Percolator query does not exist"
+    end
+  end
+end

--- a/test/client/percolator_test.rb
+++ b/test/client/percolator_test.rb
@@ -44,5 +44,9 @@ describe Elastomer::Client::Percolator do
       percolator.create :query => { :match_all => { } }
       assert percolator.exists?, "Percolator query does not exist"
     end
+
+    it 'cannot delete all percolators by providing a nil id' do
+      assert_raises(ArgumentError) { percolator = @index.percolator nil }
+    end
   end
 end


### PR DESCRIPTION
This looked like low hanging fruit, so I decided to give it a shot. "Percolate API" #24 is the motivating issue.

- [x] Create/Retrieve/Delete/Exists on percolators
- [x] Percolate new document
- [x] Percolate existing document
- [x] Percolate count new and existing [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-percolate.html#_percolator_count_api)
- [x] Multi percolate [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-percolate.html#_multi_percolate_api)