### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elastomer Client [![Build Status](https://travis-ci.org/github/elastomer-client.svg)](https://travis-ci.org/github/elastomer-client)
 
-Making a stupid simple ElasticSearch client so your project can be smarter!
+Making a stupid simple Elasticsearch client so your project can be smarter!
 
 ## Getting Started
 
@@ -15,7 +15,7 @@ $ script/test
 
 ## Client
 
-The client provides a one-to-one mapping to the ElasticSearch [API
+The client provides a one-to-one mapping to the Elasticsearch [API
 endpoints](http://www.elasticsearch.org/guide/reference/api/). The API is
 decomposed into logical sections and accessed according to what you are trying
 to accomplish. Each logical section is represented as a [client
@@ -89,7 +89,7 @@ docs.index({
   :_id    => 1,
   :_type  => 'tweet',
   :author => '@pea53',
-  :tweet  => 'announcing Elastomer, the stupid simple ElasticSearch client'
+  :tweet  => 'announcing Elastomer, the stupid simple Elasticsearch client'
 })
 
 docs.search({:query => {:match_all => {}}}, :search_type => 'count')
@@ -98,7 +98,7 @@ docs.search({:query => {:match_all => {}}}, :search_type => 'count')
 #### Performance
 
 By default Elastomer uses Net::HTTP (via Faraday) to communicate with
-ElasticSearch. You may find that Excon performs better for your use. To enable
+Elasticsearch. You may find that Excon performs better for your use. To enable
 Excon, add it to your bundle and then change your Elastomer initialization
 thusly:
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ $ script/test
 ## Client
 
 The client provides a one-to-one mapping to the Elasticsearch [API
-endpoints](http://www.elasticsearch.org/guide/reference/api/). The API is
-decomposed into logical sections and accessed according to what you are trying
-to accomplish. Each logical section is represented as a [client
+endpoints](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html).
+The API is decomposed into logical sections and accessed according to what you
+are trying to accomplish. Each logical section is represented as a [client
 class](lib/elastomer/client) and a top-level accessor is provided for each.
 
 #### Cluster

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ in action.
 To that end we have tried to be as faithful as possible to the Elasticsearch API
 with our implementation. There are a few places where it made sense to wrap the
 Elasticsearch API inside Ruby idioms. One notable location is the
-[scan-scroll](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html)
+[scan-scroll](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html)
 search type; the Elastomer Client provides a Ruby iterator to work with these
 types of queries.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@ We first started building the Elastomer Client gem when an
 was not yet available from Elasticsearch. We were looking for a client that
 provided a one-to-one mapping of the Elasticsearch APIs and avoided higher level
 complexity such as connection pooling, round-robin connections, thrift support,
-and the like. We think these things these things are bettered handled at
-different layers and by other software libraries.
+and the like. We think these things are better handled at different layers and
+by other software libraries.
 
 Our goal is to keep our Elasticsearch client simple and then compose
 higher level functionality from smaller components. This is the UNIX philosophy

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,19 +2,19 @@
 
 We first started building the Elastomer Client gem when an
 [official client](https://github.com/elasticsearch/elasticsearch-ruby)
-was not yet available from ElasticSearch. We were looking for a client that
-provided a one-to-one mapping of the ElasticSearch APIs and avoided higher level
+was not yet available from Elasticsearch. We were looking for a client that
+provided a one-to-one mapping of the Elasticsearch APIs and avoided higher level
 complexity such as connection pooling, round-robin connections, thrift support,
 and the like. We think these things these things are bettered handled at
 different layers and by other software libraries.
 
-Our goal is to keep our ElasticSearch client simple and then compose
+Our goal is to keep our Elasticsearch client simple and then compose
 higher level functionality from smaller components. This is the UNIX philosophy
 in action.
 
-To that end we have tried to be as faithful as possible to the ElasticSearch API
+To that end we have tried to be as faithful as possible to the Elasticsearch API
 with our implementation. There are a few places where it made sense to wrap the
-ElasticSearch API inside Ruby idioms. One notable location is the
+Elasticsearch API inside Ruby idioms. One notable location is the
 [scan-scroll](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html)
 search type; the Elastomer Client provides a Ruby iterator to work with these
 types of queries.

--- a/docs/client.md
+++ b/docs/client.md
@@ -59,7 +59,7 @@ timeout can be set for each request.
 
 ```ruby
 client = Elastomer::Client.new \
-  :url          => "http:/localhost:19200",
+  :url          => "http://localhost:19200",
   :adapter      => :net_http_persistent,
   :open_timeout => 1,
   :read_timeout => 5

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,8 +1,8 @@
 # Elastomer Client Component
 
 All methods in the Elastomer Client gem eventually make an HTTP request to
-ElasticSearch. The [`Elastomer::Client`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client.rb)
-class is responsible for connecting to an ElasticSearch instance, making HTTP
+Elasticsearch. The [`Elastomer::Client`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client.rb)
+class is responsible for connecting to an Elasticsearch instance, making HTTP
 requests, processing the response, and handling errors. Let's look at the
 details of how `Elastomer::Client` handles HTTP communication.
 
@@ -13,10 +13,10 @@ communication. Faraday provides a uniform wrapper around several different HTTP
 clients allowing any of these clients to be used at runtime. Faraday also has
 the concept of *middlewares* that operate on the HTTP request and response. We
 use Faraday middleware to encode and decode JSON messages exchanged with
-ElasticSearch.
+Elasticsearch.
 
 Without any options the `Elastomer::Client` will connect to the default
-ElasticSearch URL `http://localhost:9200`. The `Net:HTTP` client from the Ruby
+Elasticsearch URL `http://localhost:9200`. The `Net:HTTP` client from the Ruby
 standard library will be used.
 
 ```ruby
@@ -26,9 +26,9 @@ client.port  #=> 9200
 client.url   #=> 'http://localhost:9200'
 ```
 
-[Boxen](https://boxen.github.com) configures ElasticSearch to listen on port
+[Boxen](https://boxen.github.com) configures Elasticsearch to listen on port
 `19200` instead of the standard port. We can provide either the full URL or just
-a different port number if ElasticSearch is running on `localhost`.
+a different port number if Elasticsearch is running on `localhost`.
 
 ```ruby
 client = Elastomer::Client.new :port => 19200
@@ -39,7 +39,7 @@ client.url   #=> 'http://localhost:19200'
 client = Elastomer::Client.new :url => "http://localhost:19200"
 ```
 
-ElasticSearch works best with persistent connections. We can use the
+Elasticsearch works best with persistent connections. We can use the
 `Net::HTTP::Persistent` adapter with Faraday.
 
 ```ruby
@@ -49,7 +49,7 @@ client = Elastomer::Client.new \
 ```
 
 We also want to configure the `:open_timeout` (for making the initial connection
-to ElasticSearch) and the `:read_timeout` (used to limit each request). The open
+to Elasticsearch) and the `:read_timeout` (used to limit each request). The open
 timeout should be short - it defaults to 2 seconds. The read timeout should be
 longer, but it can vary depending upon the type of request you are making. Large
 bulk requests will take longer than a quick count query.
@@ -73,9 +73,9 @@ read timeout is reached. If the connection is left open and reused, then the
 returned data might actually be from a previous request. This can lead to all
 kinds of horrible data leaks.
 
-ElasticSearch provides an `X-Opaque-Id` request header. Any value set in this
+Elasticsearch provides an `X-Opaque-Id` request header. Any value set in this
 request header will be returned in the corresponding response header. This
-allows the client to correlate the response from ElasticSearch with the request
+allows the client to correlate the response from Elasticsearch with the request
 that was submitted. We have written an
 [OpaqueId](https://github.com/github/elastomer-client/blob/master/lib/elastomer/middleware/opaque_id.rb)
 middleware that will abort any request if the `X-Opaque-Id` headers disagree
@@ -109,8 +109,8 @@ HTTP request. The HTTP `head` method does not support a request body and ignores
 this parameter. The other HTTP methods all support request bodies.
 
 The `:body` value will be converted into JSON format before being sent to
-ElasticSearch unless the body is a String or an Array. If the body is a String
-it is assumed to already be JSON formatted, and it is sent to ElasticSearch as
+Elasticsearch unless the body is a String or an Array. If the body is a String
+it is assumed to already be JSON formatted, and it is sent to Elasticsearch as
 is without any modifications. When the body is an Array then all the items are
 joined with a newline character `\n` and a trailing newline is appended; this
 supports [bulk](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html)
@@ -133,10 +133,10 @@ client.cluster.health \
 ```
 
 In the example above we are waiting for the named index to reach a green state.
-The `:timeout` of 5 seconds is passed to ElasticSearch. This call will return
+The `:timeout` of 5 seconds is passed to Elasticsearch. This call will return
 after 5 seconds even if the index has not yet reached green status. So we set
 our network call timeout to 7 seconds to ensure we don't kill the request before
-ElasticSearch has responded.
+Elasticsearch has responded.
 
 **:action** and **:context**
 
@@ -228,9 +228,9 @@ fatal, then the request is fundamentally flawed and should not be retried.
 Passing a malformed search query or trying to search an index that does not
 exist are both examples of fatal errors - the request will never succeed.
 
-If an error is not fatal then it can be retried. If the ElasticSearch cluster
+If an error is not fatal then it can be retried. If the Elasticsearch cluster
 has a full search queue then any query will fail. It not the fault of the user
-or the query itself - ElasticSearch just needs more capacity. The query can be
+or the query itself - Elasticsearch just needs more capacity. The query can be
 safely retried.
 
 Therein lies the rub, though. Retrying a search or any operation will continue

--- a/docs/client.md
+++ b/docs/client.md
@@ -113,8 +113,8 @@ Elasticsearch unless the body is a String or an Array. If the body is a String
 it is assumed to already be JSON formatted, and it is sent to Elasticsearch as
 is without any modifications. When the body is an Array then all the items are
 joined with a newline character `\n` and a trailing newline is appended; this
-supports [bulk](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html)
-indexing and [multi-search](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-multi-search.html)
+supports [bulk](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html)
+indexing and [multi-search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html)
 requests.
 
 **:read_timeout**

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -3,7 +3,7 @@
 The cluster component deals with commands for managing cluster state and
 monitoring cluster health. All the commands found under the
 [cluster API](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster.html)
-section of the ElasticSearch documentation are implemented by the
+section of the Elasticsearch documentation are implemented by the
 [`cluster.rb`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client/cluster.rb)
 module and the [`nodes.rb`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client/nodes.rb)
 module.
@@ -12,7 +12,7 @@ module.
 
 API endpoints dealing with cluster level information and settings are found in
 the [`Cluster`](lib/elastomer/client/cluster.rb) class. Each of these methods
-corresponds to an API endpoint described in the ElasticSearch documentation
+corresponds to an API endpoint described in the Elasticsearch documentation
 (linked to above). The params listed in the documentation can be passed to these
 methods, so we do not take too much trouble to enumerate them all.
 

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -2,7 +2,7 @@
 
 The cluster component deals with commands for managing cluster state and
 monitoring cluster health. All the commands found under the
-[cluster API](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster.html)
+[cluster API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html)
 section of the Elasticsearch documentation are implemented by the
 [`cluster.rb`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client/cluster.rb)
 module and the [`nodes.rb`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client/nodes.rb)
@@ -18,7 +18,7 @@ methods, so we do not take too much trouble to enumerate them all.
 
 #### health
 
-The cluster [health API](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-health.html)
+The cluster [health API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html)
 returns a very simple cluster health status report.
 
 ```ruby
@@ -50,8 +50,8 @@ client.cluster.health \
 #### state & stats
 
 If you need something more than basic health information, then the
-[`state`](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-state.html)
-and [`stats`](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-stats.html)
+[`state`](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-state.html)
+and [`stats`](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-stats.html)
 endpoints are the next methods to call. Please look through the API
 documentation linked to above for all the details. And you can play with these
 endpoints via an IRB session.
@@ -67,10 +67,10 @@ client.cluster.stats
 #### settings
 
 Cluster behavior is controlled via the
-[settings API](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-update-settings.html).
+[settings API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html).
 The settings can be retrieved, and some settings can be modified at runtime to
 control shard allocations, routing, index replicas, and so forth. For example,
-when performing a [rolling restart](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_rolling_restarts.html)
+when performing a [rolling restart](https://www.elastic.co/guide/en/elasticsearch/guide/current/_rolling_restarts.html)
 of a cluster, disabling shard allocation between restarts can reduce the
 cluster recovery time.
 

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,8 +1,8 @@
 # Elastomer Documents Component
 
 The documents components handles all API calls related to
-[indexing documents](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs.html)
-and [searching documents](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search.html).
+[indexing documents](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs.html)
+and [searching documents](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html).
 
 Access to the documents component is provided via the `docs` method on the index
 component or the `docs` method on the client. The `docs` method on the index

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -68,7 +68,7 @@ This will create a new document in the search index. But what do we do if there
 is a misspelling in the body of our blog post? We'll need to re-index the
 document.
 
-ElasticSearch assigned our document a unique identifier when we first added it
+Elasticsearch assigned our document a unique identifier when we first added it
 to the index. In order to change this document, we need to supply the unique
 identifier along with our modified document.
 
@@ -86,13 +86,13 @@ docs.index(
 *The `post_body` above is a variable representing the real body of the blog
 post. I don't want to type it over and over again.*
 
-You do not have to relay on the auto-generated IDs from ElasticSearch. You can
+You do not have to relay on the auto-generated IDs from Elasticsearch. You can
 always provide your own IDs; this is recommended if your documents are also
 stored in a database that provides unique IDs. Using the same IDs in both
 locations enables you to reconcile documents between the two.
 
 The `:_id` field is only one of several special fields that control document
-indexing in ElasticSearch. The full list of supported fields are enumerated in
+indexing in Elasticsearch. The full list of supported fields are enumerated in
 the `index`
 [method documentation](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client/docs.rb#L45-56).
 
@@ -160,7 +160,7 @@ client.docs.search \
   :type  => "post"
 ```
 
-The `search` method returns the query response from ElasticSearch as a ruby
+The `search` method returns the query response from Elasticsearch as a ruby
 Hash. All the keys are represented as Strings. The [hashie](https://github.com/intridea/hashie)
 project has some useful transforms and wrappers for working with these result
 sets, but that is left to the user to implement if they so desire. Elastomer
@@ -198,7 +198,7 @@ results["hits"]["total"]  #=> 1
 The search results always contain the total number of matched documents; even if
 the `:size` is set to zero or some other number. However this is very inefficient.
 
-ElasticSearch provides specific methods for obtaining the number of documents
+Elasticsearch provides specific methods for obtaining the number of documents
 that match a search. Instead we can specify a `:search_type` tailored for
 counting.
 
@@ -212,7 +212,7 @@ results["hits"]["total"]  #=> 1
 
 The `"count"` search type is much more efficient then setting the size to zero.
 These count queries will return more quickly and consume less memory inside
-ElasticSearch.
+Elasticsearch.
 
 There is also a `count` API method, but the `:serach_type` approach is even more
 efficient than the count API.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -214,7 +214,7 @@ The `"count"` search type is much more efficient then setting the size to zero.
 These count queries will return more quickly and consume less memory inside
 Elasticsearch.
 
-There is also a `count` API method, but the `:serach_type` approach is even more
+There is also a `count` API method, but the `:search_type` approach is even more
 efficient than the count API.
 
 #### Deleting

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Elastomer Index Component
 
 The index component provides access to the
-[indices API](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices.html)
+[indices API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices.html)
 used for index management, settings, mappings, and aliases. Index
 [warmers](warmers.md) and [templates](templates.md) are handled via their own
 components. Methods for adding documents to the index and searching those
@@ -102,13 +102,13 @@ as possible.
 
 #### Analysis
 
-The [analysis](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/analysis.html)
+The [analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html)
 process has the greatest impact on the relevancy of your search results. It is
 the process of decomposing text into searchable tokens. Understanding this
 process is important, and creating your own analyzers is as much an art form as
 it is science.
 
-Elasticsearch provides an [analyze](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-analyze.html)
+Elasticsearch provides an [analyze](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html)
 API for exploring the analysis process and return tokens. We can see how
 individual fields will analyze text.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,6 @@ index.status
 index = client.index
 index.status :index => "blog"
 index.status :index => "users"
-
 ```
 
 You can operate on more than one index, too, by providing a list of index names.
@@ -129,13 +128,13 @@ client.index.analyze "The Role of Morphology in Phoneme Prediction",
 
 A common practice when dealing with non-changing data sets (event logs) is to
 create a new index for each week or month. Only the current index is written to,
-and the older indices can be made read only. Eventually, when it is time to
+and the older indices can be made read-only. Eventually, when it is time to
 expire the data, the older indices can be deleted from the cluster.
 
 Let's take a look at some simple event log maintenance using elastomer-client.
 
 ```ruby
-# the previous months event log
+# the previous month's event log
 index = client.index "event-log-2014-09"
 
 # optimize the index to have only 1 segment file (expunges deleted documents)
@@ -153,7 +152,7 @@ index.update_settings \
 ```
 
 Now we have a nicely optimized event log index that can be searched but cannot
-be written to. Some time in the future we can delete this index (but we should
+be written to. Sometime in the future we can delete this index (but we should
 take a [snapshot](snapshots.md) first).
 
 ```ruby

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,7 +96,7 @@ index.update_mapping :post,
 ```
 
 The `:post` type is given twice - once as a method argument, and once in the
-request body. This is an artifact of the ElasticSearch API. We could hide this
+request body. This is an artifact of the Elasticsearch API. We could hide this
 wart, but the philosophy of the elastomer-client is to be as faithful to the API
 as possible.
 
@@ -108,7 +108,7 @@ the process of decomposing text into searchable tokens. Understanding this
 process is important, and creating your own analyzers is as much an art form as
 it is science.
 
-ElasticSearch provides an [analyze](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-analyze.html)
+Elasticsearch provides an [analyze](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-analyze.html)
 API for exploring the analysis process and return tokens. We can see how
 individual fields will analyze text.
 
@@ -118,7 +118,7 @@ index.analyze "The Role of Morphology in Phoneme Prediction",
   :field => "post.title"
 ```
 
-And we can explore the default analyzers provided by ElasticSearch.
+And we can explore the default analyzers provided by Elasticsearch.
 
 ```ruby
 client.index.analyze "The Role of Morphology in Phoneme Prediction",

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -10,7 +10,7 @@ module Elastomer
   class Client
 
     # Create a new client that can be used to make HTTP requests to the
-    # ElasticSearch server.
+    # Elasticsearch server.
     #
     # opts - The options Hash
     #   :host - the host as a String
@@ -48,18 +48,18 @@ module Elastomer
     end
     alias_method :available?, :ping
 
-    # Returns the version String of the attached ElasticSearch instance.
+    # Returns the version String of the attached Elasticsearch instance.
     def version
       @version ||= info["version"]["number"]
     end
 
-    # Returns a Semantic::Version for the attached ElasticSearch instance.
+    # Returns a Semantic::Version for the attached Elasticsearch instance.
     # See https://rubygems.org/gems/semantic
     def semantic_version
       Semantic::Version.new(version)
     end
 
-    # Returns the information Hash from the attached ElasticSearch instance.
+    # Returns the information Hash from the attached Elasticsearch instance.
     def info
       response = get "/", :action => "cluster.info"
       response.body

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -7,7 +7,7 @@ module Elastomer
     # Bulk instance to assemble the operations called in the block into a
     # bulk request and dispatch it at the end of the block.
     #
-    # See http://www.elasticsearch.org/guide/reference/api/bulk/
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
     #
     # body   - Request body as a String (required if a block is _not_ given)
     # params - Optional request parameters as a Hash

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -142,9 +142,9 @@ module Elastomer
     end
 
     # The Bulk class provides some abstractions and helper methods for working
-    # with the ElasticSearch bulk API command. Instances of the Bulk class
+    # with the Elasticsearch bulk API command. Instances of the Bulk class
     # accumulate indexing and delete operations and then issue a single bulk
-    # API request to ElasticSearch. Those operations are then executed by the
+    # API request to Elasticsearch. Those operations are then executed by the
     # cluster.
     #
     # A maximum request size can be set. As soon as the size of the request
@@ -183,12 +183,12 @@ module Elastomer
       # Set the request size in bytes. If the value is nil, then request size
       # limiting will not be used and a request will only be made when the call
       # method is called. It is up to the user to ensure that the request does
-      # not exceed ElasticSearch request size limits.
+      # not exceed Elasticsearch request size limits.
       #
       # If the value is a number greater than zero, then actions will be
       # buffered until the request size is met or exceeded. When this happens a
       # bulk request is issued, queued actions are cleared, and the response
-      # from ElasticSearch is returned.
+      # from Elasticsearch is returned.
       def request_size=( value )
         if value.nil?
           @request_size = nil
@@ -200,12 +200,12 @@ module Elastomer
       # Set the action count. If the value is nil, then action count limiting
       # will not be used and a request will only be made when the call method
       # is called. It is up to the user to ensure that the request does not
-      # exceed ElasticSearch request size limits.
+      # exceed Elasticsearch request size limits.
       #
       # If the value is a number greater than zero, then actions will be
       # buffered until the action count is met. When this happens a bulk
       # request is issued, queued actions are cleared, and the response from
-      # ElasticSearch is returned.
+      # Elasticsearch is returned.
       def action_count=(value)
         if value.nil?
           @action_count = nil

--- a/lib/elastomer/client/cluster.rb
+++ b/lib/elastomer/client/cluster.rb
@@ -30,7 +30,7 @@ module Elastomer
       #   :wait_for_nodes - the request waits until the specified number N of nodes is available
       #   :timeout - how long to wait [default is "30s"]
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-health.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html
       #
       # Returns the response as a Hash
       def health( params = {} )
@@ -48,7 +48,7 @@ module Elastomer
       #   :metrics - list of metrics to select as an Array
       #   :indices - a single index name or an Array of index names
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-state.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-state.html
       #
       # Returns the response as a Hash
       def state( params = {} )
@@ -63,7 +63,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-stats.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-stats.html
       #
       # Returns the response as a Hash
       def stats( params = {} )
@@ -76,7 +76,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-pending.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-pending.html
       #
       # Returns the response as a Hash
       def pending_tasks( params = {} )
@@ -97,7 +97,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-update-settings.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html
       #
       # Returns the response as a Hash
       def get_settings( params = {} )
@@ -113,7 +113,7 @@ module Elastomer
       # body   - The new settings as a Hash or a JSON encoded String
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-update-settings.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html
       #
       # Returns the response as a Hash
       def update_settings( body, params = {} )
@@ -143,7 +143,7 @@ module Elastomer
       #     { :allocate => { :index => 'test', :shard => 1, :node => 'node3' }}
       #   ])
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-reroute.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-reroute.html
       #
       # Returns the response as a Hash
       def reroute( commands, params = {} )
@@ -166,7 +166,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-nodes-shutdown.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-shutdown.html
       #
       # Returns the response as a Hash
       def shutdown( params = {} )
@@ -187,7 +187,7 @@ module Elastomer
       #   get_aliases
       #   get_aliases( :index => 'users' )
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
       #
       # Returns the response body as a Hash
       def get_aliases( params = {} )
@@ -213,7 +213,7 @@ module Elastomer
       #     { :add    => { :index => 'users-2', :alias => 'users' }}
       #   ])
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
       #
       # Returns the response body as a Hash
       def update_aliases( actions, params = {} )

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -22,7 +22,7 @@ module Elastomer
     #   # same thing but using the URI request method
     #   delete_by_query(nil, { :q => '*:*', :type => 'tweet' })
     #
-    # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html
+    # See https://www.elastic.co/guide/en/elasticsearch/plugins/current/delete-by-query-usage.html
     #
     # Returns a Hash of statistics about the delete operations, for example:
     #

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -8,7 +8,7 @@ module Elastomer
     # name - The name of the index as a String (optional)
     # type - The document type as a String (optional)
     #
-    # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs.html
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs.html
     #
     # Returns a Docs instance.
     def docs( name = nil, type = nil )
@@ -62,7 +62,7 @@ module Elastomer
       # document - The document (as a Hash or JSON encoded String) to add to the index
       # params   - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-index_.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
       #
       # Returns the response body as a Hash
       def index( document, params = {} )
@@ -88,7 +88,7 @@ module Elastomer
       # params - Parameters Hash
       #   :id - the ID of the document to delete
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete.html
       #
       # Returns the response body as a Hash
       def delete( params = {} )
@@ -102,7 +102,7 @@ module Elastomer
       # params - Parameters Hash
       #   :id - the ID of the document to get
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-get.html#docs-get
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#docs-get
       #
       # Returns the response body as a Hash
       def get( params = {} )
@@ -116,7 +116,7 @@ module Elastomer
       # params - Parameters Hash
       #   :id - the ID of the document to check
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-get.html#docs-get
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#docs-get
       #
       # Returns true if the document exists
       def exists?( params = {} )
@@ -131,7 +131,7 @@ module Elastomer
       # params - Parameters Hash
       #   :id - the ID of the document
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-get.html#_source
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#_source
       #
       # Returns the response body as a Hash
       def source( params = {} )
@@ -144,7 +144,7 @@ module Elastomer
       # body   - The request body as a Hash or a JSON encoded String
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html
       #
       # Returns the response body as a Hash
       def multi_get( body, params = {} )
@@ -161,7 +161,7 @@ module Elastomer
       # script - The script (as a Hash) used to update the document in place
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html
       #
       # Returns the response body as a Hash
       def update( script, params = {} )
@@ -189,9 +189,9 @@ module Elastomer
       #   # same thing but using the URI request method
       #   search(:q => '*:*', :type => 'tweet')
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-search.html
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-uri-request.html
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-body.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-uri-request.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html
       #
       # Returns the response body as a hash
       def search( query, params = nil )
@@ -211,7 +211,7 @@ module Elastomer
       #   :preference - which shard replicas to execute the search request on
       #   :local      - boolean value to use local cluster state
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-shards.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-shards.html
       #
       # Returns the response body as a hash
       def search_shards( params = {} )
@@ -236,7 +236,7 @@ module Elastomer
       #   # same thing but using the URI request method
       #   count(:q => '*:*', :type => 'tweet')
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-count.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html
       #
       # Returns the response body as a Hash
       def count( query, params = nil )
@@ -300,7 +300,7 @@ module Elastomer
       # params - Parameters Hash
       #   :id - the ID of the document to get
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-termvectors.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html
       #
       # Returns the response body as a hash
       def termvector( params = {} )
@@ -318,7 +318,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-termvectors.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-termvectors.html
       #
       # Returns the response body as a hash
       def multi_termvectors( body, params = {} )
@@ -348,7 +348,7 @@ Percolate
       #   more_like_this({:from => 5, :size => 10}, :mlt_fields => "title",
       #                   :min_term_freq => 1, :type => "doc1", :id => 1)
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-more-like-this.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-more-like-this.html
       #
       # Returns the response body as a hash
       def more_like_this( query, params = nil )
@@ -372,7 +372,7 @@ Percolate
       #
       #   explain(:q => "message:search", :id => 1)
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-explain.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html
       #
       # Returns the response body as a hash
       def explain( query, params = nil )
@@ -397,7 +397,7 @@ Percolate
       #   # same thing but using the URI query parameter
       #   validate(:q => "post_date:foo", :explain => true)
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-validate.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-validate.html
       #
       # Returns the response body as a hash
       def validate( query, params = nil )
@@ -453,7 +453,7 @@ Percolate
       #     document['_source']
       #   end
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
       #
       # Returns a new Scroller instance
       def scroll( query, opts = {} )
@@ -509,7 +509,7 @@ Percolate
       #     ...
       #   end
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-multi-search.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html
       #
       # Returns the response body as a Hash
       def multi_search( params = {}, &block )

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -38,8 +38,8 @@ module Elastomer
       # new document will be created using POST semantics.
       #
       # There are several other document attributes that control how
-      # ElasticSearch will index the document. They are listed below. Please
-      # refer to the ElasticSearch documentation for a full explanation of each
+      # Elasticsearch will index the document. They are listed below. Please
+      # refer to the Elasticsearch documentation for a full explanation of each
       # and how it affects the indexing process.
       #
       #   :_id

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -139,7 +139,7 @@ module Elastomer
         response.body
       end
 
-      # Allows to get multiple documents based on an index, type, and id (and possibly routing).
+      # Allows you to get multiple documents based on an index, type, and id (and possibly routing).
       #
       # body   - The request body as a Hash or a JSON encoded String
       # params - Parameters Hash
@@ -311,7 +311,7 @@ module Elastomer
       alias_method :term_vector, :termvector
       alias_method :term_vectors, :termvector
 
-      # Multi termvectors API allows  you to get multiple termvectors based on
+      # Multi termvectors API allows you to get multiple termvectors based on
       # an index, type and id. The response includes a docs array with all the
       # fetched termvectors, each element having the structure provided by the
       # `termvector` API.

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -2,7 +2,7 @@ module Elastomer
   class Client
 
     # Provides access to index-level API commands. An index name is required for
-    # these API calls. If you want to operate on all inidces - flushing all
+    # these API calls. If you want to operate on all indices - flushing all
     # indices, for example - then you will need to use the "_all" index name.
     #
     # You can override the index name for one-off calls by passing in the
@@ -17,7 +17,7 @@ module Elastomer
 
     class Index
       # Create a new index client for making API requests that pertain to
-      # the health and management individual indexes.
+      # the health and management of individual indexes.
       #
       # client - Elastomer::Client used for HTTP requests to the server
       # name   - The name of the index as a String or an Array of names
@@ -181,7 +181,7 @@ module Elastomer
       #
       # name   - Name of the alias to look up
       # params - Parameters Hash
-      #   :ignore_unavailable - What to do is an specified index name doesn’t
+      #   :ignore_unavailable - What to do if a specified index name doesn’t
       #                         exist. If set to `true` then those indices are ignored.
       #
       # Examples
@@ -234,7 +234,8 @@ module Elastomer
         response.body
       end
 
-      # Performs the analysis process on a text and return the tokens breakdown of the text.
+      # Perform the analysis process on some text and return the tokens
+      # breakdown of the text.
       #
       # text   - The text to analyze as a String
       # params - Parameters Hash
@@ -304,7 +305,7 @@ module Elastomer
         response.body
       end
 
-      # Provides insight into on-going index shard recoveries. Recovery status
+      # Provides insight into ongoing index shard recoveries. Recovery status
       # may be reported for specific indices, or cluster-wide.
       #
       # params - Parameters Hash

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -35,8 +35,8 @@ module Elastomer
       # params - Parameters Hash
       #   :type - optional type mapping as a String
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-exists.html
-      # and http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-types-exists.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-exists.html
+      # and https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-types-exists.html
       #
       # Returns true if the index (or type) exists
       def exists?( params = {} )
@@ -50,7 +50,7 @@ module Elastomer
       # body   - The index settings and mappings as a Hash or a JSON encoded String
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-create-index.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html
       #
       # Returns the response body as a Hash
       def create( body, params = {} )
@@ -62,7 +62,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-delete-index.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html
       #
       # Returns the response body as a Hash
       def delete( params = {} )
@@ -74,7 +74,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-open-close.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
       #
       # Returns the response body as a Hash
       def open( params = {} )
@@ -86,7 +86,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-open-close.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-open-close.html
       #
       # Returns the response body as a Hash
       def close( params = {} )
@@ -98,7 +98,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-get-settings.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-settings.html
       #
       # Returns the response body as a Hash
       def get_settings( params = {} )
@@ -112,7 +112,7 @@ module Elastomer
       # body   - The index settings as a Hash or a JSON encoded String
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-update-settings.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
       #
       # Returns the response body as a Hash
       def update_settings( body, params = {} )
@@ -126,7 +126,7 @@ module Elastomer
       # params - Parameters Hash
       #   :type - specific document type as a String or Array of Strings
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-get-mapping.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html
       #
       # Returns the response body as a Hash
       def get_mapping( params = {} )
@@ -141,7 +141,7 @@ module Elastomer
       # body   - The mapping values to update as a Hash or a JSON encoded String
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-put-mapping.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html
       #
       # Returns the response body as a Hash
       def update_mapping( type, body, params = {} )
@@ -156,7 +156,7 @@ module Elastomer
       # type   - Name of the mapping to update as a String
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-delete-mapping.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-mapping.html
       #
       # Returns the response body as a Hash
       def delete_mapping( type, params = {} )
@@ -168,7 +168,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
       #
       # Returns the response body as a Hash
       def get_aliases( params = {} )
@@ -189,7 +189,7 @@ module Elastomer
       #   index.get_alias("*")       # returns all aliases for the current index
       #   index.get_alias("issue*")  # returns all aliases starting with "issue"
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
       #
       # Returns the response body as a Hash
       def get_alias( name, params = {} )
@@ -208,7 +208,7 @@ module Elastomer
       #
       #   index.add_alias("foo", :routing => "foo")
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
       #
       # Returns the response body as a Hash
       def add_alias( name, params = {} )
@@ -226,7 +226,7 @@ module Elastomer
       #   index.delete_alias("foo")
       #   index.delete_alias(["foo", "bar"])
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-aliases.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
       #
       # Returns the response body as a Hash
       def delete_alias( name, params = {} )
@@ -239,7 +239,7 @@ module Elastomer
       # text   - The text to analyze as a String
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-analyze.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html
       #
       # Returns the response body as a Hash
       def analyze( text, params = {} )
@@ -253,7 +253,7 @@ module Elastomer
       # params - Parameters Hash
       #   :index - set to "_all" to refresh all indices
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-refresh.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
       #
       # Returns the response body as a Hash
       def refresh( params = {} )
@@ -266,7 +266,7 @@ module Elastomer
       # params - Parameters Hash
       #   :index - set to "_all" to flush all indices
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-flush.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html
       #
       # Returns the response body as a Hash
       def flush( params = {} )
@@ -280,7 +280,7 @@ module Elastomer
       # params - Parameters Hash
       #   :index - set to "_all" to optimize all indices
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-optimize.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-optimize.html
       #
       # Returns the response body as a Hash
       def optimize( params = {} )
@@ -296,7 +296,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/0.90/indices-gateway-snapshot.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/0.90/indices-gateway-snapshot.html
       #
       # Returns the response body as a Hash
       def snapshot( params = {} )
@@ -309,7 +309,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-recovery.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-recovery.html
       #
       # Returns the response body as a Hash
       def recovery( params = {} )
@@ -323,7 +323,7 @@ module Elastomer
       # params - Parameters Hash
       #   :index - set to "_all" to clear all index caches
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-clearcache.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-clearcache.html
       #
       # Returns the response body as a Hash
       def clear_cache( params = {} )
@@ -336,7 +336,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-stats.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html
       #
       # Returns the response body as a Hash
       def stats( params = {} )
@@ -351,7 +351,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-status.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-status.html
       #
       # Returns the response body as a Hash
       def status( params = {} )
@@ -364,7 +364,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-segments.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-segments.html
       #
       # Returns the response body as a Hash
       def segments( params = {} )
@@ -377,7 +377,7 @@ module Elastomer
       #
       # type - The document type as a String
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs.html
       #
       # Returns a Docs instance.
       def docs( type = nil )
@@ -403,7 +403,7 @@ module Elastomer
       #     ...
       #   end
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
       #
       # Returns the response body as a Hash
       def bulk( params = {}, &block )
@@ -431,7 +431,7 @@ module Elastomer
       #     document['_source']
       #   end
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
       #
       # Returns a new Scroller instance
       def scroll( query, opts = {} )
@@ -460,7 +460,7 @@ module Elastomer
       #     document['_source']
       #   end
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
       #
       # Returns a new Scroller instance
       def scan( query, opts = {} )
@@ -473,7 +473,7 @@ module Elastomer
       # will be passed to the multi_search API call as part of the request
       # parameters.
       #
-      # See http://www.elasticsearch.org/guide/reference/api/multi-search/
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html
       #
       # params - Parameters Hash that will be passed to the API call.
       # block  - Required block that is used to accumulate searches.
@@ -491,7 +491,7 @@ module Elastomer
       #     ...
       #   end
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-multi-search.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html
       #
       # Returns the response body as a Hash
       def multi_search( params = {}, &block )
@@ -541,7 +541,7 @@ module Elastomer
       #   index.warmer('warmer1').get
       #   index.warmer('warmer1').delete
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-warmers.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-warmers.html
       #
       # Returns a new Warmer instance
       def warmer(warmer_name)

--- a/lib/elastomer/client/multi_search.rb
+++ b/lib/elastomer/client/multi_search.rb
@@ -49,7 +49,7 @@ module Elastomer
     # The MultiSearch class is a helper for accumulating and submitting
     # multi_search API requests. Instances of the MultiSearch class
     # accumulate searches and then issue a single API request to
-    # ElasticSearch, which runs all accumulated searches in parallel
+    # Elasticsearch, which runs all accumulated searches in parallel
     # and returns each result hash aggregated into an array of result
     # hashes.
     #

--- a/lib/elastomer/client/multi_search.rb
+++ b/lib/elastomer/client/multi_search.rb
@@ -8,7 +8,7 @@ module Elastomer
     # the method will perform an API call, and it requires a bulk request
     # body and optional request parameters.
     #
-    # See http://www.elasticsearch.org/guide/reference/api/multi-search/
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html
     #
     # body   - Request body as a String (required if a block is not given)
     # params - Optional request parameters as a Hash

--- a/lib/elastomer/client/nodes.rb
+++ b/lib/elastomer/client/nodes.rb
@@ -45,7 +45,7 @@ module Elastomer
       #   info(:info => "os")
       #   info(:info => %w[os jvm process])
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
       #
       # Returns the response as a Hash
       def info( params = {} )
@@ -65,7 +65,7 @@ module Elastomer
       #   stats(:stats => "thread_pool")
       #   stats(:stats => %w[os process])
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html
       #
       # Returns the response as a Hash
       def stats( params = {} )
@@ -83,7 +83,7 @@ module Elastomer
       #   :interval - sampling interval [default is 500ms]
       #   :type     - the type to sample: "cpu", "wait", or "block"
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-nodes-hot-threads.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-hot-threads.html
       #
       # Returns the response as a String
       def hot_threads( params = {} )
@@ -97,7 +97,7 @@ module Elastomer
       # params - Parameters Hash
       #   :node_id - a single node ID or Array of node IDs
       #
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-nodes-shutdown.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-shutdown.html
       #
       # Returns the response as a Hash
       def shutdown( params = {} )

--- a/lib/elastomer/client/repository.rb
+++ b/lib/elastomer/client/repository.rb
@@ -20,7 +20,7 @@ module Elastomer
       attr_reader :client, :name
 
       # Check for the existence of the repository.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
       #
       # params - Parameters Hash
       #
@@ -38,7 +38,7 @@ module Elastomer
       alias_method :exist?, :exists?
 
       # Create the repository.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
       #
       # body   - The repository type and settings as a Hash or a JSON encoded String
       # params - Parameters Hash
@@ -50,7 +50,7 @@ module Elastomer
       end
 
       # Get repository type and settings.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
       #
       # params - Parameters Hash
       #
@@ -61,7 +61,7 @@ module Elastomer
       end
 
       # Get status information on snapshots in progress.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
       #
       # params - Parameters Hash
       #
@@ -72,7 +72,7 @@ module Elastomer
       end
 
       # Update the repository.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
       #
       # body   - The repository type and settings as a Hash or a JSON encoded String
       # params - Parameters Hash
@@ -84,7 +84,7 @@ module Elastomer
       end
 
       # Delete the repository.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_repositories
       #
       # params - Parameters Hash
       #

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -48,7 +48,7 @@ module Elastomer
     end
 
     # Begin scrolling a query.
-    # See http://www.elasticsearch.org/guide/reference/api/search/scroll/
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
     #
     # opts   - Options Hash
     #   :query       - the query to scroll as a Hash or JSON encoded String
@@ -78,7 +78,7 @@ module Elastomer
     end
 
     # Continue scrolling a query.
-    # See http://www.elasticsearch.org/guide/reference/api/search/scroll/
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
     #
     # scroll_id - The current scroll ID as a String
     # scroll    - The keep alive time of the scrolling request (5 minutes by default)
@@ -113,8 +113,8 @@ module Elastomer
       # returned by the `query`. The Scroller supports both the 'scan' and the
       # 'scroll' search types.
       #
-      # See http://www.elasticsearch.org/guide/reference/api/search/scroll/
-      # and the "Scan" section of http://www.elasticsearch.org/guide/reference/api/search/search-type/
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
+      # and https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-type.html#scan
       #
       # client - Elastomer::Client used for HTTP requests to the server
       # query  - The query to scan as a Hash or a JSON encoded String

--- a/lib/elastomer/client/snapshot.rb
+++ b/lib/elastomer/client/snapshot.rb
@@ -29,7 +29,7 @@ module Elastomer
       attr_reader :client, :repository, :name
 
       # Check for the existence of the snapshot.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
       #
       # params - Parameters Hash
       #
@@ -47,7 +47,7 @@ module Elastomer
       alias_method :exist?, :exists?
 
       # Create the snapshot.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
       #
       # body   - The snapshot options as a Hash or a JSON encoded String
       # params - Parameters Hash
@@ -59,7 +59,7 @@ module Elastomer
       end
 
       # Get snapshot progress information.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
       #
       # params - Parameters Hash
       #
@@ -72,7 +72,7 @@ module Elastomer
       end
 
       # Get detailed snapshot status.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
       #
       # params - Parameters Hash
       #
@@ -83,7 +83,7 @@ module Elastomer
       end
 
       # Restore the snapshot.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
       #
       # body   - The restore options as a Hash or a JSON encoded String
       # params - Parameters Hash
@@ -95,7 +95,7 @@ module Elastomer
       end
 
       # Delete the snapshot.
-      # See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_snapshot
       #
       # params - Parameters Hash
       #

--- a/lib/elastomer/client/template.rb
+++ b/lib/elastomer/client/template.rb
@@ -30,7 +30,7 @@ module Elastomer
       alias_method :exist?, :exists?
 
       # Get the template from the cluster.
-      # See http://www.elasticsearch.org/guide/reference/api/admin-indices-templates/
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#getting
       #
       # params - Parameters Hash
       #
@@ -41,7 +41,7 @@ module Elastomer
       end
 
       # Create the template on the cluster.
-      # See http://www.elasticsearch.org/guide/reference/api/admin-indices-templates/
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
       #
       # template - The template as a Hash or a JSON encoded String
       # params   - Parameters Hash
@@ -53,7 +53,7 @@ module Elastomer
       end
 
       # Delete the template from the cluster.
-      # See http://www.elasticsearch.org/guide/reference/api/admin-indices-templates/
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html#delete
       #
       # params - Parameters Hash
       #

--- a/lib/elastomer/client/warmer.rb
+++ b/lib/elastomer/client/warmer.rb
@@ -17,7 +17,7 @@ module Elastomer
       attr_reader :client, :index_name, :name
 
       # Create a warmer.
-      # See http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-warmers.html
       #
       # query  - The query the warmer should run
       # params - Parameters Hash
@@ -33,7 +33,7 @@ module Elastomer
       end
 
       # Delete a warmer.
-      # See http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-warmers.html#removing
       #
       # params   - Parameters Hash
       #
@@ -44,7 +44,7 @@ module Elastomer
       end
 
       # Get a warmer.
-      # See http://www.elasticsearch.org/guide/reference/api/admin-indices-warmers/
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-warmers.html#warmer-retrieving
       #
       # params   - Parameters Hash
       #

--- a/lib/elastomer/middleware/opaque_id.rb
+++ b/lib/elastomer/middleware/opaque_id.rb
@@ -4,7 +4,7 @@ module Elastomer
   module Middleware
 
     # This Faraday middleware implements the "X-Opaque-Id" request / response
-    # headers for ElasticSearch. The X-Opaque-Id header, when provided on the
+    # headers for Elasticsearch. The X-Opaque-Id header, when provided on the
     # request header, will be returned as a header in the response. This is
     # useful in environments which reuse connections to ensure that cross-talk
     # does not occur between two requests.
@@ -15,7 +15,7 @@ module Elastomer
     # `Elastomer::Client::OpaqueIdError` is raised. In this case no response
     # will be returned.
     #
-    # See [ElasticSearch "X-Opaque-Id"
+    # See [Elasticsearch "X-Opaque-Id"
     # header](https://github.com/elasticsearch/elasticsearch/issues/1202)
     # for more details.
     class OpaqueId < ::Faraday::Middleware

--- a/lib/elastomer/notifications.rb
+++ b/lib/elastomer/notifications.rb
@@ -4,13 +4,13 @@ require "elastomer/client"
 
 module Elastomer
 
-  # So you want to get notifications from your ElasticSearch client? Well,
+  # So you want to get notifications from your Elasticsearch client? Well,
   # you've come to the right place!
   #
   #   require 'elastomer/notifications'
   #
   # Requiring this module will add ActiveSupport notifications to all
-  # ElasticSearch requests. To subscribe to those requests ...
+  # Elasticsearch requests. To subscribe to those requests ...
   #
   #   ActiveSupport::Notifications.subscribe('request.client.elastomer') do |name, start_time, end_time, _, payload|
   #     duration = end_time - start_time
@@ -45,7 +45,7 @@ module Elastomer
     # Internal: Execute the given block and provide instrumentation info to
     # subscribers. The name we use for subscriptions is
     # `request.client.elastomer` and a supplemental payload is provided with
-    # more information about the specific ElasticSearch request.
+    # more information about the specific Elasticsearch request.
     #
     # path   - The full request path as a String
     # body   - The request body as a String or `nil`

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ $client_params = {
 }
 $client = Elastomer::Client.new $client_params
 
-# ensure we have an ElasticSearch server to test with
+# ensure we have an Elasticsearch server to test with
 raise "No server available at #{$client.url}" unless $client.available?
 
 puts "Elasticsearch version is #{$client.version}"
@@ -102,7 +102,7 @@ def es_version_always_returns_aliases?
   $client.semantic_version >= "1.4.3"
 end
 
-# ElasticSearch 1.3 added the `search_shards` API endpoint.
+# Elasticsearch 1.3 added the `search_shards` API endpoint.
 def es_version_supports_search_shards?
   $client.semantic_version >= "1.3.0"
 end


### PR DESCRIPTION
Some housekeeping-related updates to the documentation. Standardize on `Elasticsearch` rather than `ElasticSearch`, update URLs to point to `https://www.elastic.co` rather than `http://www.elasticsearch.org` and fix a few typos.