### PR TITLE
Retry requests when possible

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -15,8 +15,8 @@ module Elastomer
 
     # Create a new client that can be used to make HTTP requests to the
     # Elasticsearch server. If you use `:max_retries`, then any GET or HEAD
-    # request will be retried up this many times with a 75ms delay between the
-    # retry attempts. Only non-fatal exceptions will retried automatically.
+    # request will be retried up to this many times with a 75ms delay between
+    # the retry attempts. Only non-fatal exceptions will retried automatically.
     #
     # see lib/elastomer/client/errors.rb#L92-L94
     #

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -14,7 +14,11 @@ module Elastomer
     RETRYABLE_METHODS = %i[get head].freeze
 
     # Create a new client that can be used to make HTTP requests to the
-    # Elasticsearch server.
+    # Elasticsearch server. If you use `:max_retries`, then any GET or HEAD
+    # request will be retried up this many times with a 75ms delay between the
+    # retry attempts. Only non-fatal exceptions will retried automatically.
+    #
+    # see lib/elastomer/client/errors.rb#L92-L94
     #
     # Method params:
     #   :host - the host as a String

--- a/lib/elastomer/notifications.rb
+++ b/lib/elastomer/notifications.rb
@@ -59,7 +59,6 @@ module Elastomer
         :type         => params[:type],
         :action       => params[:action],
         :context      => params[:context],
-        :retries      => params[:retries],
         :request_body => body,
         :body         => body   # for backwards compatibility
       }
@@ -70,6 +69,7 @@ module Elastomer
         payload[:method]        = response.env[:method]
         payload[:status]        = response.status
         payload[:response_body] = response.body
+        payload[:retries]       = params[:retries]
         response
       end
     end

--- a/lib/elastomer/notifications.rb
+++ b/lib/elastomer/notifications.rb
@@ -59,6 +59,7 @@ module Elastomer
         :type         => params[:type],
         :action       => params[:action],
         :context      => params[:context],
+        :retries      => params[:retries],
         :request_body => body,
         :body         => body   # for backwards compatibility
       }

--- a/script/cibuild
+++ b/script/cibuild
@@ -57,11 +57,12 @@ trap cleanup EXIT
 export ES_PORT=${ES_PORT:-19200}
 
 es_version=${ES_VERSION:-24}
-docker_compose="docker-compose --file docker/docker-compose.es${es_version}.yml --file docker/docker-compose.cibuild.yml"
+docker_compose="docker-compose --file docker/docker-compose.es${es_version}.yml"
 
-# if [ "${CI_MODE:-}" ]; then
-#   docker_compose="${docker_compose} --no-ansi"
-# fi
+if [ "${CI_MODE:-}" ]; then
+  docker_compose="${docker_compose} --file docker/docker-compose.cibuild.yml"
+#  docker_compose="${docker_compose} --no-ansi"
+fi
 
 # change into root dir and setup path
 cd $(dirname "$0")/..


### PR DESCRIPTION
The goal of this PR is to add automated retries for failed requests. A new attribute `max_retries` is added to the client. This determines the maximum number of retry attempts that will be made by the client; it can be overridden on a per-request basis.

Only `GET` and `HEAD` requests can be retried. My thought here is that `PUT`, `POST`, and `DELETE` requests might actually succeed on the Elasticsearch cluster, but the request itself might timeout. In this case the desired modification was made so we do not want to retry the request.

Only a handful of exceptions can be retried. See:

https://github.com/github/elastomer-client/blob/master/lib/elastomer/client/errors.rb#L91-L95