### PR TITLE
Move build prerequisites to install phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ install:
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
-script:
-  - wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
   - bundle install
-  - bundle exec rake test
+  - wget --quiet --waitretry=1 --retry-connrefused --timeout=10 --output-document=- http://127.0.0.1:9200
+
+script: bundle exec rake test
 
 notifications:
   email: false


### PR DESCRIPTION
Doing multiple steps in the script phase was causing builds to not fail-fast if
Elasticsearch is not started.

However, the bigger problem is that...Elasticsearch wasn't started. I moved the
test for that to run after installing gems so it will have more time to start
up. I have not changed the wget arguments but I did use the long options so it's
easier to understand. If necessary we can increase --waitretry or --tries.

cc: @elireisman @TwP This is a CI-only change that should mitigate Travis CI failures, so I'm going to go ahead and merge it.