### PR TITLE
Scope the delete by query tests to a single index

### DIFF
--- a/test/client/delete_by_query_test.rb
+++ b/test/client/delete_by_query_test.rb
@@ -23,7 +23,7 @@ describe Elastomer::Client::DeleteByQuery do
       @docs.index({ :_id => 1, :name => "luna" })
 
       @index.refresh
-      response = $client.delete_by_query(nil, :q => "name:mittens")
+      response = @index.delete_by_query(nil, :q => "name:mittens")
       assert_equal({
         '_all' => {
           'found' => 1,
@@ -50,7 +50,7 @@ describe Elastomer::Client::DeleteByQuery do
       @docs.index({ :_id => 1, :name => "luna" })
       @index.refresh
 
-      response = $client.delete_by_query(nil, :action_count => 1)
+      response = @index.delete_by_query(nil, :action_count => 1)
 
       assert_requested(:post, /_bulk/, :times => 2)
 
@@ -95,7 +95,7 @@ describe Elastomer::Client::DeleteByQuery do
         end)
 
       @index.refresh
-      response = $client.delete_by_query(nil, :action_count => 1)
+      response = @index.delete_by_query(nil, :action_count => 1)
       assert_equal({
         '_all' => {
           'found' => 0,
@@ -131,7 +131,7 @@ describe Elastomer::Client::DeleteByQuery do
         end)
 
       @index.refresh
-      response = $client.delete_by_query(nil, :action_count => 1)
+      response = @index.delete_by_query(nil, :action_count => 1)
       assert_equal({
         '_all' => {
           'found' => 1,


### PR DESCRIPTION
Running the delete by query tests locally resulted in all documents in my local ES installation being deleted. The delete by query tests were scoped at the `$client` level, not at the `@index` level. So the scan / bulk delete operations iterated over all the indices in my development ES step :disappointed: 

These changes scope the tests to just the test index :smile:

/cc @chrismwendt @grantr 