### PR TITLE
Revert "Bump faraday dependency version"

### DIFF
--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "addressable", "~> 2.3"
-  spec.add_dependency "faraday",     ">= 0.8"
+  spec.add_dependency "faraday",     "~> 0.8"
   spec.add_dependency "multi_json",  "~> 1.7"
   spec.add_dependency "semantic",    "~> 1.3"
 


### PR DESCRIPTION
Reverts github/elastomer-client#116 - see discussion stemming from https://github.com/github/elastomer-client/pull/116#issuecomment-144756455.