### PR TITLE
Omit source in delete_by_query searches

### DIFF
--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -105,7 +105,7 @@ module Elastomer
       # Returns a Hash of statistics about the bulk operation
       def execute
         ops = Enumerator.new do |yielder|
-          @client.scan(@query, @params).each_document do |hit|
+          @client.scan(@query, @params.merge(:_source => false)).each_document do |hit|
             yielder.yield([:delete, { _id: hit["_id"], _type: hit["_type"], _index: hit["_index"] }])
           end
         end


### PR DESCRIPTION
This prevents the unused `_source` field of search results from being sent over the network.

Solves #117.

/cc @TwP @grantr