### PR TITLE
Bump faraday dependency version

### DIFF
--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "addressable", "~> 2.3"
-  spec.add_dependency "faraday",     "~> 0.9"
+  spec.add_dependency "faraday",     ">= 0.8"
   spec.add_dependency "multi_json",  "~> 1.7"
   spec.add_dependency "semantic",    "~> 1.3"
 

--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "addressable", "~> 2.3"
-  spec.add_dependency "faraday",     "~> 0.8"
+  spec.add_dependency "faraday",     "~> 0.9"
   spec.add_dependency "multi_json",  "~> 1.7"
   spec.add_dependency "semantic",    "~> 1.3"
 


### PR DESCRIPTION
This updates to the latest Faraday branch. There are a handful of not-backwards-compatible changes in the 0.9.x series of the Faraday gem, but it doesn't seem like any of those changes affect this library.