### PR TITLE
Update multi_percolate tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 Gemfile.lock
 *.gem
 tags
+.byebug_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
-# WIP for 3.3.0 release
+# WIP for 3.0.0 release
 - Fixed swapped args in {Client,Index}#multi\_percolate count calls using block API
-
 
 ## 2.3.0 (2017-11-29)
 - Remove Elasticsearch 1.x and earlier code paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# WIP for 3.3.0 release
+- Fixed swapped args in {Client,Index}#multi\_percolate count calls using block API
+
+
 ## 2.3.0 (2017-11-29)
 - Remove Elasticsearch 1.x and earlier code paths
 - Fix CI and configure an Elasticsearch 5.6 build

--- a/lib/elastomer/client/multi_percolate.rb
+++ b/lib/elastomer/client/multi_percolate.rb
@@ -80,8 +80,7 @@ module Elastomer
       #
       # Returns this MultiPercolate instance.
       def percolate(doc, header = {})
-        merged = @params.merge(header)
-        add_to_actions(:percolate => merged)
+        add_to_actions(:percolate => @params.merge(header))
         add_to_actions(:doc => doc)
       end
 
@@ -94,8 +93,7 @@ module Elastomer
       #
       # Returns this MultiPercolate instance.
       def count(doc, header = {})
-        merged = @params.merge(header)
-        add_to_actions(:count => merged)
+        add_to_actions(:count => @params.merge(header))
         add_to_actions(:doc => doc)
       end
 

--- a/lib/elastomer/client/multi_percolate.rb
+++ b/lib/elastomer/client/multi_percolate.rb
@@ -80,7 +80,8 @@ module Elastomer
       #
       # Returns this MultiPercolate instance.
       def percolate(doc, header = {})
-        add_to_actions(:percolate => header)
+        merged = @params.merge(header)
+        add_to_actions(:percolate => merged)
         add_to_actions(:doc => doc)
       end
 
@@ -93,7 +94,8 @@ module Elastomer
       #
       # Returns this MultiPercolate instance.
       def count(doc, header = {})
-        add_to_actions(:count => header)
+        merged = @params.merge(header)
+        add_to_actions(:count => merged)
         add_to_actions(:doc => doc)
       end
 

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -437,7 +437,7 @@ describe Elastomer::Client::Index do
           @index.docs.index(document)
         end
 
-        assert_equal( 400, exception.status)
+        assert_equal(400, exception.status)
         assert_match(/\[output\]/, exception.message)
       end
     end

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -437,8 +437,8 @@ describe Elastomer::Client::Index do
           @index.docs.index(document)
         end
 
-        assert_equal 400, exception.status
-        assert_match /\[output\]/, exception.message
+        assert_equal( 400, exception.status)
+        assert_match(/\[output\]/, exception.message)
       end
     end
   end

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -353,6 +353,11 @@ describe Elastomer::Client::Index do
     end
 
     it "performs multi percolate queries" do
+      # COMPATIBILITY
+      if requires_percolator_mapping?
+        @index.update_mapping("percolator", { :properties => { :query => { :type => "percolator" } } })
+      end
+
       @index.docs.index \
         :_id    => 1,
         :_type  => "doco",
@@ -367,11 +372,12 @@ describe Elastomer::Client::Index do
 
       @index.percolator("1").create :query => { :match_all => { } }
       @index.percolator("2").create :query => { :match => { :author => "pea53" } }
+      @index.refresh
 
       h = @index.multi_percolate(:type => "doco") do |m|
         m.percolate :author => "pea53"
         m.percolate :author => "grantr"
-        m.count({}, { :author => "grantr" })
+        m.count({ :author => "grantr" }, {})
       end
 
       response1, response2, response3 = h["responses"]

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -29,7 +29,7 @@ describe Elastomer::Client::MultiPercolate do
 
       # COMPATIBILITY
       if requires_percolator_mapping?
-        base_mappings_settings[:mappings] = { :percolator => { :properties => { :query => { :type => "percolator" } } } }
+        base_mappings_settings[:mappings][:percolator] = { :properties => { :query => { :type => "percolator" } } }
       end
 
       @index.create base_mappings_settings


### PR DESCRIPTION
A subset of multi_percolate tests in `index_tests.rb` that exercises the block form of bulk percolation still had an error. Exploration with `byebug` and `awesome_print` revealed that params weren't populating the final request body in the same way they did with the full-body tests or my tests of the legacy `_mpercolate` APIs that worked on 2.4 and 5.6 locally.

This PR updates all that stuff.
