### PR TITLE
Make tests more stable

### DIFF
--- a/test/client/nodes_test.rb
+++ b/test/client/nodes_test.rb
@@ -41,7 +41,8 @@ describe Elastomer::Client::Nodes do
   it "gets the hot threads for the node(s)" do
     str = $client.nodes.hot_threads :read_timeout => 2
     assert_instance_of String, str
-    assert_match %r/:::/, str
+    assert !str.nil?, "expected response to not be nil"
+    assert !str.empty?, "expected response to not be empty"
   end
 
   it "can be scoped to a single node" do

--- a/test/client/nodes_test.rb
+++ b/test/client/nodes_test.rb
@@ -41,7 +41,7 @@ describe Elastomer::Client::Nodes do
   it "gets the hot threads for the node(s)" do
     str = $client.nodes.hot_threads :read_timeout => 2
     assert_instance_of String, str
-    assert_match %r/Hot threads/, str
+    assert_match %r/:::/, str
   end
 
   it "can be scoped to a single node" do

--- a/test/client/nodes_test.rb
+++ b/test/client/nodes_test.rb
@@ -41,7 +41,7 @@ describe Elastomer::Client::Nodes do
   it "gets the hot threads for the node(s)" do
     str = $client.nodes.hot_threads :read_timeout => 2
     assert_instance_of String, str
-    assert_match %r/cpu usage by thread/, str
+    assert_match %r/Hot threads/, str
   end
 
   it "can be scoped to a single node" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ require "elastomer/client"
 # the client should always be stateless
 $client_params = {
   :port => ENV["BOXEN_ELASTICSEARCH_PORT"] || 9200,
-  :read_timeout => 2,
+  :read_timeout => 10,
   :open_timeout => 1,
   :opaque_id => false
 }


### PR DESCRIPTION
This makes the `hot_threads` test deterministic and increases the stability of other tests by increasing the `read_timeout`.

Fixes #120.

/cc @TwP @grantr