### PR TITLE
Allow routing for delete_by_query

### DIFF
--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -151,7 +151,7 @@ module Elastomer
       # and https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-type.html#scan
       #
       # client - Elastomer::Client used for HTTP requests to the server
-      # query  - The query to scan as a Hash or a JSON encoded String
+      # query  - The query to scroll as a Hash or a JSON encoded String
       # opts   - Options Hash
       #   :index       - the name of the index to search
       #   :type        - the document type to search

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -136,10 +136,10 @@ module Elastomer
     end
 
     DEFAULT_OPTS = {
-      :index => nil,
-      :type => nil,
-      :scroll => "5m",
-      :size => 50,
+      index:   nil,
+      type:    nil,
+      scroll:  "1m",
+      size:    100,
     }.freeze
 
     class Scroller

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -135,7 +135,7 @@ module Elastomer
       query.merge(:sort => [:_doc])
     end
 
-  DEFAULT_OPTS = {
+    DEFAULT_OPTS = {
       :index => nil,
       :type => nil,
       :scroll => "5m",

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -138,8 +138,8 @@ module Elastomer
     DEFAULT_OPTS = {
       index:   nil,
       type:    nil,
-      scroll:  "1m",
-      size:    100,
+      scroll:  "5m",
+      size:    50,
     }.freeze
 
     class Scroller


### PR DESCRIPTION
The main object of this pull request is to allow the passing of the `routing` parameter to the application `delete_by_query` implementation. The approach I took was to remove the param validations since the implementation is focused primarily on ES 2.X where parameter validation is not enforced. If ES 5.X or higher is being used, then the native `delete_by_query` implementation is used by default.