### PR TITLE
Fix delete by query with required routing

### DIFF
--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -106,7 +106,7 @@ module Elastomer
       def execute
         ops = Enumerator.new do |yielder|
           @client.scan(@query, @params.merge(:_source => false)).each_document do |hit|
-            yielder.yield([:delete, { :_id => hit["_id"], :_type => hit["_type"], :_index => hit["_index"] }])
+            yielder.yield([:delete, hit.select { |key, _| ["_index", "_type", "_id", "_routing"].include?(key) }])
           end
         end
 

--- a/test/client/delete_by_query_test.rb
+++ b/test/client/delete_by_query_test.rb
@@ -156,8 +156,8 @@ describe Elastomer::Client::DeleteByQuery do
       wait_for_index(@index.name)
       docs = index.docs(type)
 
-      docs.index({ :_id => 0, :name => "mittens" })
-      docs.index({ :_id => 1, :name => "luna" })
+      docs.index({ :_id => 0, :_routing => "cat", :name => "mittens" })
+      docs.index({ :_id => 1, :_routing => "cat", :name => "luna" })
 
       index.refresh
       response = index.delete_by_query(nil, :q => "name:mittens")
@@ -177,7 +177,12 @@ describe Elastomer::Client::DeleteByQuery do
       }, response["_indices"])
 
       index.refresh
-      response = docs.multi_get :ids => [0, 1]
+      response = docs.multi_get({
+        :docs => [
+          { :_id => 0, :_routing => "cat" },
+          { :_id => 1, :_routing => "cat" },
+        ]
+      })
       refute_found response["docs"][0]
       assert_found response["docs"][1]
 

--- a/test/client/delete_by_query_test.rb
+++ b/test/client/delete_by_query_test.rb
@@ -147,5 +147,41 @@ describe Elastomer::Client::DeleteByQuery do
         },
       }, response["_indices"])
     end
+
+    it "deletes by query when routing is specified" do
+      index = $client.index "elastomer-delete-by-query-routing-test"
+      index.delete if index.exists?
+      type = "docs"
+      index.create({ :mappings => { type => { :_routing => { :required => true } } } })
+      wait_for_index(@index.name)
+      docs = index.docs(type)
+
+      docs.index({ :_id => 0, :name => "mittens" })
+      docs.index({ :_id => 1, :name => "luna" })
+
+      index.refresh
+      response = index.delete_by_query(nil, :q => "name:mittens")
+      assert_equal({
+        "_all" => {
+          "found" => 1,
+          "deleted" => 1,
+          "missing" => 0,
+          "failed" => 0,
+        },
+        index.name => {
+          "found" => 1,
+          "deleted" => 1,
+          "missing" => 0,
+          "failed" => 0,
+        },
+      }, response["_indices"])
+
+      index.refresh
+      response = docs.multi_get :ids => [0, 1]
+      refute_found response["docs"][0]
+      assert_found response["docs"][1]
+
+      index.delete if index.exists?
+    end
   end
 end


### PR DESCRIPTION
This fixes delete by query when routing is required.

In ES 1.x, `_routing` is not required when deleting a document, and `_routing` is not returned in query results.

In ES 2.x, `_routing` is required when deleting a document if the mapping requires `_routing`, and `_routing` is returned in query results.