### PR TITLE
Raise an IllegalArgument exception

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -309,6 +309,7 @@ module Elastomer
         root_cause = Array(error["root_cause"]).first || error
         case root_cause["type"]
         when "index_not_found_exception"; raise IndexNotFoundError, response
+        when "illegal_argument_exception"; raise InvalidParameter, response
         when *version_support.query_parse_exception; raise QueryParsingError, response
         end
 

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -309,7 +309,7 @@ module Elastomer
         root_cause = Array(error["root_cause"]).first || error
         case root_cause["type"]
         when "index_not_found_exception"; raise IndexNotFoundError, response
-        when "illegal_argument_exception"; raise InvalidParameter, response
+        when "illegal_argument_exception"; raise IllegalArgument, response
         when *version_support.query_parse_exception; raise QueryParsingError, response
         end
 

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -74,7 +74,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       #
-      # Raises Elastomer::Client::InvalidParameter if an unsupported indexing
+      # Raises Elastomer::Client::IllegalArgument if an unsupported indexing
       # directive is used.
       def index( document, params = {} )
         overrides = from_document document
@@ -539,7 +539,7 @@ Percolate
       #
       # Returns an options Hash extracted from the document.
       #
-      # Raises Elastomer::Client::InvalidParameter if an unsupported indexing
+      # Raises Elastomer::Client::IllegalArgument if an unsupported indexing
       # directive is used.
       def from_document( document )
         opts = {:body => document}
@@ -559,7 +559,7 @@ Percolate
           # felt it was best to consistently fail fast.
           client.version_support.unsupported_indexing_directives.each do |key, field|
             if document.key?(field) || document.key?(field.to_sym)
-              raise InvalidParameter, "Elasticsearch #{client.version} does not support the '#{key}' indexing parameter"
+              raise IllegalArgument, "Elasticsearch #{client.version} does not support the '#{key}' indexing parameter"
             end
           end
         end

--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -109,7 +109,7 @@ module Elastomer
     IncompatibleVersionException = Class.new Error
 
     # Exception for client-detected invalid Elasticsearch parameter
-    InvalidParameter = Class.new Error
+    IllegalArgument = Class.new Error
 
   end  # Client
 end  # Elastomer

--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -108,8 +108,9 @@ module Elastomer
     # Elasticsearch being used.
     IncompatibleVersionException = Class.new Error
 
-    # Exception for client-detected invalid Elasticsearch parameter
+    # Exception for client-detected and server-raised invalid Elasticsearch
+    # request parameter.
     IllegalArgument = Class.new Error
 
-  end  # Client
-end  # Elastomer
+  end
+end

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -158,7 +158,7 @@ describe Elastomer::Client::Docs do
         title: "The Adventures of Huckleberry Finn"
       }.merge(incompatible_indexing_directive)
 
-      assert_raises(Elastomer::Client::InvalidParameter) do
+      assert_raises(Elastomer::Client::IllegalArgument) do
         @docs.index(doc)
       end
 
@@ -169,7 +169,7 @@ describe Elastomer::Client::Docs do
         "title" => "The Adventures of Huckleberry Finn"
       }.merge(incompatible_indexing_directive.stringify_keys)
 
-      assert_raises(Elastomer::Client::InvalidParameter) do
+      assert_raises(Elastomer::Client::IllegalArgument) do
         @docs.index(doc)
       end
     end

--- a/test/client/errors_test.rb
+++ b/test/client/errors_test.rb
@@ -72,4 +72,24 @@ describe Elastomer::Client::Error do
     assert !Elastomer::Client::ConnectionFailed.fatal, "Connection failures are not fatal"
     assert !Elastomer::Client::ServerError.fatal, "Server errors are not fatal"
   end
+
+  if parameter_validation?
+    it "wraps illegal argument exceptions" do
+      begin
+        $client.get("/_cluster/health?consistency=all")
+        assert false, "InvalidParameter exception was not raised"
+      rescue Elastomer::Client::InvalidParameter => err
+        assert_match(/request \[\/_cluster\/health\] contains unrecognized parameter: \[consistency\]/, err.message)
+      end
+    end
+  else
+    it "does not raise illegal argument exceptions" do
+      begin
+        $client.get("/_cluster/health?wait_for_active_shards=10")
+        assert true, "Exception was not raised"
+      rescue Elastomer::Client::Error => err
+        assert false, "Exception #{err} was raised"
+      end
+    end
+  end
 end

--- a/test/client/errors_test.rb
+++ b/test/client/errors_test.rb
@@ -77,8 +77,8 @@ describe Elastomer::Client::Error do
     it "wraps illegal argument exceptions" do
       begin
         $client.get("/_cluster/health?consistency=all")
-        assert false, "InvalidParameter exception was not raised"
-      rescue Elastomer::Client::InvalidParameter => err
+        assert false, "IllegalArgument exception was not raised"
+      rescue Elastomer::Client::IllegalArgument => err
         assert_match(/request \[\/_cluster\/health\] contains unrecognized parameter: \[consistency\]/, err.message)
       end
     end

--- a/test/client/errors_test.rb
+++ b/test/client/errors_test.rb
@@ -85,7 +85,7 @@ describe Elastomer::Client::Error do
   else
     it "does not raise illegal argument exceptions" do
       begin
-        $client.get("/_cluster/health?wait_for_active_shards=10")
+        $client.get("/_cluster/health?consistency=all")
         assert true, "Exception was not raised"
       rescue Elastomer::Client::Error => err
         assert false, "Exception #{err} was raised"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -214,3 +214,9 @@ def incompatible_indexing_directive
     {_consistency: "all"}
   end
 end
+
+# COMPATIBILITY
+# Returns true if the Elasticsearch cluster will validate request parameters.
+def parameter_validation?
+  $client.version_support.es_version_5_x?
+end


### PR DESCRIPTION
With Elasticsearch 5.X now validating the parameters passed with each HTTP request, this code raises an InvalidParameter excpetion if we violate what Elasticsearch expects. This will help us find and fix these problems in our own application.