### PR TITLE
Removing ES 1.X code paths

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -67,9 +67,7 @@ The event namespace is `request.client.elastomer`.
 - index.recovery
 - index.refresh
 - index.segments
-- index.snapshot
 - index.stats
-- index.status
 - index.update_mapping
 - index.update_settings
 - nodes.hot_threads

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -41,7 +41,6 @@ The event namespace is `request.client.elastomer`.
 - docs.explain
 - docs.get
 - docs.index
-- docs.more_like_this
 - docs.multi_get
 - docs.multi_termvectors
 - docs.search

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -56,7 +56,6 @@ The event namespace is `request.client.elastomer`.
 - index.create
 - index.delete
 - index.delete_alias
-- index.delete_mapping
 - index.exists
 - index.flush
 - index.get_alias

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -331,33 +331,6 @@ module Elastomer
 Percolate
 =end
 
-      # Deprecated - use the More Like This query: https://www.elastic.co/guide/en/elasticsearch/reference/2.3/query-dsl-mlt-query.html
-      # Search for documents similar to a specific document. The
-      # document :id is provided as part of the params hash. If the _all field
-      # is not enabled, :mlt_fields must be passed. A query cannot be present in
-      # the query body, but other fields like :size and :facets are allowed.
-      #
-      # params - Parameters Hash
-      #   :id - the ID of the document
-      #
-      # Examples
-      #
-      #   more_like_this(:mlt_fields => "title", :min_term_freq => 1, :type => "doc1", :id => 1)
-      #
-      #   # with query hash
-      #   more_like_this({:from => 5, :size => 10}, :mlt_fields => "title",
-      #                   :min_term_freq => 1, :type => "doc1", :id => 1)
-      #
-      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-more-like-this.html
-      #
-      # Returns the response body as a hash
-      def more_like_this( query, params = nil )
-        query, params = extract_params(query) if params.nil?
-
-        response = client.get "/{index}/{type}/{id}/_mlt", update_params(params, :body => query, :action => "docs.more_like_this")
-        response.body
-      end
-
       # Compute a score explanation for a query and a specific document. This
       # can give useful feedback about why a document matched or didn't match
       # a query. The document :id is provided as part of the params hash.

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -275,22 +275,6 @@ module Elastomer
         response.body
       end
 
-      # Deprecated: Explicitly snapshot (backup) one or more indices to the
-      # gateway. By default this happens periodically (every 1 second) but the
-      # period can be changed or disabled completely.
-      #
-      # This API was removed in ES 1.2.
-      #
-      # params - Parameters Hash
-      #
-      # See https://www.elastic.co/guide/en/elasticsearch/reference/0.90/indices-gateway-snapshot.html
-      #
-      # Returns the response body as a Hash
-      def snapshot( params = {} )
-        response = client.post "{/index}/_gateway/snapshot", update_params(params, :action => "index.snapshot")
-        response.body
-      end
-
       # Provides insight into ongoing index shard recoveries. Recovery status
       # may be reported for specific indices, or cluster-wide.
       #
@@ -334,21 +318,6 @@ module Elastomer
       # Returns the response body as a Hash
       def stats( params = {} )
         response = client.get "{/index}/_stats{/stats}", update_params(params, :action => "index.stats")
-        response.body
-      end
-
-      # Deprecated: Retrieve the status of one or more indices. Recovery and
-      # snapshot status can be retrieved with parameters.
-      #
-      # This API was deprecated in 1.2 and is slated for removal.
-      #
-      # params - Parameters Hash
-      #
-      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-status.html
-      #
-      # Returns the response body as a Hash
-      def status( params = {} )
-        response = client.get "{/index}/_status", update_params(params, :action => "index.status")
         response.body
       end
 

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -150,24 +150,6 @@ module Elastomer
       end
       alias_method :put_mapping, :update_mapping
 
-      # DEPRECATED: It is no longer possible to delete the mapping for a type.
-      # Instead you should delete the index and recreate it with new mappings.
-      # See https://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-delete-mapping.html
-      #
-      # Delete the mapping identified by `type`. This deletes all documents of
-      # that type from the index.
-      #
-      # type   - Name of the mapping to update as a String
-      # params - Parameters Hash
-      #
-      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-mapping.html
-      #
-      # Returns the response body as a Hash
-      def delete_mapping( type, params = {} )
-        response = client.delete "/{index}/{type}", update_params(params, :type => type, :action => "index.delete_mapping")
-        response.body
-      end
-
       # Return the aliases associated with this index.
       #
       # params - Parameters Hash

--- a/lib/elastomer/client/repository.rb
+++ b/lib/elastomer/client/repository.rb
@@ -29,7 +29,7 @@ module Elastomer
         response = client.get "/_snapshot{/repository}", update_params(params, :action => "repository.exists")
         response.success?
       rescue Elastomer::Client::Error => err
-        if err.error && err.error["type"] == "repository_missing_exception"
+        if err.error && err.error.dig("root_cause", 0, "type") == "repository_missing_exception"
           false
         else
           raise err

--- a/lib/elastomer/client/repository.rb
+++ b/lib/elastomer/client/repository.rb
@@ -28,11 +28,11 @@ module Elastomer
       def exists?(params = {})
         response = client.get "/_snapshot{/repository}", update_params(params, :action => "repository.exists")
         response.success?
-      rescue Elastomer::Client::Error => exception
-        if exception.message =~ /RepositoryMissingException/
+      rescue Elastomer::Client::Error => err
+        if err.error && err.error["type"] == "repository_missing_exception"
           false
         else
-          raise exception
+          raise err
         end
       end
       alias_method :exist?, :exists?

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -102,8 +102,7 @@ module Elastomer
       response = get "/_search/scroll", :body => scroll_id, :scroll => scroll, :action => "search.scroll"
       response.body
     rescue RequestError => err
-      if err.error && err.error["caused_by"]["type"] == "search_context_missing_exception" \
-      || err.message =~ /SearchContextMissingException/
+      if err.error && err.error["caused_by"]["type"] == "search_context_missing_exception"
         raise SearchContextMissing, "No search context found for scroll ID #{scroll_id.inspect}"
       else
         raise err

--- a/lib/elastomer/client/snapshot.rb
+++ b/lib/elastomer/client/snapshot.rb
@@ -37,11 +37,11 @@ module Elastomer
       def exists?(params = {})
         response = client.get "/_snapshot/{repository}/{snapshot}", update_params(params, :action => "snapshot.exists")
         response.success?
-      rescue Elastomer::Client::Error => exception
-        if exception.message =~ /SnapshotMissingException/
+      rescue Elastomer::Client::Error => err
+        if err.error && err.error.dig("root_cause", 0, "type") == "snapshot_missing_exception"
           false
         else
-          raise exception
+          raise err
         end
       end
       alias_method :exist?, :exists?

--- a/test/client/cluster_test.rb
+++ b/test/client/cluster_test.rb
@@ -27,19 +27,17 @@ describe Elastomer::Client::Cluster do
     assert_instance_of Hash, h["metadata"], "the metadata are returned"
   end
 
-  if es_version_1_x?
-    it "filters cluster state by metrics" do
-      h = @cluster.state(:metrics => "nodes")
-      refute h.key("metadata"), "expected only nodes state"
-      h = @cluster.state(:metrics => "metadata")
-      refute h.key("nodes"), "expected only metadata state"
-    end
+  it "filters cluster state by metrics" do
+    h = @cluster.state(metrics: "nodes")
+    refute h.key("metadata"), "expected only nodes state"
+    h = @cluster.state(metrics: "metadata")
+    refute h.key("nodes"), "expected only metadata state"
+  end
 
-    it "filters cluster state by indices" do
-      @index.create({}) unless @index.exists?
-      h = @cluster.state(:metrics => "metadata", :indices => @name)
-      assert [@name], h["metadata"]["indices"].keys
-    end
+  it "filters cluster state by indices" do
+    @index.create(default_index_settings) unless @index.exists?
+    h = @cluster.state(metrics: "metadata", indices: @name)
+    assert [@name], h["metadata"]["indices"].keys
   end
 
   it "gets the cluster settings" do
@@ -55,13 +53,13 @@ describe Elastomer::Client::Cluster do
   end
 
   it "updates the cluster settings" do
-    @cluster.update_settings :transient => { "indices.ttl.interval" => "30m" }
+    @cluster.update_settings transient: { "indices.ttl.interval" => "30m" }
     h = @cluster.settings
 
     value = h["transient"]["indices"]["ttl"]["interval"]
     assert_equal "30m", value
 
-    @cluster.update_settings :transient => { "indices.ttl.interval" => "60m" }
+    @cluster.update_settings transient: { "indices.ttl.interval" => "60m" }
     h = @cluster.settings
 
     value = h["transient"]["indices"]["ttl"]["interval"]
@@ -82,7 +80,7 @@ describe Elastomer::Client::Cluster do
   end
 
   it "returns the list of indices in the cluster" do
-    @index.create({}) unless @index.exists?
+    @index.create(default_index_settings) unless @index.exists?
     indices = @cluster.indices
     assert !indices.empty?, "expected to see an index"
   end
@@ -96,7 +94,7 @@ describe Elastomer::Client::Cluster do
     before do
       @name = "elastomer-cluster-test"
       @index = $client.index @name
-      @index.create({}) unless @index.exists?
+      @index.create(default_index_settings) unless @index.exists?
       wait_for_index(@name)
     end
 
@@ -111,7 +109,7 @@ describe Elastomer::Client::Cluster do
       end
 
       @cluster.update_aliases \
-        :add => {:index => @name, :alias => "elastomer-test-unikitty"}
+        add: {index: @name, alias: "elastomer-test-unikitty"}
 
       hash = @cluster.get_aliases
       assert_equal ["elastomer-test-unikitty"], hash[@name]["aliases"].keys
@@ -124,7 +122,7 @@ describe Elastomer::Client::Cluster do
       end
 
       @cluster.update_aliases \
-        :add => {:index => @name, :alias => "elastomer-test-unikitty"}
+        add: {index: @name, alias: "elastomer-test-unikitty"}
 
       hash = @cluster.aliases
       assert_equal ["elastomer-test-unikitty"], hash[@name]["aliases"].keys
@@ -132,14 +130,14 @@ describe Elastomer::Client::Cluster do
 
     it "removes an alias" do
       @cluster.update_aliases \
-        :add => {:index => @name, :alias => "elastomer-test-unikitty"}
+        add: {index: @name, alias: "elastomer-test-unikitty"}
 
       hash = @cluster.get_aliases
       assert_equal ["elastomer-test-unikitty"], hash[@name]["aliases"].keys
 
       @cluster.update_aliases([
-        {:add    => {:index => @name, :alias => "elastomer-test-SpongeBob-SquarePants"}},
-        {:remove => {:index => @name, :alias => "elastomer-test-unikitty"}}
+        {add:    {index: @name, alias: "elastomer-test-SpongeBob-SquarePants"}},
+        {remove: {index: @name, alias: "elastomer-test-unikitty"}}
       ])
 
       hash = @cluster.get_aliases
@@ -147,12 +145,12 @@ describe Elastomer::Client::Cluster do
     end
 
     it "accepts the full aliases actions hash" do
-      @cluster.update_aliases :actions => [
-        {:add => {:index => @name, :alias => "elastomer-test-He-Man"}},
-        {:add => {:index => @name, :alias => "elastomer-test-Skeletor"}}
+      @cluster.update_aliases actions: [
+        {add: {index: @name, alias: "elastomer-test-He-Man"}},
+        {add: {index: @name, alias: "elastomer-test-Skeletor"}}
       ]
 
-      hash = @cluster.get_aliases(:index => @name)
+      hash = @cluster.get_aliases(index: @name)
       assert_equal %w[elastomer-test-He-Man elastomer-test-Skeletor], hash[@name]["aliases"].keys.sort
     end
   end

--- a/test/client/cluster_test.rb
+++ b/test/client/cluster_test.rb
@@ -104,9 +104,7 @@ describe Elastomer::Client::Cluster do
 
     it "adds and gets an alias" do
       hash = @cluster.get_aliases
-      if es_version_always_returns_aliases?
-        assert_empty hash[@name]["aliases"]
-      end
+      assert_empty hash[@name]["aliases"]
 
       @cluster.update_aliases \
         add: {index: @name, alias: "elastomer-test-unikitty"}
@@ -117,9 +115,7 @@ describe Elastomer::Client::Cluster do
 
     it "adds and gets an alias with .aliases" do
       hash = @cluster.aliases
-      if es_version_always_returns_aliases?
-        assert_empty hash[@name]["aliases"]
-      end
+      assert_empty hash[@name]["aliases"]
 
       @cluster.update_aliases \
         add: {index: @name, alias: "elastomer-test-unikitty"}

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -313,48 +313,6 @@ describe Elastomer::Client::Docs do
     assert_equal 1, h["count"]
   end
 
-  # The /_mlt endpoint has been removed from ES 2.X
-  if es_version_1_x?
-    it "searches for more like this" do
-      populate!
-
-      # for some reason, if there's no document indexed here all the mlt
-      # queries return zero results
-      @docs.index \
-        :_id    => 3,
-        :_type  => "doc1",
-        :title  => "the author of faraday",
-        :author => "technoweenie"
-
-      @index.refresh
-
-      h = @docs.more_like_this({
-        :type => "doc1",
-        :id   => 1,
-        :mlt_fields    => "title",
-        :min_term_freq => 1
-      })
-      assert_equal 2, h["hits"]["total"]
-
-      h = @docs.more_like_this({
-        :facets => {
-          "author" => {
-            :terms => {
-              :field => "author"
-            }
-          }
-        }
-      }, {
-        :type => "doc1",
-        :id   => 1,
-        :mlt_fields    => "title,author",
-        :min_term_freq => 1
-      })
-      assert_equal 2, h["hits"]["total"]
-      assert_equal 2, h["facets"]["author"]["total"]
-    end
-  end
-
   it "explains scoring" do
     populate!
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -270,13 +270,11 @@ describe Elastomer::Client::Docs do
   end
 
   it "supports the shards search API" do
-    if es_version_supports_search_shards?
-      h = @docs.search_shards(:type => "docs1")
+    h = @docs.search_shards(:type => "docs1")
 
-      assert h.key?("nodes"), "response contains \"nodes\" information"
-      assert h.key?("shards"), "response contains \"shards\" information"
-      assert h["shards"].is_a?(Array), "\"shards\" is an array"
-    end
+    assert h.key?("nodes"), "response contains \"nodes\" information"
+    assert h.key?("shards"), "response contains \"shards\" information"
+    assert h["shards"].is_a?(Array), "\"shards\" is an array"
   end
 
   it "generates QueryParsingError exceptions on bad input when searching" do

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -166,37 +166,6 @@ describe Elastomer::Client::Index do
     assert_property_exists @index.mapping[@name], "mux_mool", "song"
   end
 
-  it "deletes document mappings" do
-    @index.create(
-      :mappings => {
-        :doco => {
-          :_source => { :enabled => false },
-          :_all    => { :enabled => false },
-          :properties => {:title  => { :type => "string", :analyzer => "standard" }}
-        }
-      }
-    )
-    assert_mapping_exists @index.mapping[@name], "doco"
-
-    response = @index.delete_mapping "doco"
-
-    if es_version_1_x?
-      assert_acknowledged response
-
-      mapping = @index.get_mapping
-      mapping = mapping[@name] if mapping.key? @name
-      mapping = mapping["mappings"] if mapping.key? "mappings"
-
-      assert_empty mapping, "no mappings are present"
-
-    elsif es_version_2_x?
-      assert_equal "No handler found for uri [/elastomer-index-test/doco] and method [DELETE]", response
-
-    else
-      assert false, "Unsupported Elasticsearch version #{$client.semantic_version}"
-    end
-  end
-
   it "lists all aliases to the index" do
     @index.create(nil)
 

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -235,14 +235,10 @@ describe Elastomer::Client::Index do
     before do
       suggest = {
         :type            => "completion",
-        :index_analyzer  => "simple",
+        :analyzer        => "simple",
         :search_analyzer => "simple",
         :payloads        => false
       }
-
-      if es_version_2_x?
-        suggest[:analyzer] = suggest.delete(:index_analyzer)
-      end
 
       @index.create(
         :settings => { :number_of_shards => 1, :number_of_replicas => 0 },
@@ -292,14 +288,6 @@ describe Elastomer::Client::Index do
       assert_equal 0, response["_shards"]["failed"]
     end
 
-    # COMPATIBILITY ES 1.2 removed support for the gateway snapshot API.
-    if es_version_supports_gateway_snapshots?
-      it "snapshots" do
-        response = @index.snapshot
-        assert_equal 0, response["_shards"]["failed"]
-      end
-    end
-
     it "recovery" do
       response = @index.recovery
       assert_includes response, "elastomer-index-test"
@@ -316,14 +304,6 @@ describe Elastomer::Client::Index do
         assert_includes response["indices"], "elastomer-index-test"
       else
         assert_includes response["_all"]["indices"], "elastomer-index-test"
-      end
-    end
-
-    # The /<index>/_status endpoint has been removed in ES 2.X
-    if es_version_1_x?
-      it "gets status" do
-        response = @index.status
-        assert_includes response["indices"], "elastomer-index-test"
       end
     end
 

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -178,28 +178,24 @@ describe Elastomer::Client::Index do
     $client.cluster.update_aliases :add => {:index => @name, :alias => "foofaloo"}
     assert_equal({@name => {"aliases" => {"foofaloo" => {}}}}, @index.get_aliases)
 
-    if es_version_1_x?
-      assert_equal({@name => {"aliases" => {"foofaloo" => {}}}}, @index.get_alias("f*"))
-      assert_equal({}, @index.get_alias("r*"))
-    end
+    assert_equal({@name => {"aliases" => {"foofaloo" => {}}}}, @index.get_alias("f*"))
+    assert_equal({}, @index.get_alias("r*"))
   end
 
-  if es_version_1_x?
-    it "adds and deletes aliases to the index" do
-      @index.create(nil)
-      assert_empty @index.get_alias("*")
+  it "adds and deletes aliases to the index" do
+    @index.create(nil)
+    assert_empty @index.get_alias("*")
 
-      @index.add_alias "gondolin"
-      aliases = @index.get_alias("*")
-      assert_equal %w[gondolin], aliases[@name]["aliases"].keys.sort
+    @index.add_alias "gondolin"
+    aliases = @index.get_alias("*")
+    assert_equal %w[gondolin], aliases[@name]["aliases"].keys.sort
 
-      @index.add_alias "gondor"
-      aliases = @index.get_alias("*")
-      assert_equal %w[gondolin gondor], aliases[@name]["aliases"].keys.sort
+    @index.add_alias "gondor"
+    aliases = @index.get_alias("*")
+    assert_equal %w[gondolin gondor], aliases[@name]["aliases"].keys.sort
 
-      @index.delete_alias "gon*"
-      assert_empty @index.get_alias("*")
-    end
+    @index.delete_alias "gon*"
+    assert_empty @index.get_alias("*")
   end
 
   it "analyzes text and returns tokens" do

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -105,10 +105,6 @@ describe Elastomer::Client::Index do
   end
 
   it "updates document mappings" do
-    unless es_version_supports_update_mapping_with__all_disabled?
-      skip "Mapping Update API is broken in this ES version."
-    end
-
     @index.create(
       :mappings => {
         :doco => {
@@ -136,10 +132,6 @@ describe Elastomer::Client::Index do
   end
 
   it "updates document mappings with .put_mapping" do
-    unless es_version_supports_update_mapping_with__all_disabled?
-      skip "Mapping Update API is broken in this ES version."
-    end
-
     @index.create(
       :mappings => {
         :doco => {

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -160,12 +160,7 @@ describe Elastomer::Client::Index do
 
   it "lists all aliases to the index" do
     @index.create(nil)
-
-    if es_version_always_returns_aliases?
-      assert_equal({@name => {"aliases" => {}}}, @index.get_aliases)
-    else
-      assert_equal({@name => {}}, @index.get_aliases)
-    end
+    assert_equal({@name => {"aliases" => {}}}, @index.get_aliases)
 
     $client.cluster.update_aliases :add => {:index => @name, :alias => "foofaloo"}
     assert_equal({@name => {"aliases" => {"foofaloo" => {}}}}, @index.get_aliases)

--- a/test/client/nodes_test.rb
+++ b/test/client/nodes_test.rb
@@ -16,26 +16,24 @@ describe Elastomer::Client::Nodes do
     assert node.key?("indices"), "indices stats are returned"
   end
 
-  if es_version_1_x?
-    it "fitlers node info" do
-      h = $client.nodes.info(:info => "os")
-      node = h["nodes"].values.first
-      assert node.key?("os"), "expected os info to be present"
-      assert !node.key?("jvm"), "expected jvm info to be absent"
+  it "fitlers node info" do
+    h = $client.nodes.info(:info => "os")
+    node = h["nodes"].values.first
+    assert node.key?("os"), "expected os info to be present"
+    assert !node.key?("jvm"), "expected jvm info to be absent"
 
-      h = $client.nodes.info(:info => %w[jvm process])
-      node = h["nodes"].values.first
-      assert node.key?("jvm"), "expected jvm info to be present"
-      assert node.key?("process"), "expected process info to be present"
-      assert !node.key?("network"), "expected network info to be absent"
-    end
+    h = $client.nodes.info(:info => %w[jvm process])
+    node = h["nodes"].values.first
+    assert node.key?("jvm"), "expected jvm info to be present"
+    assert node.key?("process"), "expected process info to be present"
+    assert !node.key?("network"), "expected network info to be absent"
+  end
 
-    it "filters node stats" do
-      h = $client.nodes.stats(:stats => "http")
-      node = h["nodes"].values.first
-      assert node.key?("http"), "expected http stats to be present"
-      assert !node.key?("indices"), "expected indices stats to be absent"
-    end
+  it "filters node stats" do
+    h = $client.nodes.stats(:stats => "http")
+    node = h["nodes"].values.first
+    assert node.key?("http"), "expected http stats to be present"
+    assert !node.key?("indices"), "expected indices stats to be absent"
   end
 
   it "gets the hot threads for the node(s)" do

--- a/test/client/repository_test.rb
+++ b/test/client/repository_test.rb
@@ -1,111 +1,107 @@
 require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Repository do
-
-  if es_version_1_x?
-
-    before do
-      if !run_snapshot_tests?
-        skip "To enable snapshot tests, add a path.repo setting to your elasticsearch.yml file."
-      end
-
-      @name = "elastomer-repository-test"
-      @repo = $client.repository(@name)
+  before do
+    if !run_snapshot_tests?
+      skip "To enable snapshot tests, add a path.repo setting to your elasticsearch.yml file."
     end
 
-    it "determines if a repo exists" do
-      assert_equal false, @repo.exists?
-      assert_equal false, @repo.exist?
-      with_tmp_repo(@name) do
-        assert_equal true, @repo.exists?
-      end
-    end
+    @name = "elastomer-repository-test"
+    @repo = $client.repository(@name)
+  end
 
-    it "creates repos" do
-      response = create_repo(@name)
-      assert_equal true, response["acknowledged"]
-      delete_repo(@name)
+  it "determines if a repo exists" do
+    assert_equal false, @repo.exists?
+    assert_equal false, @repo.exist?
+    with_tmp_repo(@name) do
+      assert_equal true, @repo.exists?
     end
+  end
 
-    it "cannot create a repo without a name" do
-      lambda {
-        create_repo(nil)
-      }.must_raise ArgumentError
+  it "creates repos" do
+    response = create_repo(@name)
+    assert_equal true, response["acknowledged"]
+    delete_repo(@name)
+  end
+
+  it "cannot create a repo without a name" do
+    lambda {
+      create_repo(nil)
+    }.must_raise ArgumentError
+  end
+
+  it "gets repos" do
+    with_tmp_repo do |repo|
+      response = repo.get
+      refute_nil response[repo.name]
     end
+  end
 
-    it "gets repos" do
-      with_tmp_repo do |repo|
-        response = repo.get
-        refute_nil response[repo.name]
-      end
+  it "gets all repos" do
+    with_tmp_repo do |repo|
+      response = $client.repository.get
+      refute_nil response[repo.name]
     end
+  end
 
-    it "gets all repos" do
-      with_tmp_repo do |repo|
-        response = $client.repository.get
-        refute_nil response[repo.name]
-      end
-    end
-
-    it "gets repo status" do
-      with_tmp_repo do |repo|
-        response = repo.status
-        assert_equal [], response["snapshots"]
-      end
-    end
-
-    it "gets status of all repos" do
-      response = $client.repository.status
+  it "gets repo status" do
+    with_tmp_repo do |repo|
+      response = repo.status
       assert_equal [], response["snapshots"]
     end
+  end
 
-    it "updates repos" do
-      with_tmp_repo do |repo|
-        settings = repo.get[repo.name]["settings"]
-        response = repo.update(:type => "fs", :settings => settings.merge("compress" => true))
-        assert_equal true, response["acknowledged"]
-        assert_equal "true", repo.get[repo.name]["settings"]["compress"]
-      end
+  it "gets status of all repos" do
+    response = $client.repository.status
+    assert_equal [], response["snapshots"]
+  end
+
+  it "updates repos" do
+    with_tmp_repo do |repo|
+      settings = repo.get[repo.name]["settings"]
+      response = repo.update(:type => "fs", :settings => settings.merge("compress" => true))
+      assert_equal true, response["acknowledged"]
+      assert_equal "true", repo.get[repo.name]["settings"]["compress"]
     end
+  end
 
-    it "cannot update a repo without a name" do
-      with_tmp_repo do |repo|
-        lambda {
-          settings = repo.get[repo.name]["settings"]
-          $client.repository.update(:type => "fs", :settings => settings.merge("compress" => true))
-        }.must_raise ArgumentError
-      end
-    end
-
-    it "deletes repos" do
-      with_tmp_repo do |repo|
-        response = repo.delete
-        assert_equal true, response["acknowledged"]
-        assert_equal false, repo.exists?
-      end
-    end
-
-    it "cannot delete a repo without a name" do
+  it "cannot update a repo without a name" do
+    with_tmp_repo do |repo|
       lambda {
-        $client.repository.delete
+        settings = repo.get[repo.name]["settings"]
+        $client.repository.update(:type => "fs", :settings => settings.merge("compress" => true))
       }.must_raise ArgumentError
     end
+  end
 
-    it "gets snapshots" do
-      with_tmp_repo do |repo|
-        response = repo.snapshots.get
-        assert_equal [], response["snapshots"]
+  it "deletes repos" do
+    with_tmp_repo do |repo|
+      response = repo.delete
+      assert_equal true, response["acknowledged"]
+      assert_equal false, repo.exists?
+    end
+  end
 
-        create_snapshot(repo, "test-snapshot")
-        response = repo.snapshot.get
-        assert_equal ["test-snapshot"], response["snapshots"].collect { |info| info["snapshot"] }
+  it "cannot delete a repo without a name" do
+    lambda {
+      $client.repository.delete
+    }.must_raise ArgumentError
+  end
 
-        create_snapshot(repo, "test-snapshot2")
-        response  = repo.snapshots.get
-        snapshot_names = response["snapshots"].collect { |info| info["snapshot"] }
-        assert_includes snapshot_names, "test-snapshot"
-        assert_includes snapshot_names, "test-snapshot2"
-      end
+  it "gets snapshots" do
+    with_tmp_repo do |repo|
+      response = repo.snapshots.get
+      assert_equal [], response["snapshots"]
+
+      create_snapshot(repo, "test-snapshot")
+      response = repo.snapshot.get
+      assert_equal ["test-snapshot"], response["snapshots"].collect { |info| info["snapshot"] }
+
+      create_snapshot(repo, "test-snapshot2")
+      response  = repo.snapshots.get
+      snapshot_names = response["snapshots"].collect { |info| info["snapshot"] }
+      assert_includes snapshot_names, "test-snapshot"
+      assert_includes snapshot_names, "test-snapshot2"
     end
   end
 end

--- a/test/client/snapshot_test.rb
+++ b/test/client/snapshot_test.rb
@@ -7,7 +7,7 @@ describe Elastomer::Client::Snapshot do
     end
 
     @index_name = "elastomer-snapshot-test-index"
-    @index = $client.index(@index_name)
+    @index = $client.index(@index.name)
     @name = "elastomer-test"
   end
 

--- a/test/client/snapshot_test.rb
+++ b/test/client/snapshot_test.rb
@@ -1,124 +1,121 @@
-
 require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Snapshot do
-  if es_version_1_x?
-    before do
-      if !run_snapshot_tests?
-        skip "To enable snapshot tests, add a path.repo setting to your elasticsearch.yml file."
-      end
+  before do
+    if !run_snapshot_tests?
+      skip "To enable snapshot tests, add a path.repo setting to your elasticsearch.yml file."
+    end
 
-      @index_name = "elastomer-snapshot-test-index"
-      @index = $client.index(@index_name)
-      @name = "elastomer-test"
+    @index_name = "elastomer-snapshot-test-index"
+    @index = $client.index(@index_name)
+    @name = "elastomer-test"
+  end
+
+  after do
+    @index.delete if @index && @index.exists?
+  end
+
+  it "determines if a snapshot exists" do
+    with_tmp_repo do |repo|
+      snapshot = repo.snapshot(@name)
+      assert_equal false, snapshot.exists?
+      assert_equal false, snapshot.exist?
+      snapshot.create({}, :wait_for_completion => true)
+      assert_equal true, snapshot.exist?
+    end
+  end
+
+  it "creates snapshots" do
+    with_tmp_repo do |repo|
+      response = repo.snapshot(@name).create({}, :wait_for_completion => true)
+      assert_equal @name, response["snapshot"]["snapshot"]
+    end
+  end
+
+  it "creates snapshots with options" do
+    @index.create(:number_of_shards => 1, :number_of_replicas => 0)
+    with_tmp_repo do |repo|
+      response = repo.snapshot(@name).create({:indices => [@index_name]}, :wait_for_completion => true)
+      assert_equal [@index_name], response["snapshot"]["indices"]
+      assert_equal 1, response["snapshot"]["shards"]["total"]
+    end
+  end
+
+  it "gets snapshot info for one and all" do
+    with_tmp_snapshot do |snapshot, repo|
+      response = snapshot.get
+      assert_equal snapshot.name, response["snapshots"][0]["snapshot"]
+      response = repo.snapshots.get
+      assert_equal snapshot.name, response["snapshots"][0]["snapshot"]
+    end
+  end
+
+  it "gets snapshot status for one and all" do
+    @index.create(:number_of_shards => 1, :number_of_replicas => 0)
+    with_tmp_repo do |repo|
+      repo.snapshot(@name).create({:indices => [@index_name]}, :wait_for_completion => true)
+      response = repo.snapshot(@name).status
+      assert_equal 1, response["snapshots"][0]["shards_stats"]["total"]
+    end
+  end
+
+  it "gets status of snapshots in progress" do
+    # we can't reliably get status of an in-progress snapshot in tests, so
+    # check for an empty result instead
+    with_tmp_repo do |repo|
+      response = repo.snapshots.status
+      assert_equal [], response["snapshots"]
+      response = $client.snapshot.status
+      assert_equal [], response["snapshots"]
+    end
+  end
+
+  it "disallows nil repo name with non-nil snapshot name" do
+    assert_raises(ArgumentError) { $client.repository.snapshot("snapshot") }
+    assert_raises(ArgumentError) { $client.snapshot(nil, "snapshot") }
+  end
+
+  it "deletes snapshots" do
+    with_tmp_snapshot do |snapshot|
+      response = snapshot.delete
+      assert_equal true, response["acknowledged"]
+    end
+  end
+
+  it "restores snapshots" do
+    @index.create(:number_of_shards => 1, :number_of_replicas => 0)
+    wait_for_index(@index_name)
+    with_tmp_repo do |repo|
+      snapshot = repo.snapshot(@name)
+      snapshot.create({:indices => [@index_name]}, :wait_for_completion => true)
+      @index.delete
+      response = snapshot.restore({}, :wait_for_completion => true)
+      assert_equal 1, response["snapshot"]["shards"]["total"]
+    end
+  end
+
+  describe "restoring to a different index" do
+    before do
+      @restored_index_name = "#{@index_name}-restored"
+      @restored_index = $client.index(@restored_index_name)
     end
 
     after do
-      @index.delete if @index && @index.exists?
+      @restored_index.delete if @restored_index && @restored_index.exists?
     end
 
-    it "determines if a snapshot exists" do
-      with_tmp_repo do |repo|
-        snapshot = repo.snapshot(@name)
-        assert_equal false, snapshot.exists?
-        assert_equal false, snapshot.exist?
-        snapshot.create({}, :wait_for_completion => true)
-        assert_equal true, snapshot.exist?
-      end
-    end
-
-    it "creates snapshots" do
-      with_tmp_repo do |repo|
-        response = repo.snapshot(@name).create({}, :wait_for_completion => true)
-        assert_equal @name, response["snapshot"]["snapshot"]
-      end
-    end
-
-    it "creates snapshots with options" do
-      @index.create(:number_of_shards => 1, :number_of_replicas => 0)
-      with_tmp_repo do |repo|
-        response = repo.snapshot(@name).create({:indices => [@index_name]}, :wait_for_completion => true)
-        assert_equal [@index_name], response["snapshot"]["indices"]
-        assert_equal 1, response["snapshot"]["shards"]["total"]
-      end
-    end
-
-    it "gets snapshot info for one and all" do
-      with_tmp_snapshot do |snapshot, repo|
-        response = snapshot.get
-        assert_equal snapshot.name, response["snapshots"][0]["snapshot"]
-        response = repo.snapshots.get
-        assert_equal snapshot.name, response["snapshots"][0]["snapshot"]
-      end
-    end
-
-    it "gets snapshot status for one and all" do
-      @index.create(:number_of_shards => 1, :number_of_replicas => 0)
-      with_tmp_repo do |repo|
-        repo.snapshot(@name).create({:indices => [@index_name]}, :wait_for_completion => true)
-        response = repo.snapshot(@name).status
-        assert_equal 1, response["snapshots"][0]["shards_stats"]["total"]
-      end
-    end
-
-    it "gets status of snapshots in progress" do
-      # we can't reliably get status of an in-progress snapshot in tests, so
-      # check for an empty result instead
-      with_tmp_repo do |repo|
-        response = repo.snapshots.status
-        assert_equal [], response["snapshots"]
-        response = $client.snapshot.status
-        assert_equal [], response["snapshots"]
-      end
-    end
-
-    it "disallows nil repo name with non-nil snapshot name" do
-      assert_raises(ArgumentError) { $client.repository.snapshot("snapshot") }
-      assert_raises(ArgumentError) { $client.snapshot(nil, "snapshot") }
-    end
-
-    it "deletes snapshots" do
-      with_tmp_snapshot do |snapshot|
-        response = snapshot.delete
-        assert_equal true, response["acknowledged"]
-      end
-    end
-
-    it "restores snapshots" do
+    it "restores snapshots with options" do
       @index.create(:number_of_shards => 1, :number_of_replicas => 0)
       wait_for_index(@index_name)
       with_tmp_repo do |repo|
         snapshot = repo.snapshot(@name)
         snapshot.create({:indices => [@index_name]}, :wait_for_completion => true)
-        @index.delete
-        response = snapshot.restore({}, :wait_for_completion => true)
+        response = snapshot.restore({
+          :rename_pattern => @index_name,
+          :rename_replacement => @restored_index_name
+        }, :wait_for_completion => true)
+        assert_equal [@restored_index_name], response["snapshot"]["indices"]
         assert_equal 1, response["snapshot"]["shards"]["total"]
-      end
-    end
-
-    describe "restoring to a different index" do
-      before do
-        @restored_index_name = "#{@index_name}-restored"
-        @restored_index = $client.index(@restored_index_name)
-      end
-
-      after do
-        @restored_index.delete if @restored_index && @restored_index.exists?
-      end
-
-      it "restores snapshots with options" do
-        @index.create(:number_of_shards => 1, :number_of_replicas => 0)
-        wait_for_index(@index_name)
-        with_tmp_repo do |repo|
-          snapshot = repo.snapshot(@name)
-          snapshot.create({:indices => [@index_name]}, :wait_for_completion => true)
-          response = snapshot.restore({
-            :rename_pattern => @index_name,
-            :rename_replacement => @restored_index_name
-          }, :wait_for_completion => true)
-          assert_equal [@restored_index_name], response["snapshot"]["indices"]
-          assert_equal 1, response["snapshot"]["shards"]["total"]
-        end
       end
     end
   end

--- a/test/client/snapshot_test.rb
+++ b/test/client/snapshot_test.rb
@@ -2,6 +2,9 @@ require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Snapshot do
   before do
+    @index = nil
+    @restored_index = nil
+
     if !run_snapshot_tests?
       skip "To enable snapshot tests, add a path.repo setting to your elasticsearch.yml file."
     end

--- a/test/client/template_test.rb
+++ b/test/client/template_test.rb
@@ -33,15 +33,6 @@ describe Elastomer::Client::Cluster do
     template = @template.get
     assert_equal [@name], template.keys
     assert_equal "test-elastomer*", template[@name]["template"]
-
-    if es_version_1_x?
-      assert_equal "3", template[@name]["settings"]["index.number_of_shards"]
-
-    elsif es_version_2_x?
-      assert_equal "3", template[@name]["settings"]["index"]["number_of_shards"]
-
-    else
-      assert false, "Unsupported Elasticsearch version #{$client.semantic_version}"
-    end
+    assert_equal "3", template[@name]["settings"]["index"]["number_of_shards"]
   end
 end

--- a/test/notifications_test.rb
+++ b/test/notifications_test.rb
@@ -46,7 +46,7 @@ describe Elastomer::Notifications do
 
   it "instruments index actions" do
     @index.exists?; assert_action_event("index.exists")
-    @index.create({settings: {index: {number_of_shards: 1, number_of_replicas: 0}}})
+    @index.create(default_index_settings)
     assert_action_event("index.create")
     @index.get_settings; assert_action_event("index.get_settings")
     @index.update_settings(number_of_replicas: 0)
@@ -57,13 +57,13 @@ describe Elastomer::Notifications do
   end
 
   it "includes the response body in the payload" do
-    @index.create({settings: {index: {number_of_shards: 1, number_of_replicas: 0}}})
+    @index.create(default_index_settings)
     event = @events.detect { |e| e.payload[:action] == "index.create" }
     assert event.payload[:response_body]
   end
 
   it "includes the request body in the payload" do
-    @index.create({settings: {index: {number_of_shards: 1, number_of_replicas: 0}}})
+    @index.create(default_index_settings)
     event = @events.detect { |e| e.payload[:action] == "index.create" }
 
     payload = event.payload

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -119,21 +119,6 @@ def es_version_supports_search_shards?
   $client.semantic_version >= "1.3.0"
 end
 
-# Elasticsearch 1.4.0 had a bug in its handling of the Mapping API where it
-# would not accept an Update request if the index had been created with the
-# _all field set to disabled. This bug was fixed in 1.4.1.
-#
-# See: https://github.com/elastic/elasticsearch/pull/8426
-def es_version_supports_update_mapping_with__all_disabled?
-  $client.semantic_version != "1.4.0"
-end
-
-# Elasticsearch 1.6 requires the repo.path setting when creating
-# FS repositories.
-def es_version_requires_repo_path?
-  $client.semantic_version >= "1.6.0"
-end
-
 def default_index_settings
   {settings: {index: {number_of_shards: 1, number_of_replicas: 0}}}
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,16 +84,6 @@ def wait_for_index(name, status="yellow")
   )
 end
 
-# Elasticsearch 1.0 changed some request formats in a non-backward-compatible
-# way. Some tests need to know what version is running to structure requests
-# as expected.
-#
-# Returns true if Elasticsearch version is 1.x.
-def es_version_1_x?
-  $client.semantic_version >= "1.0.0" &&
-  $client.semantic_version <  "2.0.0"
-end
-
 # Elasticsearch 2.0 changed some request formats in a non-backward-compatible
 # way. Some tests need to know what version is running to structure requests
 # as expected.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -104,16 +104,6 @@ def es_version_5_x?
   $client.semantic_version <  "6.0.0"
 end
 
-# Elasticsearch 1.4 changed the response body for interacting with index
-# aliases. If an index does not contain any aliases, then an "aliases" key is no
-# longer returned in the response.
-#
-# Returns `true` if the response contains an "aliases" key.
-def es_version_always_returns_aliases?
-  $client.semantic_version <  "1.4.0" ||
-  $client.semantic_version >= "1.4.3"
-end
-
 def default_index_settings
   {settings: {index: {number_of_shards: 1, number_of_replicas: 0}}}
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -129,13 +129,6 @@ def es_version_supports_search_shards?
   $client.semantic_version >= "1.3.0"
 end
 
-# Elasticsearch 1.2 removed support for gateway snapshots.
-#
-# Returns true if Elasticsearch version supports gateway snapshots.
-def es_version_supports_gateway_snapshots?
-  $client.semantic_version <= "1.2.0"
-end
-
 # Elasticsearch 1.4.0 had a bug in its handling of the Mapping API where it
 # would not accept an Update request if the index had been created with the
 # _all field set to disabled. This bug was fixed in 1.4.1.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -151,6 +151,10 @@ def es_version_requires_repo_path?
   $client.semantic_version >= "1.6.0"
 end
 
+def default_index_settings
+  {settings: {index: {number_of_shards: 1, number_of_replicas: 0}}}
+end
+
 def run_snapshot_tests?
   unless defined? $run_snapshot_tests
     begin

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -114,11 +114,6 @@ def es_version_always_returns_aliases?
   $client.semantic_version >= "1.4.3"
 end
 
-# Elasticsearch 1.3 added the `search_shards` API endpoint.
-def es_version_supports_search_shards?
-  $client.semantic_version >= "1.3.0"
-end
-
 def default_index_settings
   {settings: {index: {number_of_shards: 1, number_of_replicas: 0}}}
 end


### PR DESCRIPTION
This PR removes all the Elasticsearch 1.X (and earlier) code paths from the client gem. We will no longer be supporting any versions of Elasticsearch prior to Elasticsearch 2.X.

/cc @look && @elireisman 