### PR TITLE
Make ES port configurable to support testing multiple versions

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ require "elastomer/client"
 # we are going to use the same client instance everywhere!
 # the client should always be stateless
 $client_params = {
-  :port => 9200,
+  :port => ENV.fetch("ES_PORT", 9200),
   :read_timeout => 10,
   :open_timeout => 1,
   :opaque_id => false


### PR DESCRIPTION
This adds an `ES_PORT` environment variable for tests that defaults to 9200 if
not present, so the behavior will not change if it's not set. However, having
this allows you to run multiple versions of Elasticsearch locally for testing.

To start a different version of Elasticsearch than your default, use:

    bin/elasticsearch -E http.port=9400 -E transport.tcp.port=9500

Then start the tests with:

    ES_PORT=9400 bin/rake test

Of course, you can use any port you like, but they must match, and you must set
the TCP transport port to be different than the default.

cc @elireisman 