### PR TITLE
Add support for automatically refreshing indices before reads

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -238,3 +238,13 @@ to add load to a search cluster that might already be experiencing problems.
 Blindly retrying an operation might do more harm than good. It is left to the
 user to implement their own exponential back-off scheme or to implement some
 status / back-pressure system.
+
+### Automatically refreshing indices
+
+The annoyance of having to repeatedly inserting a call to `index.refresh` between writes/reads (especially in tests) can be alleviated by setting `auto_refresh => true` in the client settings:
+
+```ruby
+client = Elastomer::Client.new :auto_refresh => true
+```
+
+When `auto_refresh => true`, `index.refresh` will be called before all read operations.

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -34,10 +34,11 @@ module Elastomer
       @open_timeout = opts.fetch :open_timeout, 2
       @adapter      = opts.fetch :adapter, Faraday.default_adapter
       @opaque_id    = opts.fetch :opaque_id, false
+      @auto_refresh = opts.fetch :auto_refresh, false
     end
 
     attr_reader :host, :port, :url
-    attr_reader :read_timeout, :open_timeout
+    attr_reader :read_timeout, :open_timeout, :auto_refresh
 
     # Returns true if the server is available; returns false otherwise.
     def ping

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -197,6 +197,7 @@ module Elastomer
       def search( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
+        @client.index(@name).refresh if @client.auto_refresh
         response = client.get "/{index}{/type}/_search", update_params(params, :body => query, :action => "docs.search")
         response.body
       end
@@ -242,6 +243,7 @@ module Elastomer
       def count( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
+        @client.index(@name).refresh if @client.auto_refresh
         response = client.get "/{index}{/type}/_count", update_params(params, :body => query, :action => "docs.count")
         response.body
       end
@@ -354,6 +356,7 @@ Percolate
       def more_like_this( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
+        @client.index(@name).refresh if @client.auto_refresh
         response = client.get "/{index}/{type}/{id}/_mlt", update_params(params, :body => query, :action => "docs.more_like_this")
         response.body
       end
@@ -378,6 +381,7 @@ Percolate
       def explain( query, params = nil )
         query, params = extract_params(query) if params.nil?
 
+        @client.index(@name).refresh if @client.auto_refresh
         response = client.get "/{index}/{type}/{id}/_explain", update_params(params, :body => query, :action => "docs.explain")
         response.body
       end

--- a/lib/elastomer/client/multi_search.rb
+++ b/lib/elastomer/client/multi_search.rb
@@ -40,6 +40,7 @@ module Elastomer
         raise "multi_search request body cannot be nil" if body.nil?
         params ||= {}
 
+        index("_all").refresh if @auto_refresh
         response = self.post "{/index}{/type}/_msearch", params.merge(:body => body)
         response.body
       end

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -73,6 +73,7 @@ module Elastomer
     # Returns the response body as a Hash.
     def start_scroll( opts = {} )
       opts = opts.merge :action => "search.start_scroll"
+      index(opts["index"]).refresh if @auto_refresh
       response = get "{/index}{/type}/_search", opts
       response.body
     end

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -48,8 +48,6 @@ describe Elastomer::Client::Bulk do
     assert_bulk_index(h["items"][0])
     assert_bulk_index(h["items"][1])
 
-    @index.refresh
-
     h = @index.docs("tweet").get :id => 1
     assert_equal "pea53", h["_source"]["author"]
 
@@ -68,8 +66,6 @@ describe Elastomer::Client::Bulk do
 
     assert_bulk_index h["items"].first, "expected to index a book"
     assert_bulk_delete h["items"].last, "expected to delete a book"
-
-    @index.refresh
 
     h = @index.docs("book").get :id => 1
     assert !h["exists"], "was not successfully deleted"
@@ -93,8 +89,6 @@ describe Elastomer::Client::Bulk do
     book_id = items.last["create"]["_id"]
     assert_match %r/^\S{20,22}$/, book_id
 
-    @index.refresh
-
     h = @index.docs("tweet").get :id => 1
     assert_equal "pea53", h["_source"]["author"]
 
@@ -113,8 +107,6 @@ describe Elastomer::Client::Bulk do
 
     book_id2 = items.first["create"]["_id"]
     assert_match %r/^\S{20,22}$/, book_id2
-
-    @index.refresh
 
     h = @index.docs("book").get :id => book_id
     assert !h["exists"], "was not successfully deleted"
@@ -135,8 +127,6 @@ describe Elastomer::Client::Bulk do
     assert_bulk_index h["items"].first
     assert_bulk_create h["items"].last
 
-    @index.refresh
-
     h = @index.docs("tweet").get :id => 1
     assert_equal "pea53", h["_source"]["author"]
 
@@ -152,8 +142,6 @@ describe Elastomer::Client::Bulk do
 
     assert_bulk_index h["items"].first, "expected to index a book"
     assert_bulk_delete h["items"].last, "expected to delete a book"
-
-    @index.refresh
 
     h = @index.docs("book").get :id => 1
     assert !h["exists"], "was not successfully deleted"
@@ -187,7 +175,6 @@ describe Elastomer::Client::Bulk do
     assert_equal 4, ary.length
     ary.each { |a| a["items"].each { |b| assert_bulk_index(b) } }
 
-    @index.refresh
     h = @index.docs.search :q => "*:*", :search_type => "count"
 
     assert_equal 10, h["hits"]["total"]
@@ -218,7 +205,6 @@ describe Elastomer::Client::Bulk do
     assert_equal 4, ary.length
     ary.each { |a| a["items"].each { |b| assert_bulk_index(b) } }
 
-    @index.refresh
     h = @index.docs.search :q => "*:*", :search_type => "count"
 
     assert_equal 10, h["hits"]["total"]

--- a/test/client/delete_by_query_test.rb
+++ b/test/client/delete_by_query_test.rb
@@ -22,7 +22,6 @@ describe Elastomer::Client::DeleteByQuery do
       @docs.index({ :_id => 0, :name => "mittens" })
       @docs.index({ :_id => 1, :name => "luna" })
 
-      @index.refresh
       response = @index.delete_by_query(nil, :q => "name:mittens")
       assert_equal({
         "_all" => {
@@ -39,7 +38,6 @@ describe Elastomer::Client::DeleteByQuery do
         },
       }, response["_indices"])
 
-      @index.refresh
       response = @docs.multi_get :ids => [0, 1]
       refute_found response["docs"][0]
       assert_found response["docs"][1]
@@ -48,7 +46,6 @@ describe Elastomer::Client::DeleteByQuery do
     it "respects action_count" do
       @docs.index({ :_id => 0, :name => "mittens" })
       @docs.index({ :_id => 1, :name => "luna" })
-      @index.refresh
 
       response = @index.delete_by_query(nil, :action_count => 1)
 
@@ -69,7 +66,6 @@ describe Elastomer::Client::DeleteByQuery do
         },
       }, response["_indices"])
 
-      @index.refresh
       response = @docs.multi_get :ids => [0, 1]
       refute_found response["docs"][0]
       refute_found response["docs"][1]
@@ -94,7 +90,6 @@ describe Elastomer::Client::DeleteByQuery do
                   "found" => false } }] }) }
         end)
 
-      @index.refresh
       response = @index.delete_by_query(nil, :action_count => 1)
       assert_equal({
         "_all" => {
@@ -130,7 +125,6 @@ describe Elastomer::Client::DeleteByQuery do
                   "error" => "VersionConflictEngineException" } }] }) }
         end)
 
-      @index.refresh
       response = @index.delete_by_query(nil, :action_count => 1)
       assert_equal({
         "_all" => {

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -228,7 +228,6 @@ describe Elastomer::Client::Docs do
         "failed" => 0,
       },
     })
-    @index.refresh
     h = @docs.multi_get :ids => [1, 2]
     assert_found h["docs"][0]
     refute_found h["docs"][1]
@@ -247,7 +246,6 @@ describe Elastomer::Client::Docs do
               }
             }
           )
-      @index.refresh
       h = @docs.multi_get :ids => [1, 2]
       refute_found h["docs"][0]
       refute_found h["docs"][1]
@@ -334,8 +332,6 @@ describe Elastomer::Client::Docs do
       :_type  => "doc1",
       :title  => "the author of faraday",
       :author => "technoweenie"
-
-    @index.refresh
 
     h = @docs.more_like_this({
       :type => "doc1",
@@ -623,8 +619,6 @@ describe Elastomer::Client::Docs do
       :_type  => "doc2",
       :title  => "the author of rubber-band",
       :author => "grantr"
-
-    @index.refresh
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -123,8 +123,6 @@ describe Elastomer::Client::MultiPercolate do
     percolator2.create :query => { :match => { :author => "pea53" } }
     percolator2 = @index.percolator "3"
     percolator2.create :query => { :match => { :author => "grantr" } }
-
-    @index.refresh
   end
   # rubocop:enable Metrics/MethodLength
 end

--- a/test/client/multi_search_test.rb
+++ b/test/client/multi_search_test.rb
@@ -153,8 +153,6 @@ describe Elastomer::Client::MultiSearch do
       :_type  => "doc2",
       :title  => "the author of rubber-band",
       :author => "grantr"
-
-    @index.refresh
   end
   # rubocop:enable Metrics/MethodLength
 end

--- a/test/client/scroller_test.rb
+++ b/test/client/scroller_test.rb
@@ -107,7 +107,5 @@ describe Elastomer::Client::Scroller do
       }
     end
     h["items"].each {|item| assert_bulk_index(item) }
-
-    @index.refresh
   end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -152,4 +152,18 @@ describe Elastomer::Client do
       assert_equal Semantic::Version.new(version_string), $client.semantic_version
     end
   end
+
+  it "supports automatically refreshing the index before each search" do
+    name = "elastomer-auto-refresh-test"
+    index = $client.index(name)
+    docs = index.docs("sometype")
+
+    index.delete() if index.exists?()
+    index.create(nil)
+    wait_for_index(name)
+    index.update_settings({:index => {"refresh_interval" => -1}})
+
+    docs.index({:_id => 1})
+    assert_equal(docs.search({:query => {:match_all => {}}})["hits"]["hits"].length, 1)
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,8 @@ $client_params = {
   :port => ENV["BOXEN_ELASTICSEARCH_PORT"] || 9200,
   :read_timeout => 10,
   :open_timeout => 1,
-  :opaque_id => false
+  :opaque_id => false,
+  :auto_refresh => true
 }
 $client = Elastomer::Client.new $client_params
 


### PR DESCRIPTION
This `auto_refresh` client setting alleviates the annoyance of having to repeatedly call `index.refresh` between writes/reads (especially in tests).

Closes #128.
