### PR TITLE
Update Percolator APIs for ES 5.x upgrade

### DIFF
--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -93,6 +93,9 @@ module Elastomer
     TimeoutError.fatal     = false
     ConnectionFailed.fatal = false
 
+    # COMPATIBILITY
+    SupportedVersionError = Class.new Error
+
     # Define an Elastomer::Client exception class on the fly for
     # Faraday exception classes that we don't specifically wrap.
     Faraday::Error.constants.each do |error_name|

--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -93,9 +93,6 @@ module Elastomer
     TimeoutError.fatal     = false
     ConnectionFailed.fatal = false
 
-    # COMPATIBILITY
-    SupportedVersionError = Class.new Error
-
     # Define an Elastomer::Client exception class on the fly for
     # Faraday exception classes that we don't specifically wrap.
     Faraday::Error.constants.each do |error_name|

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -14,12 +14,7 @@ module Elastomer
         @id = client.assert_param_presence(id, "id")
 
         # COMPATIBILITY
-        @percolator_type =
-          if client.version_support.percolator_type?
-            'percolator'
-          else
-            '.percolator'
-          end
+        @percolator_type = client.version_support.percolator_type
       end
 
       attr_reader :client, :index_name, :id

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -19,7 +19,7 @@ module Elastomer
                            elsif client.es_version_2_x?
                                '.percolator'
                            else
-                               raise SupportedVersionError "elastomer-client doesn't support Percolate API for ES version < 2.x or > 5.x"
+                               raise IncompatibleVersionException "Percolator API not supported for ES #{@client.version}"
                            end
       end
 

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -15,12 +15,10 @@ module Elastomer
 
         # COMPATIBILITY
         @percolator_type =
-          if client.es_version_5_x?
+          if client.version_support.es_version_5_x?
             'percolator'
-          elsif client.es_version_2_x?
-            '.percolator'
           else
-            raise IncompatibleVersionException "Percolator API not supported for ES #{@client.version}"
+            '.percolator'
           end
       end
 

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -14,16 +14,17 @@ module Elastomer
         @id = client.assert_param_presence(id, "id")
 
         # COMPATIBILITY
-        @percolator_type = if client.es_version_5_x?
-                               'percolator'
-                           elsif client.es_version_2_x?
-                               '.percolator'
-                           else
-                               raise IncompatibleVersionException "Percolator API not supported for ES #{@client.version}"
-                           end
+        @percolator_type =
+          if client.es_version_5_x?
+            'percolator'
+          elsif client.es_version_2_x?
+            '.percolator'
+          else
+            raise IncompatibleVersionException "Percolator API not supported for ES #{@client.version}"
+          end
       end
 
-      attr_reader :client, :index_name, :id, :percolator_type
+      attr_reader :client, :index_name, :id
 
       # Create a percolator query.
       #
@@ -34,7 +35,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create(body, params = {})
-        response = client.put("/{index}/{percolator_type}/{id}", defaults.merge(params.merge(:body => body, :action => "percolator.create")))
+        response = client.put("/{index}/#{@percolator_type}/{id}", defaults.merge(params.merge(:body => body, :action => "percolator.create")))
         response.body
       end
 
@@ -47,7 +48,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get(params = {})
-        response = client.get("/{index}/{percolator_type}/{id}", defaults.merge(params.merge(:action => "percolator.get")))
+        response = client.get("/{index}/#{@percolator_type}/{id}", defaults.merge(params.merge(:action => "percolator.get")))
         response.body
       end
 
@@ -60,7 +61,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete(params = {})
-        response = client.delete("/{index}/{percolator_type}/{id}", defaults.merge(params.merge(:action => "percolator.delete")))
+        response = client.delete("/{index}/#{@percolator_type}/{id}", defaults.merge(params.merge(:action => "percolator.delete")))
         response.body
       end
 
@@ -78,7 +79,7 @@ module Elastomer
 
       # Internal: Returns a Hash containing default parameters.
       def defaults
-        {:index => index_name, :id => id, :percolator_type => percolator_type}
+        {:index => index_name, :id => id}
       end
 
     end  # Percolator

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -15,7 +15,7 @@ module Elastomer
 
         # COMPATIBILITY
         @percolator_type =
-          if client.version_support.es_version_5_x?
+          if client.version_support.percolator_type?
             'percolator'
           else
             '.percolator'

--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -66,10 +66,14 @@ module Elastomer
       version >= "5.0.0" && version < "6.0.0"
     end
 
-    # Wraps version check where ES version >= 5.x requires percolator type + field
-    # defined in mappings
-    def percolator_type?
-      es_version_5_x?
+    # Wraps version check and param gen where ES version >= 5.x requires
+    # percolator type + field defined in mappings
+    def percolator_type
+      if es_version_5_x?
+        "percolator"
+      else
+        ".percolator"
+      end
     end
 
     private

--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -66,6 +66,11 @@ module Elastomer
       version >= "5.0.0" && version < "6.0.0"
     end
 
+    # Wraps version check where ES version >= 5.x requires percolator type + field
+    # defined in mappings
+    def percolator_type?
+      es_version_5_x?
+    end
 
     private
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -13,18 +13,23 @@ describe Elastomer::Client::Docs do
           :doc1 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard", :term_vector => "with_positions_offsets" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => { :type => "text", :analyzer => "standard", :term_vector => "with_positions_offsets" },
+              :author => { :type => "keyword", :index => "not_analyzed" }
             }
           },
           :doc2 => {
             :_source => { :enabled => true }, :_all => { :enabled => false },
             :properties => {
-              :title  => { :type => "string", :analyzer => "standard", :term_vector => "with_positions_offsets" },
-              :author => { :type => "string", :index => "not_analyzed" }
+              :title  => { :type => "text", :analyzer => "standard", :term_vector => "with_positions_offsets" },
+              :author => { :type => "keyword", :index => "not_analyzed" }
             }
           }
         }
+
+      # COMPATIBILITY
+      if es_version_5_x?
+        @index.update_mapping("percolator", { :properties => { :query => { :type => "percolator"}}})
+      end
 
       wait_for_index(@name)
     end
@@ -463,6 +468,7 @@ describe Elastomer::Client::Docs do
     percolator2 = @index.percolator "2"
     response = percolator2.create :query => { :match => { :author => "defunkt" } }
     assert response["created"], "Couldn't create the percolator query"
+    @index.refresh
 
     response = @index.docs("doc1").percolate(:doc => { :author => "pea53" })
     assert_equal 1, response["matches"].length
@@ -478,6 +484,7 @@ describe Elastomer::Client::Docs do
     percolator2 = @index.percolator "2"
     response = percolator2.create :query => { :match => { :author => "defunkt" } }
     assert response["created"], "Couldn't create the percolator query"
+    @index.refresh
 
     response = @index.docs("doc2").percolate(nil, :id => "1")
     assert_equal 1, response["matches"].length
@@ -493,6 +500,7 @@ describe Elastomer::Client::Docs do
     percolator2 = @index.percolator "2"
     response = percolator2.create :query => { :match => { :author => "defunkt" } }
     assert response["created"], "Couldn't create the percolator query"
+    @index.refresh
 
     count = @index.docs("doc1").percolate_count :doc => { :author => "pea53" }
     assert_equal 1, count
@@ -507,6 +515,7 @@ describe Elastomer::Client::Docs do
     percolator2 = @index.percolator "2"
     response = percolator2.create :query => { :match => { :author => "defunkt" } }
     assert response["created"], "Couldn't create the percolator query"
+    @index.refresh
 
     count = @index.docs("doc2").percolate_count(nil, :id => "1")
     assert_equal 1, count
@@ -515,6 +524,7 @@ describe Elastomer::Client::Docs do
   it "performs multi percolate queries" do
     @index.percolator("1").create :query => { :match_all => { } }
     @index.percolator("2").create :query => { :match => { :author => "pea53" } }
+    @index.refresh
 
     h = @index.docs("doc2").multi_percolate do |m|
       m.percolate :author => "pea53"

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -27,7 +27,7 @@ describe Elastomer::Client::Docs do
         }
 
       # COMPATIBILITY
-        if $client.version_support.es_version_5_x?
+        if requires_percolator_mapping?
         @index.update_mapping("percolator", { :properties => { :query => { :type => "percolator"}}})
       end
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -27,7 +27,7 @@ describe Elastomer::Client::Docs do
         }
 
       # COMPATIBILITY
-        if requires_percolator_mapping?
+      if requires_percolator_mapping?
         @index.update_mapping("percolator", { :properties => { :query => { :type => "percolator"}}})
       end
 

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -7,7 +7,7 @@ describe Elastomer::Client::MultiPercolate do
     @index = $client.index(@name)
 
     unless @index.exists?
-      @index.create \
+      base_mappings_settings = {
         :settings => { "index.number_of_shards" => 1, "index.number_of_replicas" => 0 },
         :mappings => {
           :doc1 => {
@@ -25,19 +25,14 @@ describe Elastomer::Client::MultiPercolate do
             }
           }
         }
+      }
 
       # COMPATIBILITY
-      # percolator clause must now be defined in index mappings as ordinary data type for ES versions >= 5.x
       if es_version_5_x?
-          @index.update_mapping("percolator",
-            :percolator => {
-              :properties => {
-                :query => { :type => "percolator" }
-              }
-            }
-          )
+        base_mappings_settings[:mappings] = { :percolator => { :properties => { :query => { :type => "percolator" } } } }
       end
 
+      @index.create base_mappings_settings
       wait_for_index(@name)
     end
 

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -28,7 +28,7 @@ describe Elastomer::Client::MultiPercolate do
       }
 
       # COMPATIBILITY
-      if $client.version_support.es_version_5_x?
+      if requires_percolator_mapping?
         base_mappings_settings[:mappings] = { :percolator => { :properties => { :query => { :type => "percolator" } } } }
       end
 

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -26,6 +26,18 @@ describe Elastomer::Client::MultiPercolate do
           }
         }
 
+      # COMPATIBILITY
+      # percolator clause must now be defined in index mappings as ordinary data type for ES versions >= 5.x
+      if es_version_5_x?
+          @index.update_mapping("percolator",
+            :percolator => {
+              :properties => {
+                :query => { :type => "percolator" }
+              }
+            }
+          )
+      end
+
       wait_for_index(@name)
     end
 

--- a/test/client/percolator_test.rb
+++ b/test/client/percolator_test.rb
@@ -16,7 +16,7 @@ describe Elastomer::Client::Percolator do
     before do
       # COMPATIBILITY
       base_mappings =
-        if es_version_5_x?
+        if requires_percolator_mapping?
           { :mappings => { :percolator => { :properties => { :query => { :type => "percolator" } } } } }
         else
           nil

--- a/test/client/percolator_test.rb
+++ b/test/client/percolator_test.rb
@@ -14,7 +14,15 @@ describe Elastomer::Client::Percolator do
 
   describe "when an index exists" do
     before do
-      @index.create(default_index_mappings)
+      # COMPATIBILITY
+      base_mappings =
+        if es_version_5_x?
+          { :mappings => { :percolator => { :properties => { :query => { :type => "percolator" } } } } }
+        else
+          nil
+        end
+
+      @index.create(base_mappings)
       wait_for_index(@index.name)
     end
 

--- a/test/client/percolator_test.rb
+++ b/test/client/percolator_test.rb
@@ -14,7 +14,7 @@ describe Elastomer::Client::Percolator do
 
   describe "when an index exists" do
     before do
-      @index.create(nil)
+      @index.create(default_index_mappings)
       wait_for_index(@index.name)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -106,16 +106,6 @@ def default_index_settings
   {settings: {index: {number_of_shards: 1, number_of_replicas: 0}}}
 end
 
-def default_index_mappings
-  if es_version_5_x?
-    {mappings: {percolator: {properties: {query: { type: "percolator"}}}}}
-  elsif es_version_2_x?
-    {}
-  else
-    raise IncompatibleVersionException "Percolator API not supported for ES #{$client.version}"
-  end
-end
-
 def run_snapshot_tests?
   unless defined? $run_snapshot_tests
     begin

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -106,6 +106,16 @@ def default_index_settings
   {settings: {index: {number_of_shards: 1, number_of_replicas: 0}}}
 end
 
+def default_index_mappings
+  if es_version_5_x?
+    {mappings: {percolator: {properties: {query: { type: "percolator"}}}}}
+  elsif es_version_2_x?
+    {}
+  else
+    raise SupportedVersionError "elastomer-client currently supports ES versions >= 2.x and <= 5.x only"
+  end
+end
+
 def run_snapshot_tests?
   unless defined? $run_snapshot_tests
     begin

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -185,4 +185,3 @@ end
 def requires_percolator_mapping?
   $client.version_support.es_version_5_x?
 end
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -178,3 +178,11 @@ end
 def cluster_stats_includes_underscore_nodes?
   $client.version_support.es_version_5_x?
 end
+
+# COMPATIBILITY
+# ES 5.6 percolator queries/document submissions require that an appropriate
+# percolator type and field within that type are defined on the index mappings
+def requires_percolator_mapping?
+  $client.version_support.es_version_5_x?
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,7 +112,7 @@ def default_index_mappings
   elsif es_version_2_x?
     {}
   else
-    raise SupportedVersionError "elastomer-client currently supports ES versions >= 2.x and <= 5.x only"
+    raise IncompatibleVersionException "Percolator API not supported for ES #{$client.version}"
   end
 end
 


### PR DESCRIPTION
I expect this will receive a few more updated to the PR and probably a couple more test cases but thought I would put this out for everyone to have a peek in the meantime.

#### Changes for 5.x tl;dr:
- legacy `_percolate`, `_percolate/count` and `_mpercolate` API endpoints are deprecated but still function if percolation for the given index mapping is configured properly, and some perc queries are registered using the new API
- legacy `/:index/.percolate/:id` for registering perc q's on an index are gone in 5.x although docs claim ES5 can still read indices written by an older ES version
- However, types like `.percolator` starting with `.` aren't allowed anymore in 5.x
- an index that needs perc q's must register a new datatype for the queries in the index mapping, and that must have a field of type `percolator`
- new API registers/indexes perc queries by writing them to this new field in this new mapped data type

#### Further work
- we'll need to conditionally update the mappings at index create time in `github/github` and other uses of `elastomer-client` whenever they run on ES 5.x during the transition for indices that use percolator now
- We'll want to update the legacy endpoint usage (`_percolate` and friends) to use the new `_search` based perc API (using a `percolate` clause like [this](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-percolate-query.html#query-dsl-percolate-query)) once we're off ES2; this includes parsing changes for a search-style response

#### Questions:
*Parameterize the new perc query data type and it's field, as end users may name them differently in their own mappings?*
The new type and it's field can have any names but for this PR I chose what the docs do: `percolator` for the index data type, `query` for the field. If people get creative with those in their index mappings and we don't parameterize them in `elastomer-client`, end users will have a bad day. Let me know and I can add that plumbing here.

(more coming as I think of it)