### PR TITLE
Add VersionSupport class for ES version differences

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -4,6 +4,7 @@ require "multi_json"
 require "semantic"
 
 require "elastomer/version"
+require "elastomer/version_support"
 
 module Elastomer
 
@@ -377,6 +378,10 @@ module Elastomer
       else
         raise ArgumentError, "#{name} is invalid: #{param.inspect}"
       end
+    end
+
+    def version_support
+      @version_support ||= VersionSupport.new(self)
     end
 
   end  # Client

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -63,24 +63,6 @@ module Elastomer
       Semantic::Version.new(version)
     end
 
-    # Elasticsearch 2.0 changed some request formats in a non-backward-compatible
-    # way. Some tests need to know what version is running to structure requests
-    # as expected.
-    #
-    # Returns true if Elasticsearch version is 2.x.
-    def es_version_2_x?
-      version >= "2.0.0" && version <  "3.0.0"
-    end
-
-    # Elasticsearch 5.0 changed some request formats in a non-backward-compatible
-    # way. Some tests need to know what version is running to structure requests
-    # as expected.
-    #
-    # Returns true if Elasticsearch version is 5.x.
-    def es_version_5_x?
-      version >= "5.0.0" && version < "6.0.0"
-    end
-
     # Returns the information Hash from the attached Elasticsearch instance.
     def info
       response = get "/", :action => "cluster.info"
@@ -381,7 +363,7 @@ module Elastomer
     end
 
     def version_support
-      @version_support ||= VersionSupport.new(self)
+      @version_support ||= VersionSupport.new(version)
     end
 
   end  # Client

--- a/lib/elastomer/client/warmer.rb
+++ b/lib/elastomer/client/warmer.rb
@@ -11,7 +11,7 @@ module Elastomer
       # index_name - The name of the index as a String
       # name       - The name of the warmer as a String
       def initialize(client, index_name, name)
-        unless client.es_version_2_x?
+        unless client.version_support.supports_warmers?
           raise IncompatibleVersionException, "ES #{client.version} does not support warmers"
         end
 

--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -1,0 +1,48 @@
+module Elastomer
+  class VersionSupport
+    attr_reader :client
+
+    def initialize(client)
+      @client = client
+    end
+
+    # COMPATIBILITY: Return a "text"-type mapping for a field.
+    #
+    # On ES 2.x, this will be a string field. On ES 5+, it will be a text field.
+    def text(**args)
+      reject_args!(args, :type, :index)
+
+      if client.es_version_2_x?
+        {type: "string"}.merge(args)
+      else
+        {type: "text"}.merge(args)
+      end
+    end
+
+    # COMPATIBILITY: Return a "keyword"-type mapping for a field.
+    #
+    # On ES 2.x, this will be a string field with not_analyzed=true. On ES 5+,
+    # it will be a keyword field.
+    def keyword(**args)
+      reject_args!(args, :type, :index)
+
+      if client.es_version_2_x?
+        {type: "string", index: "not_analyzed"}.merge(args)
+      else
+        {type: "keyword"}.merge(args)
+      end
+    end
+
+    private
+
+    # Internal: Helper to reject arguments that shouldn't be passed because
+    # merging them in would defeat the purpose of a compatibility layer.
+    def reject_args!(args, *names)
+      names.each do |name|
+        if args.include?(name.to_s) || args.include?(name.to_sym)
+          raise ArgumentError, "Argument '#{name}' is not allowed"
+        end
+      end
+    end
+  end
+end

--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -5,7 +5,13 @@ module Elastomer
     attr_reader :version
 
     # version - an Elasticsearch version string e.g., 2.3.5 or 5.3.0
+    #
+    # Raises ArgumentError if version is unsupported.
     def initialize(version)
+      if version < "2.3" || version >= "5.7"
+        raise ArgumentError, "Elasticsearch version #{version} is not supported by elastomer-client"
+      end
+
       @version = version
     end
 

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -89,16 +89,14 @@ describe Elastomer::Client::Bulk do
 
     assert_equal 2, h["items"].length
 
-    if es_version_2_x?
+    if bulk_index_returns_create_for_new_documents?
       assert_bulk_index h["items"].first
       assert_bulk_create h["items"].last
       book_id = items.last["create"]["_id"]
-    elsif es_version_5_x?
+    else
       assert_bulk_index h["items"].first
       assert_bulk_index h["items"].last
       book_id = items.last["index"]["_id"]
-    else
-      fail "Unknown ES version!"
     end
 
     assert_match %r/^\S{20,22}$/, book_id
@@ -120,18 +118,16 @@ describe Elastomer::Client::Bulk do
 
     assert_equal 2, h["items"].length
 
-    if es_version_2_x?
+    if bulk_index_returns_create_for_new_documents?
       assert_bulk_create h["items"].first, "expected to create a book"
       assert_bulk_delete h["items"].last, "expected to delete a book"
 
       book_id2 = items.first["create"]["_id"]
-    elsif es_version_5_x?
+    else
       assert_bulk_index h["items"].first, "expected to create a book"
       assert_bulk_delete h["items"].last, "expected to delete a book"
 
       book_id2 = items.first["index"]["_id"]
-    else
-      fail "Unknown ES version!"
     end
 
     assert_match %r/^\S{20,22}$/, book_id2

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -13,15 +13,15 @@ describe Elastomer::Client::Bulk do
           :tweet => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :message => { :type => "string", :analyzer => "standard" },
-              :author  => { :type => "string", :index => "not_analyzed" }
+              :message => $client.version_support.text(analyzer: "standard"),
+              :author  => $client.version_support.keyword
             }
           },
           :book => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => $client.version_support.text(analyzer: "standard"),
+              :author => $client.version_support.keyword
             }
           }
         }

--- a/test/client/cluster_test.rb
+++ b/test/client/cluster_test.rb
@@ -69,7 +69,7 @@ describe Elastomer::Client::Cluster do
   it "returns cluster stats" do
     h = @cluster.stats
     expected = %w[cluster_name indices nodes status timestamp]
-    expected.unshift("_nodes") if es_version_5_x?
+    expected.unshift("_nodes") if cluster_stats_includes_underscore_nodes?
     assert_equal expected, h.keys.sort
   end
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -13,15 +13,15 @@ describe Elastomer::Client::Docs do
           :doc1 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard", :term_vector => "with_positions_offsets" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => $client.version_support.text(analyzer: "standard", term_vector: "with_positions_offsets"),
+              :author => $client.version_support.keyword
             }
           },
           :doc2 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard", :term_vector => "with_positions_offsets" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => $client.version_support.text(analyzer: "standard", term_vector: "with_positions_offsets"),
+              :author => $client.version_support.keyword
             }
           }
         }

--- a/test/client/es_5_x_warmer_test.rb
+++ b/test/client/es_5_x_warmer_test.rb
@@ -2,14 +2,12 @@ require File.expand_path("../../test_helper", __FILE__)
 
 describe "Elastomer::Client::Warmer under ES 5.x" do
   it "cannot be instantiated" do
-    if es_version_2_x?
-      skip "warmers are still supported in ES 2.x."
-    elsif es_version_5_x?
-      exception = assert_raises(Elastomer::Client::IncompatibleVersionException) do
-        Elastomer::Client::Warmer.new($client, "index", "warmer")
-      end
-    else
-      fail "Unknown elasticsearch version"
+    if $client.version_support.supports_warmers?
+      skip "warmers are still supported in ES #{$client.version}."
+    end
+
+    exception = assert_raises(Elastomer::Client::IncompatibleVersionException) do
+      Elastomer::Client::Warmer.new($client, "index", "warmer")
     end
   end
 end

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -55,8 +55,8 @@ describe Elastomer::Client::Index do
             :_source => { :enabled => false },
             :_all    => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => $client.version_support.text(analyzer: "standard"),
+              :author => $client.version_support.keyword
             }
           }
         }
@@ -74,8 +74,8 @@ describe Elastomer::Client::Index do
             :_source => { :enabled => false },
             :_all    => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => $client.version_support.text(analyzer: "standard"),
+              :author => $client.version_support.keyword
             }
           }
         }
@@ -110,7 +110,7 @@ describe Elastomer::Client::Index do
         :doco => {
           :_source => { :enabled => false },
           :_all    => { :enabled => false },
-          :properties => {:title  => { :type => "string", :analyzer => "standard" }}
+          :properties => {:title  => $client.version_support.text(analyzer: "standard")}
         }
       }
     )
@@ -118,14 +118,14 @@ describe Elastomer::Client::Index do
     assert_property_exists @index.mapping[@name], "doco", "title"
 
     @index.update_mapping "doco", { :doco => { :properties => {
-      :author => { :type => "string", :index => "not_analyzed" }
+      :author => $client.version_support.keyword
     }}}
 
     assert_property_exists @index.mapping[@name], "doco", "author"
     assert_property_exists @index.mapping[@name], "doco", "title"
 
     @index.update_mapping "mux_mool", { :mux_mool => { :properties => {
-      :song => { :type => "string", :index => "not_analyzed" }
+      :song => $client.version_support.keyword
     }}}
 
     assert_property_exists @index.mapping[@name], "mux_mool", "song"
@@ -137,7 +137,7 @@ describe Elastomer::Client::Index do
         :doco => {
           :_source => { :enabled => false },
           :_all    => { :enabled => false },
-          :properties => {:title  => { :type => "string", :analyzer => "standard" }}
+          :properties => {:title  => $client.version_support.text(analyzer: "standard")}
         }
       }
     )
@@ -145,14 +145,14 @@ describe Elastomer::Client::Index do
     assert_property_exists @index.mapping[@name], "doco", "title"
 
     @index.put_mapping "doco", { :doco => { :properties => {
-      :author => { :type => "string", :index => "not_analyzed" }
+      :author => $client.version_support.keyword
     }}}
 
     assert_property_exists @index.mapping[@name], "doco", "author"
     assert_property_exists @index.mapping[@name], "doco", "title"
 
     @index.put_mapping "mux_mool", { :mux_mool => { :properties => {
-      :song => { :type => "string", :index => "not_analyzed" }
+      :song => $client.version_support.keyword
     }}}
 
     assert_property_exists @index.mapping[@name], "mux_mool", "song"
@@ -234,8 +234,8 @@ describe Elastomer::Client::Index do
             :_source => { :enabled => false },
             :_all    => { :enabled => false },
             :properties => {
-              :title   => { :type => "string", :analyzer => "standard" },
-              :author  => { :type => "string", :index => "not_analyzed" },
+              :title   => $client.version_support.text(analyzer: "standard"),
+              :author  => $client.version_support.keyword,
               :suggest => suggest
             }
           }

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -13,15 +13,15 @@ describe Elastomer::Client::MultiPercolate do
           :doc1 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => $client.version_support.text(analyzer: "standard"),
+              :author => $client.version_support.keyword
             }
           },
           :doc2 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => $client.version_support.text(analyzer: "standard"),
+              :author => $client.version_support.keyword
             }
           }
         }

--- a/test/client/multi_search_test.rb
+++ b/test/client/multi_search_test.rb
@@ -13,15 +13,15 @@ describe Elastomer::Client::MultiSearch do
           :doc1 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => $client.version_support.text(analyzer: "standard"),
+              :author => $client.version_support.keyword
             }
           },
           :doc2 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => $client.version_support.text(analyzer: "standard"),
+              :author => $client.version_support.keyword
             }
           }
         }

--- a/test/client/scroller_test.rb
+++ b/test/client/scroller_test.rb
@@ -13,16 +13,16 @@ describe Elastomer::Client::Scroller do
           :tweet => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :message => { :type => "string", :analyzer => "standard" },
-              :author  => { :type => "string", :index => "not_analyzed" },
+              :message => $client.version_support.text(analyzer: "standard"),
+              :author  => $client.version_support.keyword,
               :sorter  => { :type => "integer" }
             }
           },
           :book => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard" },
-              :author => { :type => "string", :index => "not_analyzed" },
+              :title  => $client.version_support.text(analyzer: "standard"),
+              :author => $client.version_support.keyword,
               :sorter  => { :type => "integer" }
             }
           }

--- a/test/client/warmer_test.rb
+++ b/test/client/warmer_test.rb
@@ -16,8 +16,8 @@ describe Elastomer::Client::Warmer do
           :tweet => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :message => { :type => "string", :analyzer => "standard" },
-              :author  => { :type => "string", :index => "not_analyzed" }
+              :message => $client.version_support.text(analyzer: "standard"),
+              :author  => $client.version_support.keyword
             }
           }
         }

--- a/test/client/warmer_test.rb
+++ b/test/client/warmer_test.rb
@@ -2,8 +2,8 @@ require File.expand_path("../../test_helper", __FILE__)
 
 describe Elastomer::Client::Warmer do
   before do
-    if es_version_5_x?
-      skip "warmers are not supported in ES 5.x."
+    unless $client.version_support.supports_warmers?
+      skip "warmers are not supported in ES #{client.version}"
     end
 
     @name  = "elastomer-warmer-test"

--- a/test/core_ext/time_test.rb
+++ b/test/core_ext/time_test.rb
@@ -13,7 +13,7 @@ describe "JSON conversions for Time" do
           :doc1 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title      => { :type => "string", :index => "not_analyzed" },
+              :title      => $client.version_support.keyword,
               :created_at => { :type => "date" }
             }
           }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,24 +84,6 @@ def wait_for_index(name, status="yellow")
   )
 end
 
-# Elasticsearch 2.0 changed some request formats in a non-backward-compatible
-# way. Some tests need to know what version is running to structure requests
-# as expected.
-#
-# Returns true if Elasticsearch version is 2.x.
-def es_version_2_x?
-  $client.es_version_2_x?
-end
-
-# Elasticsearch 5.0 changed some request formats in a non-backward-compatible
-# way. Some tests need to know what version is running to structure requests
-# as expected.
-#
-# Returns true if Elasticsearch version is 5.x.
-def es_version_5_x?
-  $client.es_version_5_x?
-end
-
 def default_index_settings
   {settings: {index: {number_of_shards: 1, number_of_replicas: 0}}}
 end
@@ -162,4 +144,37 @@ def with_tmp_snapshot(name = SecureRandom.uuid, &block)
     create_snapshot(repo, name)
     yield repo.snapshot(name), repo
   end
+end
+
+# The methods below are to support intention-revealing names about version
+# differences in the tests. If necessary for general operation they can be moved
+# into Elastomer::VersionSupport.
+
+# COMPATIBILITY
+# ES 5.x returns `index` bulk request as `index` responses whether or not the
+# document was created or updated. ES 2.x returns a `create` response if it was
+# created.
+def bulk_index_returns_create_for_new_documents?
+  $client.version_support.es_version_2_x?
+end
+
+# COMPATIBILITY
+# ES 5.x drops support for index-time payloads
+def index_time_payloads?
+  $client.version_support.es_version_2_x?
+end
+
+# COMPATIBILITY
+# ES 2.x returns an empty result when an alias does not exist for a full or partial match
+# ES 5.6 returns an error when an alias does not exist for a full or partial match
+def fetching_non_existent_alias_returns_error?
+  $client.version_support.es_version_5_x?
+end
+
+# COMPATIBILITY
+# ES 5.6 includes a _nodes key in the /_cluster/stats response. Strangely
+# enough, this is not documented in the example response:
+# https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cluster-stats.html
+def cluster_stats_includes_underscore_nodes?
+  $client.version_support.es_version_5_x?
 end

--- a/test/version_support_test.rb
+++ b/test/version_support_test.rb
@@ -2,16 +2,7 @@ require_relative './test_helper'
 
 describe Elastomer::VersionSupport do
   describe "ES 2.x" do
-    let(:client) do
-      client = Elastomer::Client.new(host: "fake.web", port: 8888)
-
-      def client.version
-        "2.3.5"
-      end
-
-      client
-    end
-    let(:version_support) { Elastomer::VersionSupport.new(client) }
+    let(:version_support) { Elastomer::VersionSupport.new("2.3.5") }
 
     describe "#keyword" do
       it "returns non_analyzed string" do
@@ -37,16 +28,7 @@ describe Elastomer::VersionSupport do
   end
 
   describe "ES 5.x" do
-    let(:client) do
-      client = Elastomer::Client.new(host: "fake.web", port: 8888)
-
-      def client.version
-        "5.6.0"
-      end
-
-      client
-    end
-    let(:version_support) { Elastomer::VersionSupport.new(client) }
+    let(:version_support) { Elastomer::VersionSupport.new("5.6.0") }
 
     describe "#keyword" do
       it "returns keyword" do

--- a/test/version_support_test.rb
+++ b/test/version_support_test.rb
@@ -1,6 +1,37 @@
 require_relative './test_helper'
 
 describe Elastomer::VersionSupport do
+  describe "supported versions" do
+    it "allows 2.3.0 to 5.6" do
+      two_three_series = ["2.3.0", "2.3.5", "2.4.0", "2.9.9", "2.9.100"]
+      five_series = ["5.0.0", "5.0.9", "5.2.0", "5.6.9", "5.6.100"]
+
+      two_three_series.each do |version|
+        assert Elastomer::VersionSupport.new(version).es_version_2_x?
+      end
+
+      five_series.each do |version|
+        assert Elastomer::VersionSupport.new(version).es_version_5_x?
+      end
+    end
+  end
+
+  describe "unsupported versions" do
+    it "blow up" do
+      too_low = ["0.90", "1.0.1", "2.0.0", "2.2.0"]
+      too_high = ["5.7.0", "6.0.0"]
+
+      (too_low + too_high).each do |version|
+        exception = assert_raises(ArgumentError, "expected #{version} to not be supported") do
+          Elastomer::VersionSupport.new(version)
+        end
+
+        assert_match version, exception.message
+        assert_match "is not supported", exception.message
+      end
+    end
+  end
+
   describe "ES 2.x" do
     let(:version_support) { Elastomer::VersionSupport.new("2.3.5") }
 

--- a/test/version_support_test.rb
+++ b/test/version_support_test.rb
@@ -1,0 +1,71 @@
+require_relative './test_helper'
+
+describe Elastomer::VersionSupport do
+  describe "ES 2.x" do
+    let(:client) do
+      client = Elastomer::Client.new(host: "fake.web", port: 8888)
+
+      def client.version
+        "2.3.5"
+      end
+
+      client
+    end
+    let(:version_support) { Elastomer::VersionSupport.new(client) }
+
+    describe "#keyword" do
+      it "returns non_analyzed string" do
+        expected = {
+          type: "string",
+          index: "not_analyzed",
+          store: true
+        }
+        assert_equal(expected, version_support.keyword(store: true))
+      end
+    end
+
+    describe "#text" do
+      it "returns analyzed string" do
+        expected = {
+          type: "string",
+          term_vector: "with_positions_offsets"
+        }
+        assert_equal(expected, version_support.text(term_vector: "with_positions_offsets"))
+      end
+    end
+
+  end
+
+  describe "ES 5.x" do
+    let(:client) do
+      client = Elastomer::Client.new(host: "fake.web", port: 8888)
+
+      def client.version
+        "5.6.0"
+      end
+
+      client
+    end
+    let(:version_support) { Elastomer::VersionSupport.new(client) }
+
+    describe "#keyword" do
+      it "returns keyword" do
+        expected = {
+          type: "keyword",
+          store: true
+        }
+        assert_equal(expected, version_support.keyword(store: true))
+      end
+    end
+
+    describe "#text" do
+      it "returns text" do
+        expected = {
+          type: "text",
+          term_vector: "with_positions_offsets"
+        }
+        assert_equal(expected, version_support.text(term_vector: "with_positions_offsets"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
VersionSupport is pretty basic right now but the idea is to have a place to
stash version-aware helpers. Currently it's used to provide a way to paper over
the difference between `text` and `keyword` fields in ES 5+ and `string` fields
in ES 2.

Supposedly ES 5 can take a legacy `string` field and do the right thing with it,
but there are severe limitations, such as not being able to handle an a `string`
field with `term_vectors` enabled. :(

See: https://github.com/elastic/elasticsearch/issues/21356

I've used the VersionSupport helpers to update all the tests that were using `string` fields. With this in place I'm getting 3 failures and 42 errors.

**UPDATE:** After some discussion with @TwP I updated the tests to use intention-revealing names for their version checks as well. I think this improves how the code reads nicely, but I wanted to ping you all so you can let me know what you think.

I also updated `VersionSupport` to raise an error if we attempt to use it with an unsupported version of Elasticsearch. This gives us a place to document what versions we support and also lets us blow up if we try to use it some place we shouldn't (like a 2.0 or 6.0 cluster).

cc: @elireisman @juruen 