### PR TITLE
New assertions to document 2.x/5.x alias behavior

### DIFF
--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -181,11 +181,13 @@ describe Elastomer::Client::Index do
         @index.get_alias("not-there")
       end
       assert_equal("alias [not-there] missing", exception.message)
+      assert_equal(404, exception.status)
 
       exception = assert_raises(Elastomer::Client::RequestError) do
         @index.get_alias("not*")
       end
       assert_equal("alias [not*] missing", exception.message)
+      assert_equal(404, exception.status)
     else
       fail "Unknown Elasticsearch version!"
     end


### PR DESCRIPTION
In Elasticsearch 2.x, requesting an alias that does not exist will return an
empty result. But in Elasticsearch 5.x, it will raise an error. This applies to
both full matches and wildcards.

This documents the difference, it doesn't do anything to paper it over.

cc: @juruen @elireisman 