### PR TITLE
Suggest endpoint

### DIFF
--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -385,6 +385,19 @@ module Elastomer
         client.docs name, type
       end
 
+      # Exposes the `/_suggest` endpoint of the Elasticsearch API.
+      #
+      # query  - The query body as a Hash
+      # params - Parameters Hash
+      #
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html
+      #
+      # Returns the response body as a Hash
+      def suggest(query, params = {})
+        response = client.post "{/index}/_suggest", update_params(params, :body => query, :action => "index.suggest")
+        response.body
+      end
+
       # Perform bulk indexing and/or delete operations. The current index name
       # will be passed to the bulk API call as part of the request parameters.
       #

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,11 @@
+require "rubygems" unless defined? Gem
+require "bundler"
+Bundler.require(:default, :development)
+
 require "webmock/minitest"
 WebMock.allow_net_connect!
 
 require "securerandom"
-require "rubygems" unless defined? Gem
-require "bundler"
-Bundler.require(:default, :development)
 
 if ENV["COVERAGE"] == "true"
   require "simplecov"


### PR DESCRIPTION
This PR adds support for the [suggesters API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html) in Elasticsearch.

/cc @chrismwendt @grantr 