### PR TITLE
pass analyzer as a json object

### DIFF
--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -230,8 +230,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def analyze( text, params = {} )
-        body = {:text => text.to_s}.merge params
-        body.delete :index
+        body = text.is_a?(Hash) ? text : {text: text.to_s}
         response = client.get "{/index}/_analyze", update_params(params, :body => body, :action => "index.analyze")
         response.body
       end

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -230,7 +230,8 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def analyze( text, params = {} )
-        response = client.get "{/index}/_analyze", update_params(params, :body => text.to_s, :action => "index.analyze")
+        body = params.merge(:text => text.to_s).tap { |h| h.delete(:index) }
+        response = client.get "{/index}/_analyze", update_params(params, :body => body, :action => "index.analyze")
         response.body
       end
 

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -231,7 +231,7 @@ module Elastomer
       # Returns the response body as a Hash
       def analyze( text, params = {} )
         body = text.is_a?(Hash) ? text : {text: text.to_s}
-        response = client.get "{/index}/_analyze", update_params(params, :body => body, :action => "index.analyze")
+        response = client.get "{/index}/_analyze", update_params(params, body: body, action: "index.analyze")
         response.body
       end
 

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -230,7 +230,8 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def analyze( text, params = {} )
-        body = params.merge(:text => text.to_s).tap { |h| h.delete(:index) }
+        body = {:text => text.to_s}.merge params
+        body.delete :index
         response = client.get "{/index}/_analyze", update_params(params, :body => body, :action => "index.analyze")
         response.body
       end

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -186,7 +186,7 @@ describe Elastomer::Client::Index do
   end
 
   it "analyzes text and returns tokens" do
-    tokens = @index.analyze "Just a few words to analyze.", :analyzer => "standard", :index => nil
+    tokens = @index.analyze({text: "Just a few words to analyze.", analyzer: "standard"}, index: nil)
     tokens = tokens["tokens"].map { |h| h["token"] }
     assert_equal %w[just a few words to analyze], tokens
 
@@ -206,7 +206,7 @@ describe Elastomer::Client::Index do
     )
     wait_for_index(@name)
 
-    tokens = @index.analyze "Just a few words to analyze.", :analyzer => "english_standard"
+    tokens = @index.analyze({text: "Just a few words to analyze.", analyzer: "english_standard"})
     tokens = tokens["tokens"].map { |h| h["token"] }
     assert_equal %w[just few words analyze], tokens
   end


### PR DESCRIPTION
In ES 5.x, it's required to pass the analyzer as
a json object in the body and not as a URI parameter.

This PR does so by passing all the parameters bar `:index` in the body.

\cc @look and @elireisman 