### PR TITLE
ES5 compatibility: strip :read_timeout param in native delete-by-query

### DIFF
--- a/lib/elastomer/client/native_delete_by_query.rb
+++ b/lib/elastomer/client/native_delete_by_query.rb
@@ -38,6 +38,9 @@ module Elastomer
           raise IncompatibleVersionException, "Elasticsearch '#{client.version}' does not support _delete_by_query"
         end
 
+        # COMPATIBILITY: read_timeout param is invalid, must remove at last moment
+        parameters.select! { |k, _| k.to_sym != :read_timeout }
+
         parameters.keys.each do |key|
           unless PARAMETERS.include?(key) || PARAMETERS.include?(key.to_sym)
             raise IllegalArgument, "'#{key}' is not a valid _delete_by_query parameter"
@@ -47,7 +50,6 @@ module Elastomer
         @client = client
         @query = query
         @parameters = parameters
-
       end
 
       def execute

--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,5 +1,5 @@
 module Elastomer
-  VERSION = "3.0.1"
+  VERSION = "3.0.2"
 
   def self.version
     VERSION

--- a/test/client/native_delete_by_query_test.rb
+++ b/test/client/native_delete_by_query_test.rb
@@ -72,6 +72,11 @@ describe Elastomer::Client::NativeDeleteByQuery do
         end
       end
 
+      it "removes :read_timeout param from native delete-by-query calls, since ES5 removes it" do
+        dbq = Elastomer::Client::NativeDeleteByQuery.new(@index.client, {}, read_timeout: "2m")
+        assert_equal dbq.parameters.key?(:read_timeout) || dbq.parameters.key?("read_timeout"), false
+      end
+
       it "deletes by query when routing is specified" do
         index = $client.index "elastomer-delete-by-query-routing-test"
         index.delete if index.exists?


### PR DESCRIPTION
As stated in title. Fixes some fails in `github-es56` CI build when native delete_by_query is used.