### PR TITLE
Handle different query parsing exception between versions

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -306,21 +306,10 @@ module Elastomer
       raise ServerError, response if response.status >= 500
 
       if response.body.is_a?(Hash) && (error = response.body["error"])
-        # ES 2.X style
-        if error.is_a?(Hash)
-          root_cause = Array(error["root_cause"]).first || error
-          case root_cause["type"]
-          when "index_not_found_exception"; raise IndexNotFoundError, response
-          when "query_parsing_exception"; raise QueryParsingError, response
-          end
-
-        # ES 1.X style
-        elsif error.is_a?(String)
-          case error
-          when %r/IndexMissingException/; raise IndexNotFoundError, response
-          when %r/QueryParsingException/; raise QueryParsingError, response
-          when %r/ParseException/; raise QueryParsingError, response
-          end
+        root_cause = Array(error["root_cause"]).first || error
+        case root_cause["type"]
+        when "index_not_found_exception"; raise IndexNotFoundError, response
+        when *version_support.query_parse_exception; raise QueryParsingError, response
         end
 
         raise RequestError, response

--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -76,6 +76,20 @@ module Elastomer
       end
     end
 
+    # COMPATIBILITY
+    # ES 2.x reports query parsing exceptions as query_parse_exception whereas
+    # ES 5.x reports them as query_shard_exception or parsing_exception
+    # depending on when the error occurs.
+    #
+    # Returns an Array of Strings to match.
+    def query_parse_exception
+      if es_version_2_x?
+        ["query_parsing_exception"]
+      else
+        ["query_shard_exception", "parsing_exception"]
+      end
+    end
+
     private
 
     # Internal: Helper to reject arguments that shouldn't be passed because


### PR DESCRIPTION
ES 2.x uses query_parsing_exception and ES 5.x uses query_shard_exception or
parsing_exception depending on where the parse error occurs (top-level keys
error out early, but a query string parse failure will happen on a shard and
throw a different exception).

Java classes:

https://github.com/elastic/elasticsearch/blob/v2.4.6/core/src/main/java/org/elasticsearch/index/query/QueryParsingException.java

https://github.com/elastic/elasticsearch/blob/v5.0.0-alpha1/core/src/main/java/org/elasticsearch/index/query/QueryShardException.java
https://github.com/elastic/elasticsearch/blob/v5.0.0-alpha1/core/src/main/java/org/elasticsearch/common/ParsingException.java

I also removed an ES 1.x code path that is unnecessary now.