### PR TITLE
Use rm -f on Gemfile.lock

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -19,7 +19,7 @@ if [ -d /usr/share/rbenv/shims ]; then
     export PATH=/usr/share/rbenv/shims:$PATH
 fi
 ruby -v
-rm Gemfile.lock
+rm -f Gemfile.lock
 script/bootstrap
 bundle exec rake test || result=$?
 


### PR DESCRIPTION
If the Gemfile.lock WASN'T there, the build would fail. :(
This will ignore the error and allow the build to proceed.