### PR TITLE
Preparing release 2.0.0

### DIFF
--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,5 +1,5 @@
 module Elastomer
-  VERSION = "0.9.0"
+  VERSION = "2.0.0"
 
   def self.version
     VERSION


### PR DESCRIPTION
This release of `elastomer-client` is now compatible with the ES 2.X main major version. The decision was made to sync up the client version number with the Elasticsearch version number - at least the major number. Hence the jump from 0.9.0 to 2.0.0

/cc @chrismwendt @grantr 