### PR TITLE
Enforce request size limits

### DIFF
--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -81,6 +81,7 @@ module Elastomer
     SSLError         = Class.new Error
     ServerError      = Class.new Error
     RequestError     = Class.new Error
+    RequestSizeError = Class.new Error
 
     ServerError.fatal      = false
     TimeoutError.fatal     = false

--- a/lib/elastomer/middleware/limit_size.rb
+++ b/lib/elastomer/middleware/limit_size.rb
@@ -1,0 +1,30 @@
+module Elastomer
+  module Middleware
+
+    # Request middleware that raises an exception if the request body exceeds a
+    # `max_request_size`.
+    class LimitSize < Faraday::Middleware
+
+      def initialize(app = nil, options = {})
+        super(app)
+        @max_request_size = options.fetch(:max_request_size)
+      end
+
+      attr_reader :max_request_size
+
+      def call(env)
+        if body = env[:body]
+          if body.is_a?(String) && body.bytesize > max_request_size
+            raise ::Elastomer::Client::RequestSizeError,
+              "Request of size `#{body.bytesize}` exceeds the maximum requst size: #{max_request_size}"
+          end
+        end
+        @app.call(env)
+      end
+
+    end
+  end
+end
+
+Faraday::Request.register_middleware \
+  :limit_size => ::Elastomer::Middleware::LimitSize

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -177,14 +177,14 @@ describe Elastomer::Client::Bulk do
         ary << b.index(document)
       }
       ary.compact!
-      assert_equal 3, ary.length
+      assert_equal 4, ary.length
 
       document = {:_id => 10, :_type => "tweet", :author => "pea53", :message => "tweet 10 is a 102 character request"}
       ary << b.index(document)
     end
     ary.compact!
 
-    assert_equal 4, ary.length
+    assert_equal 5, ary.length
     ary.each { |a| a["items"].each { |b| assert_bulk_index(b) } }
 
     @index.refresh
@@ -208,7 +208,7 @@ describe Elastomer::Client::Bulk do
         ary << b.index(document)
       }
       ary.compact!
-      assert_equal 3, ary.length
+      assert_equal 2, ary.length
 
       document = {:_id => 10, :_type => "tweet", :author => "pea53", :message => "this is tweet number 10"}
       ary << b.index(document)


### PR DESCRIPTION
The goal of this PR is to add some default request size limits to elastomer client. Currently with our `bulk` indexing layer, it is possible to send very very large requests to Elasticsearch - multi-gigabyte requests.

This PR implements a `limit_size` request middleware that will raise a `RequestSizeError` if the request body exceeds a a `max_request_size`. This limit defaults to 250 MB, but it is configurable when the `Elastomer::Client` is first created.

This PR also reworks the criteria determining when an actual bulk request is set. As bulk request actions are accumulated, we now perform a pre-check on the request size to ensure that a large document does not push any single bulk request above this request size. Any single document that is larger than the request size will also raise a `RequestSizeError` exception.

/cc @chrismwendt @grantr 