### PR TITLE
Implement scan through scroll plus sort by doc (fixes delete_by_query in 5.x)

### DIFF
--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -144,9 +144,7 @@ module Elastomer
 
       # Remove parameters that are not valid for the _bulk endpoint
       def bulk_params
-        params = @params.clone
-        params.delete(:q) if params.has_key?(:q)
-        params
+        @params.clone.tap { |p| p.delete(:q) }
       end
 
     end  # DeleteByQuery

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -136,13 +136,13 @@ module Elastomer
         @response_stats
       end
 
-      # Remove parameters that are not valid for the _search endpoint
+      # Internal: Remove parameters that are not valid for the _search endpoint
       def search_params
         params = @params.merge(:_source => false)
         params.select {|p, _| SEARCH_PARAMETERS.include? p}
       end
 
-      # Remove parameters that are not valid for the _bulk endpoint
+      # Internal: Remove parameters that are not valid for the _bulk endpoint
       def bulk_params
         @params.clone.tap { |p| p.delete(:q) }
       end

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -1,5 +1,3 @@
-require 'active_support/core_ext/hash'
-
 module Elastomer
   class Client
 
@@ -146,7 +144,7 @@ module Elastomer
 
       # Remove parameters that are not valid for the _bulk endpoint
       def bulk_params
-        @params.except :q
+        @params.clone.tap { |p| p.delete(:q) }
       end
 
     end  # DeleteByQuery

--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/hash'
+
 module Elastomer
   class Client
 
@@ -144,7 +146,7 @@ module Elastomer
 
       # Remove parameters that are not valid for the _bulk endpoint
       def bulk_params
-        @params.clone.tap { |p| p.delete(:q) }
+        @params.except :q
       end
 
     end  # DeleteByQuery

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -129,7 +129,7 @@ module Elastomer
       end
 
       if query.has_key? :sort
-         raise ArgumentError, "#{query} cannot contain a sort #{query[:sort]}"
+         raise ArgumentError, "Query cannot contain a sort (found sort '#{query[:sort]}' in query: #{query})"
       end
 
       query.merge(:sort => [:_doc])

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -45,7 +45,13 @@ module Elastomer
     #
     # Returns a new Scroller instance
     def scan( query, opts = {} )
-      opts = opts.merge(:search_type => "scan")
+      if query.nil?
+        query = {}
+      elsif query.is_a? String
+        query = MultiJson.load(query)
+      end
+      query = query.merge(:sort => [:_doc])
+
       Scroller.new(self, query, opts)
     end
 

--- a/test/client/scroller_test.rb
+++ b/test/client/scroller_test.rb
@@ -107,6 +107,10 @@ describe Elastomer::Client::Scroller do
     assert_empty response
   end
 
+  it "raises an exception on existing sort in query" do
+    assert_raises(ArgumentError) { @index.scan :sort => [:_doc] , :query => {} }
+  end
+
   def populate!
     h = @index.bulk do |b|
       50.times { |num|


### PR DESCRIPTION
This is my first attempt at fixing the deprecated `scan` search_type in 5.x.

First of all, this depends on another super simple PR https://github.com/github/elastomer-client/pull/162 that fixes how `scroll_id` is passed.

The recommended way to replace the `scan` functionality according to the ES doc https://www.elastic.co/guide/en/elasticsearch/reference/2.1/breaking_21_search_changes.html#_literal_search_type_scan_literal_deprecated is to do the following:

>search_type=scan deprecatededit
The scan search type has been deprecated. All benefits from this search type can now be achieved by doing a scroll request that sorts documents in _doc order, for instance:
```
GET /my_index/_search?scroll=2m
{
  "sort": [
    "_doc"
  ]
}
```

We do so in the query that we send to ES.

The other thing that we address in this PR is the fact that some internal parameters of the library were being leaked to the URI that is used for the request. For instance, we would hit the `_search` end point with `action_count` or the `_bulk` end point with `q:name=foo`. Previous versions of ES were more lenient regarding this, but ES 5.x is strict about it. My current approach is pretty naive: try to filter the parameters accordingly.

As it stands right now, the `delete_by_query` test passes in both versions.

cc @look and @elireisman 