### PR TITLE
Default bulk streaming request_size to 10MB

### DIFF
--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -174,7 +174,7 @@ module Elastomer
         @actions = []
         @current_request_size = 0
         @current_action_count = 0
-        self.request_size = params.delete(:request_size)
+        self.request_size = params.delete(:request_size) || 10 * 1024 * 1024
         self.action_count = params.delete(:action_count)
       end
 

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -158,6 +158,7 @@ module Elastomer
     # immediately.
     #
     class Bulk
+      DEFAULT_REQUEST_SIZE = 10 * 2**20 # 10 MB
 
       # Create a new bulk client for handling some of the details of
       # accumulating documents to index and then formatting them properly for
@@ -174,7 +175,7 @@ module Elastomer
         @actions = []
         @current_request_size = 0
         @current_action_count = 0
-        self.request_size = params.delete(:request_size) || 10 * 1024 * 1024
+        self.request_size = params.delete(:request_size) || DEFAULT_REQUEST_SIZE
         self.action_count = params.delete(:action_count)
       end
 


### PR DESCRIPTION
I keep getting bit by a hanging process, only to find that I forgot to set the `request_size` when streaming bulk operations. This sets a default `request_size` of 10MB.

cc @github/search