### PR TITLE
Add 'Content-Type' for empty request bodies

### DIFF
--- a/lib/elastomer/middleware/encode_json.rb
+++ b/lib/elastomer/middleware/encode_json.rb
@@ -23,8 +23,8 @@ module Elastomer
       end
 
       def match_content_type(env)
+        add_content_type!(env)
         if process_request?(env)
-          env[:request_headers][CONTENT_TYPE] ||= MIME_TYPE
           yield env[:body] unless env[:body].respond_to?(:to_str)
         end
       end
@@ -42,6 +42,13 @@ module Elastomer
         type = env[:request_headers][CONTENT_TYPE].to_s
         type = type.split(";", 2).first if type.index(";")
         type
+      end
+
+      def add_content_type!(env)
+        method = env[:method]
+        if method == :put || method == :post || has_body?(env)
+          env[:request_headers][CONTENT_TYPE] ||= MIME_TYPE
+        end
       end
     end
   end

--- a/test/middleware/encode_json_test.rb
+++ b/test/middleware/encode_json_test.rb
@@ -3,8 +3,8 @@ require File.expand_path("../../test_helper", __FILE__)
 describe Elastomer::Middleware::EncodeJson do
   let(:middleware) { Elastomer::Middleware::EncodeJson.new(lambda {|env| env})}
 
-  def process(body, content_type = nil)
-    env = { :body => body, :request_headers => Faraday::Utils::Headers.new }
+  def process(body, content_type: nil, method: :post)
+    env = { :body => body, :request_headers => Faraday::Utils::Headers.new, method: method }
     env[:request_headers]["content-type"] = content_type if content_type
     middleware.call(env)
   end
@@ -12,11 +12,19 @@ describe Elastomer::Middleware::EncodeJson do
   it "handles no body" do
     result = process(nil)
     assert_nil result[:body]
+    assert_equal "application/json", result[:request_headers]["content-type"]
+
+    result = process(nil, method: :get)
+    assert_nil result[:body]
     assert_nil result[:request_headers]["content-type"]
   end
 
   it "handles empty body" do
     result = process("")
+    assert_empty result[:body]
+    assert_equal "application/json", result[:request_headers]["content-type"]
+
+    result = process("", method: :get)
     assert_empty result[:body]
     assert_nil result[:request_headers]["content-type"]
   end
@@ -40,13 +48,13 @@ describe Elastomer::Middleware::EncodeJson do
   end
 
   it "handles object body with json type" do
-    result = process({:a => 1}, "application/json; charset=utf-8")
+    result = process({:a => 1}, content_type: "application/json; charset=utf-8")
     assert_equal '{"a":1}', result[:body]
     assert_equal "application/json; charset=utf-8", result[:request_headers]["content-type"]
   end
 
   it "handles object body with incompatible type" do
-    result = process({:a => 1}, "application/xml; charset=utf-8")
+    result = process({:a => 1}, content_type: "application/xml; charset=utf-8")
     assert_equal({:a => 1}, result[:body])
     assert_equal "application/xml; charset=utf-8", result[:request_headers]["content-type"]
   end


### PR DESCRIPTION
If a `PUT` or `POST` request does not have a body, we still need to add a 'Content-Type' to the HTTP request headers. This change accounts for that condition.

This will clear up the warnings about missing 'Content-Type' that are being emitted by the `net/http` library.

/cc @look 