### PR TITLE
pass scroll_id as a json object

### DIFF
--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -99,7 +99,7 @@ module Elastomer
     #
     # Returns the response body as a Hash.
     def continue_scroll( scroll_id, scroll = "5m" )
-      response = get "/_search/scroll", :body => scroll_id, :scroll => scroll, :action => "search.scroll"
+      response = get "/_search/scroll", :body => {:scroll_id => scroll_id}, :scroll => scroll, :action => "search.scroll"
       response.body
     rescue RequestError => err
       if err.error && err.error["caused_by"]["type"] == "search_context_missing_exception"


### PR DESCRIPTION
Passing the scroll_id directly in the request body
without being wrapped in a json object makes
ES 5.X unable to parse it.

It seems that previous ES versions supported both a json object and just the id.

cc @look and @elireisman 