### PR TITLE
Quick fix for a warning message

### DIFF
--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -432,7 +432,7 @@ describe Elastomer::Client::Index do
         end
 
         assert_equal 400, exception.status
-        assert_match /\[output\]/, exception.message
+        assert_match(/\[output\]/, exception.message)
       end
     end
   end


### PR DESCRIPTION
Fixes a warning message by adding parenthesis around the assert method.