### PR TITLE
Handle ES 5 removing `output` option for fields

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -185,3 +185,10 @@ end
 def requires_percolator_mapping?
   $client.version_support.es_version_5_x?
 end
+
+# COMPATIBILITY
+# ES 5 removes the `output` option for fields.
+# See: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/breaking_50_suggester.html#_simpler_completion_indexing
+def supports_suggest_output?
+  $client.version_support.es_version_2_x?
+end


### PR DESCRIPTION
The `output` option for fields (to be used as the output for suggest queries)
was removed in 5.0. I split up the suggestion tests so there is one specifically
testing this behavior change.

See: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/breaking_50_suggester.html#_simpler_completion_indexing