### PR TITLE
Exception wrapping

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -313,7 +313,8 @@ module Elastomer
         elsif error.is_a?(String)
           case error
           when %r/IndexMissingException/; raise IndexNotFoundError, response
-          when %/QueryParsingException/; raise QueryParsingError, response
+          when %r/QueryParsingException/; raise QueryParsingError, response
+          when %r/ParseException/; raise QueryParsingError, response
           end
         end
 

--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -83,6 +83,9 @@ module Elastomer
     RequestError     = Class.new Error
     RequestSizeError = Class.new Error
 
+    # Provide some nice errors for common Elasticsearch exceptions.
+    IndexNotFoundError = Class.new Error
+
     ServerError.fatal      = false
     TimeoutError.fatal     = false
     ConnectionFailed.fatal = false

--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -83,8 +83,10 @@ module Elastomer
     RequestError     = Class.new Error
     RequestSizeError = Class.new Error
 
-    # Provide some nice errors for common Elasticsearch exceptions.
-    IndexNotFoundError = Class.new Error
+    # Provide some nice errors for common Elasticsearch exceptions. These are
+    # all subclasses of the more general RequestError
+    IndexNotFoundError = Class.new RequestError
+    QueryParsingError  = Class.new RequestError
 
     ServerError.fatal      = false
     TimeoutError.fatal     = false

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -279,6 +279,14 @@ describe Elastomer::Client::Docs do
     end
   end
 
+  it "generates QueryParsingError exceptions on bad input when searching" do
+    query = {:query => {:query_string => {:query => "OR should fail"}}}
+    assert_raises(Elastomer::Client::QueryParsingError) { @docs.search(query, :type => %w[doc1 doc2]) }
+
+    query = {:query => {:foo_is_not_value => {}}}
+    assert_raises(Elastomer::Client::QueryParsingError) { @docs.search(query, :type => %w[doc1 doc2]) }
+  end
+
   it "counts documents" do
     h = @docs.count :q => "*:*"
     assert_equal 0, h["count"]

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -283,7 +283,7 @@ describe Elastomer::Client::Docs do
     query = {:query => {:query_string => {:query => "OR should fail"}}}
     assert_raises(Elastomer::Client::QueryParsingError) { @docs.search(query, :type => %w[doc1 doc2]) }
 
-    query = {:query => {:foo_is_not_value => {}}}
+    query = {:query => {:foo_is_not_valid => {}}}
     assert_raises(Elastomer::Client::QueryParsingError) { @docs.search(query, :type => %w[doc1 doc2]) }
   end
 

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -259,6 +259,13 @@ describe Elastomer::Client::Index do
     assert_equal %w[just few words analyze], tokens
   end
 
+  describe "when an index does not exist" do
+    it "raises an IndexNotFoundError on delete" do
+      index = $client.index("index-that-does-not-exist")
+      assert_raises(Elastomer::Client::IndexNotFoundError) { index.delete }
+    end
+  end
+
   describe "when an index exists" do
     before do
       suggest = {


### PR DESCRIPTION
This PR is aimed at adding some exception wrappers around common error responses from Elasticsearch. The problem is that in some of our error handling code we have lines like this:
    
```ruby
rescue StandardError => err
  if err.message =~ %r/IndexMissingException|index_not_found_exception/
    # do someting here
  end
```
    
A better approach is to rescue a named exception and not worry about using a regular expression on the error message to figure out what the problem actually is.

/cc @chrismwendt @grantr 