### PR TITLE
Remove Client#warmer method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.7.0 (2015-09-18)
+- BREAKING: Remove `Client#warmer` method
 - Add streaming bulk functionality via `bulk_stream_items`
 - Make Delete by Query compatible with Elasticsearch 2.0
 

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -519,8 +519,8 @@ module Elastomer
       # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-warmers.html
       #
       # Returns a new Warmer instance
-      def warmer( warmer_name )
-        client.warmer(name, warmer_name)
+      def warmer(warmer_name)
+        Warmer.new(client, name, warmer_name)
       end
 
       # Delete documents from one or more indices and one or more types based

--- a/lib/elastomer/client/warmer.rb
+++ b/lib/elastomer/client/warmer.rb
@@ -1,17 +1,6 @@
 module Elastomer
   class Client
 
-    # Provides access to warmer API commands.
-    # See http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
-    #
-    # index_name  - The name of the index as a String
-    # warmer_name - The name of the warmer as a String
-    #
-    # Returns a Warmer instance.
-    def warmer(index_name, warmer_name)
-      Warmer.new(self, index_name, warmer_name)
-    end
-
     class Warmer
 
       # Create a new Warmer helper for making warmer API requests.


### PR DESCRIPTION
Since warmers require an index scope, we should be consistent and only provide access from an Index object. This is a breaking change.

/cc @TwP @chrismwendt