### PR TITLE
Change test using deprecated `filter` API

### DIFF
--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -261,7 +261,7 @@ describe Elastomer::Client::Docs do
 
     h = @docs.search({
       :query => {:match_all => {}},
-      :filter => {:term => {:author => "defunkt"}}
+      :post_filter => {:term => {:author => "defunkt"}}
     }, :type => %w[doc1 doc2] )
     assert_equal 1, h["hits"]["total"]
 


### PR DESCRIPTION
`filter` was renamed to `post_filter` in 1.0(!) It has been removed in 5.0 so
this causes a test failure in the 5.x build.