### PR TITLE
alias for strict request params by ES version

### DIFF
--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -135,6 +135,11 @@ module Elastomer
     end
 
     # COMPATIBILITY
+    #
+    # ES5 doesn't accept/ignore ambiguous or unexpected req params any more
+    alias :strict_request_params? :es_version_5_x?
+
+    # COMPATIBILITY
     # ES 5.X supports `delete_by_query` natively again.
     alias :native_delete_by_query? :es_version_5_x?
 


### PR DESCRIPTION
for caller-side shims removing illegal unexpected req params when talking to ES5+ needed for `:read_timeout` for `native_delete_by_query`, `:timeout` for `_count` and `_refresh` params, and others (gh/gh PR for this on the way once this is checked in) 