### PR TITLE
Freeze the body to prevent excon from changing its encoding

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -162,6 +162,9 @@ module Elastomer
       body = extract_body params
       path = expand_path path, params
 
+      # prevent excon from changing the encoding
+      body.freeze
+
       instrument(path, body, params) do
         begin
           response =

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -162,7 +162,7 @@ module Elastomer
       body = extract_body params
       path = expand_path path, params
 
-      # prevent excon from changing the encoding
+      # Prevent excon from changing the encoding (see https://github.com/github/elastomer-client/issues/138)
       body.freeze
 
       instrument(path, body, params) do

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -162,9 +162,6 @@ module Elastomer
       body = extract_body params
       path = expand_path path, params
 
-      # Prevent excon from changing the encoding (see https://github.com/github/elastomer-client/issues/138)
-      body.freeze
-
       instrument(path, body, params) do
         begin
           response =
@@ -234,7 +231,7 @@ module Elastomer
         body.join "\n"
       else
         MultiJson.dump body
-      end
+      end.freeze # Prevent excon from changing the encoding (see https://github.com/github/elastomer-client/issues/138)
     end
 
     # Internal: Apply path expansions to the `path` and append query

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -223,15 +223,19 @@ module Elastomer
       body = params.delete :body
       return if body.nil?
 
-      case body
-      when String
-        body
-      when Array
-        body << nil unless body.last.nil?
-        body.join "\n"
-      else
-        MultiJson.dump body
-      end.freeze # Prevent excon from changing the encoding (see https://github.com/github/elastomer-client/issues/138)
+      body =
+        case body
+        when String
+          body
+        when Array
+          body << nil unless body.last.nil?
+          body.join "\n"
+        else
+          MultiJson.dump body
+        end
+
+      # Prevent excon from changing the encoding (see https://github.com/github/elastomer-client/issues/138)
+      body.freeze
     end
 
     # Internal: Apply path expansions to the `path` and append query

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -97,6 +97,20 @@ describe Elastomer::Client do
       body = $client.extract_body :body => {:query => {:match_all => {}}}
       assert_equal '{"query":{"match_all":{}}}', body
     end
+
+    it "returns frozen strings" do
+      body = $client.extract_body :body => '{"query":{"match_all":{}}}'
+      assert_equal '{"query":{"match_all":{}}}', body
+      assert body.frozen?, "the body string should be frozen"
+
+      body = $client.extract_body :body => %w[foo bar baz]
+      assert_equal "foo\nbar\nbaz\n", body
+      assert body.frozen?, "Array body strings should be frozen"
+
+      body = $client.extract_body :body => {:query => {:match_all => {}}}
+      assert_equal '{"query":{"match_all":{}}}', body
+      assert body.frozen?, "JSON encoded body strings should be frozen"
+    end
   end
 
   describe "when validating parameters" do


### PR DESCRIPTION
This prevents excon from [changing the encoding of the body](https://github.com/excon/excon/blob/v0.32.1/lib/excon/connection.rb#L183), causing downstream encoding compatibility errors.

Fixes #138

/cc @github/search