### PR TITLE
Deprecate warmers

### DIFF
--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -104,5 +104,9 @@ module Elastomer
       ::Elastomer::Client.const_set(error_name, Class.new(Error))
     end
 
+    # Exception for operations that are unsupported with the version of
+    # Elasticsearch being used.
+    IncompatibleVersionException = Class.new Error
+
   end  # Client
 end  # Elastomer

--- a/lib/elastomer/client/warmer.rb
+++ b/lib/elastomer/client/warmer.rb
@@ -1,6 +1,8 @@
 module Elastomer
   class Client
 
+    # DEPRECATED: Warmers have been removed from Elasticsearch as of 5.0.
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/5.0/indices-warmers.html
     class Warmer
 
       # Create a new Warmer helper for making warmer API requests.
@@ -66,6 +68,7 @@ module Elastomer
       # See https://github.com/elasticsearch/elasticsearch/issues/5155
       def exists?
         response = get
+
         response != {}
       rescue Elastomer::Client::Error => exception
         if exception.message =~ /IndexWarmerMissingException/

--- a/lib/elastomer/client/warmer.rb
+++ b/lib/elastomer/client/warmer.rb
@@ -11,6 +11,10 @@ module Elastomer
       # index_name - The name of the index as a String
       # name       - The name of the warmer as a String
       def initialize(client, index_name, name)
+        unless client.es_version_2_x?
+          raise IncompatibleVersionException, "ES #{client.version} does not support warmers"
+        end
+
         @client     = client
         @index_name = @client.assert_param_presence(index_name, "index name")
         @name       = @client.assert_param_presence(name, "warmer name")

--- a/lib/elastomer/client/warmer.rb
+++ b/lib/elastomer/client/warmer.rb
@@ -72,7 +72,6 @@ module Elastomer
       # See https://github.com/elasticsearch/elasticsearch/issues/5155
       def exists?
         response = get
-
         response != {}
       rescue Elastomer::Client::Error => exception
         if exception.message =~ /IndexWarmerMissingException/

--- a/test/client/es_5_x_warmer_test.rb
+++ b/test/client/es_5_x_warmer_test.rb
@@ -1,0 +1,15 @@
+require File.expand_path("../../test_helper", __FILE__)
+
+describe "Elastomer::Client::Warmer under ES 5.x" do
+  it "cannot be instantiated" do
+    if es_version_2_x?
+      skip "warmers are still supported in ES 2.x."
+    elsif es_version_5_x?
+      exception = assert_raises(Elastomer::Client::IncompatibleVersionException) do
+        Elastomer::Client::Warmer.new($client, "index", "warmer")
+      end
+    else
+      fail "Unknown elasticsearch version"
+    end
+  end
+end

--- a/test/client/warmer_test.rb
+++ b/test/client/warmer_test.rb
@@ -2,6 +2,10 @@ require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Warmer do
   before do
+    if es_version_5_x?
+      skip "warmers are not supported in ES 5.x."
+    end
+
     @name  = "elastomer-warmer-test"
     @index = $client.index(@name)
 
@@ -23,7 +27,7 @@ describe Elastomer::Client::Warmer do
   end
 
   after do
-    @index.delete if @index.exists?
+    @index.delete if defined?(@index) && @index.exists?
   end
 
   it "creates warmers" do


### PR DESCRIPTION
Warmers have been deprecated as of ES 2.3 and removed from Elasticsearch as of
5.0:

https://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-warmers.html
https://www.elastic.co/guide/en/elasticsearch/reference/5.0/indices-warmers.html

I have marked Elastomer::Client::Warmer as DEPRECATED and skipped the tests when
running under ES 5.x.