### PR TITLE
add version_support shim for strict bool fields

### DIFF
--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -71,6 +71,8 @@ module Elastomer
     end
 
     # COMPATIBILITY: return a simple boolean value or legacy {"enabled": true/false}.
+    #
+    # https://www.elastic.co/guide/en/elasticsearch/reference/5.5/breaking_50_mapping_changes.html#_literal_norms_literal
     def strict_boolean(b)
       if es_version_2_x?
         {enabled: b}

--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -70,6 +70,15 @@ module Elastomer
       end
     end
 
+    # COMPATIBILITY: return a simple boolean value or legacy {"enabled": true/false}.
+    def strict_boolean(b)
+      if es_version_2_x?
+        {enabled: b}
+      else
+        b
+      end 
+    end
+
     # Elasticsearch 2.0 changed some request formats in a non-backward-compatible
     # way. Some tests need to know what version is running to structure requests
     # as expected.


### PR DESCRIPTION
just quick shim for updating the `lib/elastomer/indexes` `:norms` and any other stray fields that should be on strict boolean values now