### PR TITLE
rename `Index#optimize` to `Index#forcemerge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.3.0 (2017-11-29)
 - Remove Elasticsearch 1.x and earlier code paths
 - Fix CI and configure an Elasticsearch 5.6 build
-- BREAKING: Rename `Index#optimize` to `Index#forcemerge`
 
 ## 2.2.0 (2017-04-29)
 - Added a `clear_scroll` API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.0 (2017-11-29)
 - Remove Elasticsearch 1.x and earlier code paths
 - Fix CI and configure an Elasticsearch 5.6 build
+- BREAKING: Rename `Index#optimize` to `Index#forcemerge`
 
 ## 2.2.0 (2017-04-29)
 - Added a `clear_scroll` API

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,8 +137,8 @@ Let's take a look at some simple event log maintenance using elastomer-client.
 # the previous month's event log
 index = client.index "event-log-2014-09"
 
-# optimize the index to have only 1 segment file (expunges deleted documents)
-index.optimize \
+# force merge the index to have only 1 segment file (expunges deleted documents)
+index.force merge \
   :max_num_segments => 1,
   :wait_for_merge   => true
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -63,7 +63,7 @@ The event namespace is `request.client.elastomer`.
 - index.get_mapping
 - index.get_settings
 - index.open
-- index.optimize
+- index.forcemerge
 - index.recovery
 - index.refresh
 - index.segments

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -261,17 +261,17 @@ module Elastomer
         response.body
       end
 
-      # Optimize one or more indices. Optimizing an index allows for faster
-      # search operations but can be resource intensive.
+      # Force merge one or more indices. Force merging an index allows to
+      # reduce the number of segments but can be resource intensive.
       #
       # params - Parameters Hash
-      #   :index - set to "_all" to optimize all indices
+      #   :index - set to "_all" to force merge all indices
       #
-      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-optimize.html
+      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html
       #
       # Returns the response body as a Hash
-      def optimize( params = {} )
-        response = client.post "{/index}/_optimize", update_params(params, :action => "index.optimize")
+      def forcemerge( params = {} )
+        response = client.post "{/index}/_forcemerge", update_params(params, :action => "index.forcemerge")
         response.body
       end
 

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -274,6 +274,8 @@ module Elastomer
         response = client.post "{/index}/_forcemerge", update_params(params, :action => "index.forcemerge")
         response.body
       end
+      # DEPRECATED:  ES 5.X has removed the `/_optimize` endpoint.
+      alias_method :optimize, :forcemerge
 
       # Provides insight into ongoing index shard recoveries. Recovery status
       # may be reported for specific indices, or cluster-wide.

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -271,7 +271,11 @@ describe Elastomer::Client::Index do
     end
 
     it "force merges" do
-      response = @index.forcemerge
+      if es_version_5_x?
+        response = @index.forcemerge
+      else
+        response = @index.optimize
+      end
       assert_equal 0, response["_shards"]["failed"]
     end
 

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -270,8 +270,8 @@ describe Elastomer::Client::Index do
       assert_equal 0, response["_shards"]["failed"]
     end
 
-    it "optimizes" do
-      response = @index.optimize
+    it "force merges" do
+      response = @index.forcemerge
       assert_equal 0, response["_shards"]["failed"]
     end
 

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -271,12 +271,12 @@ describe Elastomer::Client::Index do
     end
 
     it "force merges" do
-      if es_version_5_x?
-        response = @index.forcemerge
-      else
-        response = @index.optimize
-      end
+      response = @index.forcemerge
       assert_equal 0, response["_shards"]["failed"]
+    end
+
+    it "optimizes through force merge" do
+      assert_equal @index.method(:forcemerge),  @index.method(:optimize)
     end
 
     it "recovery" do


### PR DESCRIPTION
This was deprecated in favor of `forcemerge` in 2.1:

https://www.elastic.co/guide/en/elasticsearch/reference/2.1/indices-optimize.html

A few options if we would want to break the API:

1. Use an `alias_method` for `optimize` that would use `forcemerge`. However, this wouldn't work with ES 2.0.x, i.e: 2.0, 2.0.1 and 2.0.2.
2. Use approach (1) but detect whether we are targeting ES 2.0.x to use `_optimize` instead.
3. Support both  `optimize` and `forcemerge` at the same time.

Update: we ended up taking  approach (1)