### PR TITLE
Fix warnings

### DIFF
--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -427,7 +427,7 @@ describe Elastomer::Client::Docs do
       populate!(b)
     end
 
-    assert_instance_of Integer, response["took"]
+    assert_kind_of Integer, response["took"]
 
     response = @docs.get(:id => 1, :type => "doc1")
     assert_found response

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -427,7 +427,7 @@ describe Elastomer::Client::Docs do
       populate!(b)
     end
 
-    assert_instance_of Fixnum, response["took"]
+    assert_instance_of Integer, response["took"]
 
     response = @docs.get(:id => 1, :type => "doc1")
     assert_found response

--- a/test/client/percolator_test.rb
+++ b/test/client/percolator_test.rb
@@ -15,7 +15,7 @@ describe Elastomer::Client::Percolator do
   describe "when an index exists" do
     before do
       @index.create(nil)
-      wait_for_index(@index_name)
+      wait_for_index(@index.name)
     end
 
     it "creates a query" do


### PR DESCRIPTION
This PR cleans up some warnings that were being emitted during test runs. The tests are now clean on ES 2.4

/cc @look && @elireisman 