### PR TITLE
Restrict delete_by_query tests to the test index

### DIFF
--- a/test/client/delete_by_query_test.rb
+++ b/test/client/delete_by_query_test.rb
@@ -23,7 +23,7 @@ describe Elastomer::Client::DeleteByQuery do
       @docs.index({ :_id => 1, :name => "luna" })
 
       @index.refresh
-      response = $client.delete_by_query(nil, :q => "name:mittens")
+      response = $client.delete_by_query(nil, :q => "name:mittens", :index => @index.name)
       assert_equal({
         '_all' => {
           'found' => 1,
@@ -50,7 +50,7 @@ describe Elastomer::Client::DeleteByQuery do
       @docs.index({ :_id => 1, :name => "luna" })
       @index.refresh
 
-      response = $client.delete_by_query(nil, :action_count => 1)
+      response = $client.delete_by_query(nil, :action_count => 1, :index =>  @index.name)
 
       assert_requested(:post, /_bulk/, :times => 2)
 
@@ -95,7 +95,7 @@ describe Elastomer::Client::DeleteByQuery do
         end)
 
       @index.refresh
-      response = $client.delete_by_query(nil, :action_count => 1)
+      response = $client.delete_by_query(nil, :action_count => 1, :index => @index.name)
       assert_equal({
         '_all' => {
           'found' => 0,
@@ -131,7 +131,7 @@ describe Elastomer::Client::DeleteByQuery do
         end)
 
       @index.refresh
-      response = $client.delete_by_query(nil, :action_count => 1)
+      response = $client.delete_by_query(nil, :action_count => 1, :index => @index.name)
       assert_equal({
         '_all' => {
           'found' => 1,

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -213,7 +213,7 @@ describe Elastomer::Client::Docs do
     authors = h['docs'].map { |d| d['_source']['author'] }
     assert_equal %w[pea53 grantr], authors
 
-    h = @docs.delete_by_query(:q => "author:grantr")
+    h = @docs.delete_by_query(:q => "author:grantr", :index => @index.name)
     assert_equal(h['_indices'], {
       '_all' => {
         'found' => 1,
@@ -239,14 +239,12 @@ describe Elastomer::Client::Docs do
     # the query hash version of this api never worked with 0.90 in the first
     # place, only test it if running 1.0.
     if es_version_1_x?
-      h = @docs.delete_by_query(
+      h = @docs.delete_by_query({
             :query => {
               :filtered => {
                 :query => {:match_all => {}},
-                :filter => {:term => {:author => 'pea53'}}
-              }
-            }
-          )
+                :filter => {:term => {:author => 'pea53'} } } } },
+            :index => @index.name)
       @index.refresh
       h = @docs.multi_get :ids => [1, 2]
       refute_found h['docs'][0]

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -366,7 +366,7 @@ describe Elastomer::Client::Index do
     it 'deletes by query' do
       @index.docs('foo').index("foo" => "bar")
       @index.refresh
-      r = @index.delete_by_query(:q => '*')
+      r = @index.delete_by_query(:q => '*', :index => @index.name)
       assert_equal({
         '_all' => {
           'found' => 1,


### PR DESCRIPTION
This prevents the `delete_by_query` tests from deleting documents contained in indices other than the test index specifically created by the test.

/cc @grantr