### PR TITLE
Fail fast on known invalid indexing directive fields

### DIFF
--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -527,6 +527,9 @@ Percolate
       # document - A document Hash or JSON encoded String.
       #
       # Returns an options Hash extracted from the document.
+      #
+      # Raises Elastomer::Client::InvalidParameter if an unsupported indexing
+      # directive is used.
       def from_document( document )
         opts = {:body => document}
 
@@ -545,7 +548,7 @@ Percolate
           # felt it was best to consistently fail fast.
           client.version_support.unsupported_indexing_directives.each do |key, field|
             if document.key?(field) || document.key?(field.to_sym)
-              raise IncompatibleVersionException, "Elasticsearch #{client.version} does not support the '#{key}' indexing parameter"
+              raise InvalidParameter, "Elasticsearch #{client.version} does not support the '#{key}' indexing parameter"
             end
           end
         end

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -40,7 +40,9 @@ module Elastomer
       # There are several other document attributes that control how
       # Elasticsearch will index the document. They are listed below. Please
       # refer to the Elasticsearch documentation for a full explanation of each
-      # and how it affects the indexing process.
+      # and how it affects the indexing process. These indexing directives vary
+      # by Elasticsearch version. Attempting to use a directive not supported
+      # by the Elasticsearch server will raise an exception.
       #
       #   :_id
       #   :_type
@@ -49,11 +51,17 @@ module Elastomer
       #   :_op_type
       #   :_routing
       #   :_parent
-      #   :_timestamp
-      #   :_ttl
-      #   :_consistency
-      #   :_replication
       #   :_refresh
+      #
+      # Elasticsearch 2.X only:
+      #
+      #   :_timestamp (deprecated)
+      #   :_ttl (deprecated)
+      #   :_consistency
+      #
+      # Elasticsearch 5.x only:
+      #
+      #   :_wait_for_active_shards
       #
       # If any of these attributes are present in the document they will be
       # removed from the document before it is indexed. This means that the
@@ -65,6 +73,9 @@ module Elastomer
       # See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
       #
       # Returns the response body as a Hash
+      #
+      # Raises Elastomer::Client::InvalidParameter if an unsupported indexing
+      # directive is used.
       def index( document, params = {} )
         overrides = from_document document
         params = update_params(params, overrides)

--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -108,5 +108,8 @@ module Elastomer
     # Elasticsearch being used.
     IncompatibleVersionException = Class.new Error
 
+    # Exception for client-detected invalid Elasticsearch parameter
+    InvalidParameter = Class.new Error
+
   end  # Client
 end  # Elastomer

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -1,4 +1,5 @@
 require File.expand_path("../../test_helper", __FILE__)
+require 'active_support/core_ext/hash'
 
 describe Elastomer::Client::Docs do
 
@@ -97,26 +98,81 @@ describe Elastomer::Client::Docs do
     assert_match %r/^\S{20,22}$/, h["_id"]
   end
 
-  it "extracts underscore attributes from the document" do
-    doc = {
-      :_id => "12",
-      :_type => "doc2",
-      :_routing => "author",
-      "_consistency" => "all",
-      :title => "The Adventures of Huckleberry Finn",
-      :author => "Mark Twain",
-      :_unknown => "unknown attribute"
-    }
+  describe "indexing directive fields" do
+    it "indexes fields that are not recognized as indexing directives" do
+      doc = {
+        _id: "12",
+        _type: "doc2",
+        title: "The Adventures of Huckleberry Finn",
+        author: "Mark Twain",
+        _unknown_1: "unknown attribute 1",
+        "_unknown_2" => "unknown attribute 2"
+      }
 
-    h = @docs.index doc
-    assert_created h
-    assert_equal "12", h["_id"]
+      h = @docs.index(doc)
+      assert_created h
+      assert_equal "12", h["_id"]
 
-    refute doc.key?(:_id)
-    refute doc.key?(:_type)
-    refute doc.key?(:_routing)
-    refute doc.key?("_consistency")
-    assert doc.key?(:_unknown)
+      indexed_doc = @docs.get(type: "doc2", id: "12")
+      expected = {
+        "title" => "The Adventures of Huckleberry Finn",
+        "author" => "Mark Twain",
+        "_unknown_1" => "unknown attribute 1",
+        "_unknown_2" => "unknown attribute 2"
+      }
+      assert_equal expected, indexed_doc["_source"]
+    end
+
+    it "extracts indexing directives from the document" do
+      doc = {
+        _id: "12",
+        "_type" => "doc2",
+        _routing: "author",
+        title: "The Adventures of Huckleberry Finn",
+        author: "Mark Twain"
+      }
+
+      h = @docs.index(doc)
+      assert_created h
+      assert_equal "12", h["_id"]
+
+      # Special keys are removed from the document hash
+      refute doc.key?(:_id)
+      refute doc.key?("_type")
+      refute doc.key?(:_routing)
+
+      indexed_doc = @docs.get(type: "doc2", id: "12")
+      expected = {
+        "title" => "The Adventures of Huckleberry Finn",
+        "author" => "Mark Twain",
+      }
+      assert_equal expected, indexed_doc["_source"]
+    end
+
+    # COMPATIBILITY: Fail fast on known indexing directives that aren't for this version of ES
+    it "raises an exception when a known indexing directive from an unsupported version is used" do
+      # Symbol keys
+      doc = {
+        _id: "12",
+        _type: "doc2",
+        title: "The Adventures of Huckleberry Finn"
+      }.merge(incompatible_indexing_directive)
+
+      assert_raises(Elastomer::Client::IncompatibleVersionException) do
+        @docs.index(doc)
+      end
+
+      # String keys
+      doc = {
+        "_id" => "12",
+        "_type" => "doc2",
+        "title" => "The Adventures of Huckleberry Finn"
+      }.merge(incompatible_indexing_directive.stringify_keys)
+
+      assert_raises(Elastomer::Client::IncompatibleVersionException) do
+        @docs.index(doc)
+      end
+    end
   end
 
   it "gets documents from the search index" do

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -158,7 +158,7 @@ describe Elastomer::Client::Docs do
         title: "The Adventures of Huckleberry Finn"
       }.merge(incompatible_indexing_directive)
 
-      assert_raises(Elastomer::Client::IncompatibleVersionException) do
+      assert_raises(Elastomer::Client::InvalidParameter) do
         @docs.index(doc)
       end
 
@@ -169,7 +169,7 @@ describe Elastomer::Client::Docs do
         "title" => "The Adventures of Huckleberry Finn"
       }.merge(incompatible_indexing_directive.stringify_keys)
 
-      assert_raises(Elastomer::Client::IncompatibleVersionException) do
+      assert_raises(Elastomer::Client::InvalidParameter) do
         @docs.index(doc)
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -204,3 +204,13 @@ end
 def returns_cleared_scroll_id_info?
   $client.version_support.es_version_5_x?
 end
+
+# COMPATIBILITY
+# Return a Hash with an unsupported indexing directive key/value to test fail-fast.
+def incompatible_indexing_directive
+  if $client.version_support.es_version_2_x?
+    {_wait_for_active_shards: 10}
+  else
+    {_consistency: "all"}
+  end
+end

--- a/test/version_support_test.rb
+++ b/test/version_support_test.rb
@@ -61,6 +61,18 @@ describe Elastomer::VersionSupport do
         refute version_support.native_delete_by_query?, "ES 2.X does not have native delete_by_query support"
       end
     end
+
+    describe "#indexing_directives" do
+      it "returns a Hash of indexing parameter name to field name" do
+        assert_includes(version_support.indexing_directives.to_a, [:consistency, "_consistency"])
+      end
+    end
+
+    describe "#unsupported_indexing_directives" do
+      it "returns a Hash of indexing parameter name to field name" do
+        assert_includes(version_support.unsupported_indexing_directives.to_a, [:wait_for_active_shards, "_wait_for_active_shards"])
+      end
+    end
   end
 
   describe "ES 5.x" do
@@ -89,6 +101,18 @@ describe Elastomer::VersionSupport do
     describe "native_delete_by_query?" do
       it "returns true" do
         assert version_support.native_delete_by_query?, "ES 5.X has native delete_by_query support"
+      end
+    end
+
+    describe "#indexing_directives" do
+      it "returns a Hash of indexing parameter name to field name" do
+        assert_includes(version_support.indexing_directives.to_a, [:wait_for_active_shards, "_wait_for_active_shards"])
+      end
+    end
+
+    describe "#unsupported_indexing_directives" do
+      it "returns an Hash of indexing parameter names to field name" do
+        assert_includes(version_support.unsupported_indexing_directives.to_a, [:consistency, "_consistency"])
       end
     end
   end


### PR DESCRIPTION
Pull the different "special" fields that affect indexing into VersionSupport in
order to return a different Hash of parameter name/field name depending on the
client's version.

If a caller attempts to index a document with a known indexing directive field
that is not supported by the version of Elasticsearch, the client will fail fast
and not allow the document to be indexed.

Fixes #178.