### PR TITLE
Use `payloads` conditionally for 5.x compatibility

### DIFF
--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -224,8 +224,11 @@ describe Elastomer::Client::Index do
         :type            => "completion",
         :analyzer        => "simple",
         :search_analyzer => "simple",
-        :payloads        => false
       }
+
+      # COMPATIBILITY
+      # ES 5.x drops support for index-time payloads
+      suggest[:payloads] = false if es_version_2_x?
 
       @index.create(
         :settings => { :number_of_shards => 1, :number_of_replicas => 0 },


### PR DESCRIPTION
Use `payloads` conditionally as 5.x drops support for index-time payloads.

I did it this way to keep the old behavior but maybe we could just remove `payloads` altogether for both versions?