### PR TITLE
Implement `dup` method for Client

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -43,6 +43,18 @@ module Elastomer
     attr_reader :host, :port, :url
     attr_reader :read_timeout, :open_timeout, :max_request_size
 
+    # Returns a duplicate of this Client connection configured in the exact same
+    # fashion.
+    def dup
+      self.class.new \
+          url:              url,
+          read_timeout:     read_timeout,
+          open_timeout:     open_timeout,
+          adapter:          @adapter,
+          opaque_id:        @opaque_id,
+          max_request_size: max_request_size
+    end
+
     # Returns true if the server is available; returns false otherwise.
     def ping
       response = head "/", :action => "cluster.ping"

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -167,4 +167,25 @@ describe Elastomer::Client do
       assert_equal Semantic::Version.new(version_string), $client.semantic_version
     end
   end
+
+  describe "duplicating a client connection" do
+    it "is configured the same" do
+      client = $client.dup
+
+      refute_same $client, client
+
+      assert_equal $client.host, client.host
+      assert_equal $client.port, client.port
+      assert_equal $client.url, client.url
+      assert_equal $client.read_timeout, client.read_timeout
+      assert_equal $client.open_timeout, client.open_timeout
+      assert_equal $client.max_request_size, client.max_request_size
+    end
+
+    it "has a unique connection" do
+      client = $client.dup
+
+      refute_same $client.connection, client.connection
+    end
+  end
 end


### PR DESCRIPTION
The goal of this PR is to implement an `Elastomer::Client#dup` method that returns a client with the same configuration but with a unique connection to the Elasticsearch cluster. This is useful for multi-threaded environments where the socket connection to the cluster should not be shared across thread boundaries.