### PR TITLE
Fix the `delete_by_query` logic

### DIFF
--- a/lib/elastomer/client/delete_by_query.rb
+++ b/lib/elastomer/client/delete_by_query.rb
@@ -48,28 +48,31 @@ module Elastomer
       DeleteByQuery.new(self, query, params).execute
     end
 
-    SEARCH_PARAMETERS = [
-      :q,
-      :df,
-      :analyzer,
-      :analyze_wildcard,
-      :batched_reduce_size,
-      :default_operator,
-      :lenient,
-      :explain,
-      :_source,
-      :stored_fields,
-      :sort,
-      :track_scores,
-      :timeout,
-      :terminate_after,
-      :from,
-      :size,
-      :search_type,
-      :scroll
-    ].to_set.freeze
-
     class DeleteByQuery
+
+      SEARCH_PARAMETERS = %i[
+        index
+        type
+        q
+        df
+        analyzer
+        analyze_wildcard
+        batched_reduce_size
+        default_operator
+        lenient
+        explain
+        _source
+        stored_fields
+        sort
+        track_scores
+        timeout
+        terminate_after
+        from
+        size
+        search_type
+        scroll
+      ].to_set.freeze
+
 
       # Create a new DeleteByQuery command for deleting documents matching a
       # query

--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -90,6 +90,10 @@ module Elastomer
       end
     end
 
+    # COMPATIBILITY
+    # ES 5.X supports `delete_by_query` natively again.
+    alias :native_delete_by_query? :es_version_5_x?
+
     private
 
     # Internal: Helper to reject arguments that shouldn't be passed because

--- a/test/client/scroller_test.rb
+++ b/test/client/scroller_test.rb
@@ -104,7 +104,13 @@ describe Elastomer::Client::Scroller do
     refute_nil h["_scroll_id"], "response is missing a scroll ID"
 
     response = $client.clear_scroll(h["_scroll_id"])
-    assert_empty response
+
+    if returns_cleared_scroll_id_info?
+      assert response["succeeded"]
+      assert_equal 1, response["num_freed"]
+    else
+      assert_empty response
+    end
   end
 
   it "raises an exception on existing sort in query" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -198,3 +198,9 @@ end
 def supports_suggest_output?
   $client.version_support.es_version_2_x?
 end
+
+# COMPATIBILITY
+# ES 5 returns information about the number of cleared scroll IDs
+def returns_cleared_scroll_id_info?
+  $client.version_support.es_version_5_x?
+end

--- a/test/version_support_test.rb
+++ b/test/version_support_test.rb
@@ -56,6 +56,11 @@ describe Elastomer::VersionSupport do
       end
     end
 
+    describe "native_delete_by_query?" do
+      it "returns false" do
+        refute version_support.native_delete_by_query?, "ES 2.X does not have native delete_by_query support"
+      end
+    end
   end
 
   describe "ES 5.x" do
@@ -78,6 +83,12 @@ describe Elastomer::VersionSupport do
           term_vector: "with_positions_offsets"
         }
         assert_equal(expected, version_support.text(term_vector: "with_positions_offsets"))
+      end
+    end
+
+    describe "native_delete_by_query?" do
+      it "returns true" do
+        assert version_support.native_delete_by_query?, "ES 5.X has native delete_by_query support"
       end
     end
   end


### PR DESCRIPTION
The change here allows `index` and `type` to be passed to the scroll query. These parameters are used to restrict the `delete_by_query` action to the given index and document type.