### PR TITLE
Handle difference in ES 5 bulk API behavior

### DIFF
--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest",           "~> 5.10"
   spec.add_development_dependency "minitest-fail-fast", "~> 0.1.0"
   spec.add_development_dependency "webmock",            "~> 2.3"
+  spec.add_development_dependency "awesome_print",      "~> 1.8"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
I couldn't find this in the changelogs or API docs, but experimentally ES 5
responds to a bulk "index" operation with no ID with a "index" response instead
of a "create" response.

This also adds awesome_print to help debug output during tests. When you need to
use it `require "awesome_print"` and then use `ap`.

@TwP I'm not sure how far you want to go in making this library look like ES 2. We could post-process the result of indexing operations to change the key in the response (maybe by detecting an "ES-like" ID?) but I'm not sure if that's worth it/desired.

cc: @elireisman 