### PR TITLE
Request Parameter Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin
+/vendor/elasticsearch
 /vendor/gems
 /.bundle
 /.rbenv-version

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -332,11 +332,15 @@ module Elastomer
       query_values.delete :context
       query_values.delete :retries
 
+      rest_api = query_values.delete :rest_api
+
       template.keys.map(&:to_sym).each do |key|
         value = query_values.delete key
         value = assert_param_presence(value, key) unless path =~ /{\/#{key}}/ && value.nil?
         expansions[key] = value
       end
+
+      query_values = api_spec.select_params(api: rest_api, from: query_values) if rest_api
 
       uri = template.expand(expansions)
       uri.query_values = query_values unless query_values.empty?

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -69,7 +69,7 @@ module Elastomer
 
     # Returns true if the server is available; returns false otherwise.
     def ping
-      response = head "/", :action => "cluster.ping"
+      response = head "/", action: "cluster.ping"
       response.success?
     rescue StandardError
       false
@@ -92,7 +92,7 @@ module Elastomer
 
     # Returns the information Hash from the attached Elasticsearch instance.
     def info
-      response = get "/", :action => "cluster.info"
+      response = get "/", action: "cluster.info"
       response.body
     end
 
@@ -111,7 +111,7 @@ module Elastomer
         conn.request(:encode_json)
         conn.response(:parse_json)
         conn.request(:opaque_id) if @opaque_id
-        conn.request(:limit_size, :max_request_size => max_request_size) if max_request_size
+        conn.request(:limit_size, max_request_size: max_request_size) if max_request_size
 
         if @adapter.is_a?(Array)
           conn.adapter(*@adapter)
@@ -316,10 +316,10 @@ module Elastomer
     #
     # Examples
     #
-    #   expand_path('/foo{/bar}', {:bar => 'hello', :q => 'what', :p => 2})
+    #   expand_path('/foo{/bar}', {bar: 'hello', q: 'what', p: 2})
     #   #=> '/foo/hello?q=what&p=2'
     #
-    #   expand_path('/foo{/bar}{/baz}', {:baz => 'no bar'}
+    #   expand_path('/foo{/bar}{/baz}', {baz: 'no bar'}
     #   #=> '/foo/no%20bar'
     #
     # Returns an Addressable::Uri

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -78,7 +78,10 @@ module Elastomer
 
     # Returns the version String of the attached Elasticsearch instance.
     def version
-      @version ||= info["version"]["number"]
+      @version ||= begin
+        response = get "/"
+        response.body.dig("version", "number")
+      end
     end
 
     # Returns a Semantic::Version for the attached Elasticsearch instance.
@@ -91,6 +94,12 @@ module Elastomer
     def info
       response = get "/", :action => "cluster.info"
       response.body
+    end
+
+    # Returns the ApiSpec for the specific version of Elasticsearch that this
+    # Client is connected to.
+    def api_spec
+      @api_spec ||= RestApiSpec.api_spec(version)
     end
 
     # Internal: Provides access to the Faraday::Connection used by this client

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -38,7 +38,7 @@ module Elastomer
         raise "bulk request body cannot be nil" if body.nil?
         params ||= {}
 
-        response = self.post "{/index}{/type}/_bulk", params.merge(:body => body, :action => "bulk")
+        response = self.post "{/index}{/type}/_bulk", params.merge(body: body, action: "bulk", rest_api: "bulk")
         response.body
       end
     end

--- a/lib/elastomer/client/cluster.rb
+++ b/lib/elastomer/client/cluster.rb
@@ -34,7 +34,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def health( params = {} )
-        response = client.get "/_cluster/health{/index}", params.merge(action: "cluster.health")
+        response = client.get "/_cluster/health{/index}", params.merge(action: "cluster.health", rest_api: "cluster.health")
         response.body
       end
 
@@ -52,7 +52,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def state( params = {} )
-        response = client.get "/_cluster/state{/metrics}{/indices}", params.merge(action: "cluster.state")
+        response = client.get "/_cluster/state{/metrics}{/indices}", params.merge(action: "cluster.state", rest_api: "cluster.state")
         response.body
       end
 
@@ -67,7 +67,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def stats( params = {} )
-        response = client.get "/_cluster/stats", params.merge(action: "cluster.stats")
+        response = client.get "/_cluster/stats", params.merge(action: "cluster.stats", rest_api: "cluster.stats")
         response.body
       end
 
@@ -80,7 +80,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def pending_tasks( params = {} )
-        response = client.get "/_cluster/pending_tasks", params.merge(action: "cluster.pending_tasks")
+        response = client.get "/_cluster/pending_tasks", params.merge(action: "cluster.pending_tasks", rest_api: "cluster.pending_tasks")
         response.body
       end
 
@@ -101,7 +101,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def get_settings( params = {} )
-        response = client.get "/_cluster/settings", params.merge(action: "cluster.get_settings")
+        response = client.get "/_cluster/settings", params.merge(action: "cluster.get_settings", rest_api: "cluster.get_settings")
         response.body
       end
       alias_method :settings, :get_settings
@@ -117,7 +117,7 @@ module Elastomer
       #
       # Returns the response as a Hash
       def update_settings( body, params = {} )
-        response = client.put "/_cluster/settings", params.merge(body: body, action: "cluster.update_settings")
+        response = client.put "/_cluster/settings", params.merge(body: body, action: "cluster.update_settings", rest_api: "cluster.put_settings")
         response.body
       end
 
@@ -157,20 +157,7 @@ module Elastomer
           body = {commands: Array(commands)}
         end
 
-        response = client.post "/_cluster/reroute", params.merge(body: body, action: "cluster.reroute")
-        response.body
-      end
-
-      # Shutdown the entire cluster. There is also a Nodes#shutdown method for
-      # shutting down individual nodes.
-      #
-      # params - Parameters Hash
-      #
-      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-shutdown.html
-      #
-      # Returns the response as a Hash
-      def shutdown( params = {} )
-        response = client.post "/_shutdown", params.merge(action: "cluster.shutdown")
+        response = client.post "/_cluster/reroute", params.merge(body: body, action: "cluster.reroute", rest_api: "cluster.reroute")
         response.body
       end
 
@@ -181,6 +168,7 @@ module Elastomer
       #
       # params - Parameters Hash
       #   :index - an index name or Array of index names
+      #   :name  - an alias name or Array of alias names
       #
       # Examples
       #
@@ -191,7 +179,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_aliases( params = {} )
-        response = client.get "{/index}/_aliases", params.merge(action: "cluster.get_aliases")
+        response = client.get "{/index}/_alias{/name}", params.merge(action: "cluster.get_aliases", rest_api: "indices.get_alias")
         response.body
       end
       alias_method :aliases, :get_aliases
@@ -227,7 +215,7 @@ module Elastomer
           body = {actions: Array(actions)}
         end
 
-        response = client.post "/_aliases", params.merge(body: body, action: "cluster.update_aliases")
+        response = client.post "/_aliases", params.merge(body: body, action: "cluster.update_aliases", rest_api: "indices.update_aliases")
         response.body
       end
 

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -40,7 +40,7 @@ module Elastomer
       #
       # Returns true if the index (or type) exists
       def exists?( params = {} )
-        response = client.head "/{index}{/type}", update_params(params, :action => "index.exists")
+        response = client.head "/{index}{/type}", update_params(params, action: "index.exists", rest_api: "indices.exists")
         response.success?
       end
       alias_method :exist?, :exists?
@@ -54,7 +54,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create( body, params = {} )
-        response = client.put "/{index}", update_params(params, :body => body, :action => "index.create")
+        response = client.put "/{index}", update_params(params, body: body, action: "index.create", rest_api: "indices.create")
         response.body
       end
 
@@ -66,7 +66,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete( params = {} )
-        response = client.delete "/{index}", update_params(params, :action => "index.delete")
+        response = client.delete "/{index}", update_params(params, action: "index.delete", rest_api: "indices.delete")
         response.body
       end
 
@@ -78,7 +78,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def open( params = {} )
-        response = client.post "/{index}/_open", update_params(params, :action => "index.open")
+        response = client.post "/{index}/_open", update_params(params, action: "index.open", rest_api: "indices.open")
         response.body
       end
 
@@ -90,7 +90,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def close( params = {} )
-        response = client.post "/{index}/_close", update_params(params, :action => "index.close")
+        response = client.post "/{index}/_close", update_params(params, action: "index.close", rest_api: "indices.close")
         response.body
       end
 
@@ -102,7 +102,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_settings( params = {} )
-        response = client.get "{/index}/_settings", update_params(params, :action => "index.get_settings")
+        response = client.get "{/index}/_settings", update_params(params, action: "index.get_settings", rest_api: "indices.get_settings")
         response.body
       end
       alias_method :settings, :get_settings
@@ -116,7 +116,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def update_settings( body, params = {} )
-        response = client.put "{/index}/_settings", update_params(params, :body => body, :action => "index.update_settings")
+        response = client.put "{/index}/_settings", update_params(params, body: body, action: "index.update_settings", rest_api: "indices.put_settings")
         response.body
       end
 
@@ -130,7 +130,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_mapping( params = {} )
-        response = client.get "/{index}/_mapping{/type}", update_params(params, :action => "index.get_mapping")
+        response = client.get "/{index}/_mapping{/type}", update_params(params, action: "index.get_mapping", rest_api: "indices.get_mapping")
         response.body
       end
       alias_method :mapping, :get_mapping
@@ -145,7 +145,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def update_mapping( type, body, params = {} )
-        response = client.put "/{index}/_mapping/{type}", update_params(params, :body => body, :type => type, :action => "index.update_mapping")
+        response = client.put "/{index}/_mapping/{type}", update_params(params, body: body, type: type, action: "index.update_mapping", rest_api: "indices.put_mapping")
         response.body
       end
       alias_method :put_mapping, :update_mapping
@@ -158,7 +158,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_aliases( params = {} )
-        response = client.get "/{index}/_aliases", update_params(:action => "index.get_aliases")
+        response = client.get "/{index}/_alias", update_params(action: "index.get_aliases", rest_api: "indices.get_alias")
         response.body
       end
       alias_method :aliases, :get_aliases
@@ -179,7 +179,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get_alias( name, params = {} )
-        response = client.get "/{index}/_alias/{name}", update_params(params, :name => name, :action => "index.get_alias")
+        response = client.get "/{index}/_alias/{name}", update_params(params, name: name, action: "index.get_alias", rest_api: "indices.get_alias")
         response.body
       end
 
@@ -192,13 +192,13 @@ module Elastomer
       #
       # Examples
       #
-      #   index.add_alias("foo", :routing => "foo")
+      #   index.add_alias("foo", routing: "foo")
       #
       # See https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html
       #
       # Returns the response body as a Hash
       def add_alias( name, params = {} )
-        response = client.put "/{index}/_alias/{name}", update_params(params, :name => name, :action => "index.add_alias")
+        response = client.put "/{index}/_alias/{name}", update_params(params, name: name, action: "index.add_alias", rest_api: "indices.put_alias")
         response.body
       end
 
@@ -216,7 +216,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete_alias( name, params = {} )
-        response = client.delete "/{index}/_alias/{name}", update_params(params, :name => name, :action => "index.delete_alias")
+        response = client.delete "/{index}/_alias/{name}", update_params(params, name: name, action: "index.delete_alias", rest_api: "indices.delete_alias")
         response.body
       end
 
@@ -231,7 +231,7 @@ module Elastomer
       # Returns the response body as a Hash
       def analyze( text, params = {} )
         body = text.is_a?(Hash) ? text : {text: text.to_s}
-        response = client.get "{/index}/_analyze", update_params(params, body: body, action: "index.analyze")
+        response = client.get "{/index}/_analyze", update_params(params, body: body, action: "index.analyze", rest_api: "indices.analyze")
         response.body
       end
 
@@ -245,7 +245,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def refresh( params = {} )
-        response = client.post "{/index}/_refresh", update_params(params, :action => "index.refresh")
+        response = client.post "{/index}/_refresh", update_params(params, action: "index.refresh", rest_api: "indices.refresh")
         response.body
       end
 
@@ -258,7 +258,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def flush( params = {} )
-        response = client.post "{/index}/_flush", update_params(params, :action => "index.flush")
+        response = client.post "{/index}/_flush", update_params(params, action: "index.flush", rest_api: "indices.flush")
         response.body
       end
 
@@ -272,7 +272,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def forcemerge( params = {} )
-        response = client.post "{/index}/_forcemerge", update_params(params, :action => "index.forcemerge")
+        response = client.post "{/index}/_forcemerge", update_params(params, action: "index.forcemerge", rest_api: "indices.forcemerge")
         response.body
       end
       # DEPRECATED:  ES 5.X has removed the `/_optimize` endpoint.
@@ -287,7 +287,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def recovery( params = {} )
-        response = client.get "{/index}/_recovery", update_params(params, :action => "index.recovery")
+        response = client.get "{/index}/_recovery", update_params(params, action: "index.recovery", rest_api: "indices.recovery")
         response.body
       end
 
@@ -301,7 +301,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def clear_cache( params = {} )
-        response = client.post "{/index}/_cache/clear", update_params(params, :action => "index.clear_cache")
+        response = client.post "{/index}/_cache/clear", update_params(params, action: "index.clear_cache", rest_api: "indices.clear_cache")
         response.body
       end
 
@@ -320,7 +320,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def stats( params = {} )
-        response = client.get "{/index}/_stats{/stats}", update_params(params, :action => "index.stats")
+        response = client.get "{/index}/_stats{/stats}", update_params(params, action: "index.stats", rest_api: "indices.stats")
         response.body
       end
 
@@ -333,7 +333,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def segments( params = {} )
-        response = client.get "{/index}/_segments", update_params(params, :action => "index.segments")
+        response = client.get "{/index}/_segments", update_params(params, action: "index.segments", rest_api: "indices.segments")
         response.body
       end
 
@@ -358,7 +358,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def suggest(query, params = {})
-        response = client.post "{/index}/_suggest", update_params(params, :body => query, :action => "index.suggest")
+        response = client.post "{/index}/_suggest", update_params(params, body: query, action: "index.suggest", rest_api: "suggest")
         response.body
       end
 
@@ -387,7 +387,7 @@ module Elastomer
       def bulk( params = {}, &block )
         raise "a block is required" if block.nil?
 
-        params = {:index => self.name}.merge params
+        params = {index: self.name}.merge params
         client.bulk params, &block
       end
 
@@ -413,7 +413,7 @@ module Elastomer
       #
       # Returns a new Scroller instance
       def scroll( query, opts = {} )
-        opts = {:index => name}.merge opts
+        opts = {index: name}.merge opts
         client.scroll query, opts
       end
 
@@ -442,7 +442,7 @@ module Elastomer
       #
       # Returns a new Scroller instance
       def scan( query, opts = {} )
-        opts = {:index => name}.merge opts
+        opts = {index: name}.merge opts
         client.scan query, opts
       end
 
@@ -464,8 +464,8 @@ module Elastomer
       # Examples
       #
       #   index.multi_search do |m|
-      #     m.search({:query => {:match_all => {}}, :size => 0)
-      #     m.search({:query => {:field => {"author" => "grantr"}}}, :type => 'tweet')
+      #     m.search({query: {match_all: {}}, size: 0)
+      #     m.search({query: {field: {"author" => "grantr"}}}, type: 'tweet')
       #     ...
       #   end
       #
@@ -475,7 +475,7 @@ module Elastomer
       def multi_search( params = {}, &block )
         raise "a block is required" if block.nil?
 
-        params = {:index => self.name}.merge params
+        params = {index: self.name}.merge params
         client.multi_search params, &block
       end
 
@@ -493,8 +493,8 @@ module Elastomer
       #
       #   # block form
       #   multi_percolate do |m|
-      #     m.percolate({ :author => "pea53" }, { :type => 'default-type' })
-      #     m.count({ :author => "pea53" }, { :type => 'type2' })
+      #     m.percolate({ author: "pea53" }, { type: 'default-type' })
+      #     m.count({ author: "pea53" }, { type: 'type2' })
       #     ...
       #   end
       #
@@ -515,7 +515,7 @@ module Elastomer
       # warmer_name - The name of the warmer to operate on.
       #
       # Examples
-      #   index.warmer('warmer1').create(:query => {:match_all => {}})
+      #   index.warmer('warmer1').create(query: {match_all: {}})
       #   index.warmer('warmer1').get
       #   index.warmer('warmer1').delete
       #
@@ -587,7 +587,7 @@ module Elastomer
 
       # Internal: Returns a Hash containing default parameters.
       def defaults
-        { :index => name }
+        { index: name }
       end
 
     end

--- a/lib/elastomer/client/multi_percolate.rb
+++ b/lib/elastomer/client/multi_percolate.rb
@@ -21,12 +21,12 @@ module Elastomer
     #   multi_percolate(request_body)
     #
     #   # index in URI
-    #   multi_percolate(request_body, :index => 'default-index')
+    #   multi_percolate(request_body, index: 'default-index')
     #
     #   # block form
-    #   multi_percolate(:index => 'default-index') do |m|
-    #     m.percolate({ :author => "pea53" }, { :type => 'default-type' })
-    #     m.count({ :author => "pea53" }, { :type => 'type2' })
+    #   multi_percolate(index: 'default-index') do |m|
+    #     m.percolate({ author: "pea53" }, { type: 'default-type' })
+    #     m.count({ author: "pea53" }, { type: 'type2' })
     #     ...
     #   end
     #
@@ -40,7 +40,7 @@ module Elastomer
         raise "multi_percolate request body cannot be nil" if body.nil?
         params ||= {}
 
-        response = self.post "{/index}{/type}/_mpercolate", params.merge(:body => body)
+        response = self.post "{/index}{/type}/_mpercolate", params.merge(body: body, action: "mpercolate", rest_api: "mpercolate")
         response.body
       end
     end
@@ -80,8 +80,8 @@ module Elastomer
       #
       # Returns this MultiPercolate instance.
       def percolate(doc, header = {})
-        add_to_actions(:percolate => @params.merge(header))
-        add_to_actions(:doc => doc)
+        add_to_actions(percolate: @params.merge(header))
+        add_to_actions(doc: doc)
       end
 
       # Add a percolate acount action to the multi percolate request. This
@@ -93,8 +93,8 @@ module Elastomer
       #
       # Returns this MultiPercolate instance.
       def count(doc, header = {})
-        add_to_actions(:count => @params.merge(header))
-        add_to_actions(:doc => doc)
+        add_to_actions(count: @params.merge(header))
+        add_to_actions(doc: doc)
       end
 
       # Execute the multi_percolate call with the accumulated percolate actions.

--- a/lib/elastomer/client/multi_search.rb
+++ b/lib/elastomer/client/multi_search.rb
@@ -21,12 +21,12 @@ module Elastomer
     #   multi_search(request_body)
     #
     #   # index in URI
-    #   multi_search(request_body, :index => 'default-index')
+    #   multi_search(request_body, index: 'default-index')
     #
     #   # block form
-    #   multi_search(:index => 'default-index') do |m|
-    #     m.search({:query => {:match_all => {}}, :size => 0)
-    #     m.search({:query => {:field => {"foo" => "bar"}}}, :type => 'default-type')
+    #   multi_search(index: 'default-index') do |m|
+    #     m.search({query: {match_all: {}}, size: 0)
+    #     m.search({query: {field: {"foo" => "bar"}}}, type: 'default-type')
     #     ...
     #   end
     #
@@ -40,7 +40,7 @@ module Elastomer
         raise "multi_search request body cannot be nil" if body.nil?
         params ||= {}
 
-        response = self.post "{/index}{/type}/_msearch", params.merge(:body => body)
+        response = self.post "{/index}{/type}/_msearch", params.merge(body: body, action: "msearch", rest_api: "msearch")
         response.body
       end
     end

--- a/lib/elastomer/client/native_delete_by_query.rb
+++ b/lib/elastomer/client/native_delete_by_query.rb
@@ -29,7 +29,7 @@ module Elastomer
 
         if rest_api = client.api_spec.get(REST_API)
           parameters.keys.each do |key|
-            unless rest_api.valid_param? key
+            unless rest_api.valid_param?(key) || rest_api.valid_part?(key)
               raise IllegalArgument, "'#{key}' is not a valid _delete_by_query parameter"
             end
           end

--- a/lib/elastomer/client/native_delete_by_query.rb
+++ b/lib/elastomer/client/native_delete_by_query.rb
@@ -8,7 +8,7 @@ module Elastomer
     # Examples
     #
     #   # request body query
-    #   native_delete_by_query({:query => {:match_all => {}}}, :type => 'tweet')
+    #   native_delete_by_query({query: {match_all: {}}}, type: 'tweet')
     #
     # See https://www.elastic.co/guide/en/elasticsearch/reference/5.6/docs-delete-by-query.html
     #
@@ -18,41 +18,31 @@ module Elastomer
     end
 
     class NativeDeleteByQuery
-      attr_reader :client, :query, :parameters
+      REST_API = "delete_by_query".freeze
 
-      PARAMETERS = %i[
-        conflicts
-        index
-        q
-        refresh
-        routing
-        scroll_size
-        timeout
-        type
-        wait_for_active_shards
-        wait_for_completion
-      ].to_set.freeze
+      attr_reader :client, :query, :parameters
 
       def initialize(client, query, parameters)
         unless client.version_support.native_delete_by_query?
           raise IncompatibleVersionException, "Elasticsearch '#{client.version}' does not support _delete_by_query"
         end
 
-        parameters.keys.each do |key|
-          unless PARAMETERS.include?(key) || PARAMETERS.include?(key.to_sym)
-            raise IllegalArgument, "'#{key}' is not a valid _delete_by_query parameter"
+        if rest_api = client.api_spec.get(REST_API)
+          parameters.keys.each do |key|
+            unless rest_api.valid_param? key
+              raise IllegalArgument, "'#{key}' is not a valid _delete_by_query parameter"
+            end
           end
         end
 
         @client = client
         @query = query
         @parameters = parameters
-
       end
 
       def execute
         # TODO: Require index parameter. type is optional.
-        response = client.post("/{index}{/type}/_delete_by_query", parameters.merge(body: query))
+        response = client.post("/{index}{/type}/_delete_by_query", parameters.merge(body: query, action: "delete_by_query"))
         response.body
       end
     end

--- a/lib/elastomer/client/native_delete_by_query.rb
+++ b/lib/elastomer/client/native_delete_by_query.rb
@@ -18,21 +18,11 @@ module Elastomer
     end
 
     class NativeDeleteByQuery
-      REST_API = "delete_by_query".freeze
-
       attr_reader :client, :query, :parameters
 
       def initialize(client, query, parameters)
         unless client.version_support.native_delete_by_query?
           raise IncompatibleVersionException, "Elasticsearch '#{client.version}' does not support _delete_by_query"
-        end
-
-        if rest_api = client.api_spec.get(REST_API)
-          parameters.keys.each do |key|
-            unless rest_api.valid_param?(key) || rest_api.valid_part?(key)
-              raise IllegalArgument, "'#{key}' is not a valid _delete_by_query parameter"
-            end
-          end
         end
 
         @client = client
@@ -42,7 +32,7 @@ module Elastomer
 
       def execute
         # TODO: Require index parameter. type is optional.
-        response = client.post("/{index}{/type}/_delete_by_query", parameters.merge(body: query, action: "delete_by_query"))
+        response = client.post("/{index}{/type}/_delete_by_query", parameters.merge(body: query, action: "delete_by_query", rest_api: "delete_by_query"))
         response.body
       end
     end

--- a/lib/elastomer/client/nodes.rb
+++ b/lib/elastomer/client/nodes.rb
@@ -41,15 +41,15 @@ module Elastomer
       #
       # Examples
       #
-      #   info(:info => "_all")
-      #   info(:info => "os")
-      #   info(:info => %w[os jvm process])
+      #   info(info: "_all")
+      #   info(info: "os")
+      #   info(info: %w[os jvm process])
       #
       # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html
       #
       # Returns the response as a Hash
       def info( params = {} )
-        response = client.get "/_nodes{/node_id}{/info}", update_params(params, :action => "nodes.info")
+        response = client.get "/_nodes{/node_id}{/info}", update_params(params, action: "nodes.info", rest_api: "nodes.info")
         response.body
       end
 
@@ -62,14 +62,14 @@ module Elastomer
       #
       # Examples
       #
-      #   stats(:stats => "thread_pool")
-      #   stats(:stats => %w[os process])
+      #   stats(stats: "thread_pool")
+      #   stats(stats: %w[os process])
       #
       # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html
       #
       # Returns the response as a Hash
       def stats( params = {} )
-        response = client.get "/_nodes{/node_id}/stats{/stats}", update_params(params, :action => "nodes.stats")
+        response = client.get "/_nodes{/node_id}/stats{/stats}", update_params(params, action: "nodes.stats", rest_api: "nodes.stats")
         response.body
       end
 
@@ -87,21 +87,7 @@ module Elastomer
       #
       # Returns the response as a String
       def hot_threads( params = {} )
-        response = client.get "/_nodes{/node_id}/hot_threads", update_params(params, :action => "nodes.hot_threads")
-        response.body
-      end
-
-      # Shutdown one or more nodes in the cluster. There is also a
-      # Cluster#shutdown command for shutting down the entire cluseter.
-      #
-      # params - Parameters Hash
-      #   :node_id - a single node ID or Array of node IDs
-      #
-      # See https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-shutdown.html
-      #
-      # Returns the response as a Hash
-      def shutdown( params = {} )
-        response = client.post "/_cluster/nodes{/node_id}/_shutdown", update_params(params, :action => "nodes.shutdown")
+        response = client.get "/_nodes{/node_id}/hot_threads", update_params(params, action: "nodes.hot_threads", rest_api: "nodes.hot_threads")
         response.body
       end
 

--- a/lib/elastomer/client/percolator.rb
+++ b/lib/elastomer/client/percolator.rb
@@ -24,11 +24,11 @@ module Elastomer
       # Examples
       #
       #   percolator = $client.index("default-index").percolator "1"
-      #   percolator.create :query => { :match_all => { } }
+      #   percolator.create query: { match_all: { } }
       #
       # Returns the response body as a Hash
       def create(body, params = {})
-        response = client.put("/{index}/#{@percolator_type}/{id}", defaults.merge(params.merge(:body => body, :action => "percolator.create")))
+        response = client.put("/{index}/#{@percolator_type}/{id}", defaults.merge(params.merge(body: body, action: "percolator.create")))
         response.body
       end
 
@@ -41,7 +41,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get(params = {})
-        response = client.get("/{index}/#{@percolator_type}/{id}", defaults.merge(params.merge(:action => "percolator.get")))
+        response = client.get("/{index}/#{@percolator_type}/{id}", defaults.merge(params.merge(action: "percolator.get")))
         response.body
       end
 
@@ -54,7 +54,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete(params = {})
-        response = client.delete("/{index}/#{@percolator_type}/{id}", defaults.merge(params.merge(:action => "percolator.delete")))
+        response = client.delete("/{index}/#{@percolator_type}/{id}", defaults.merge(params.merge(action: "percolator.delete")))
         response.body
       end
 
@@ -72,7 +72,7 @@ module Elastomer
 
       # Internal: Returns a Hash containing default parameters.
       def defaults
-        {:index => index_name, :id => id}
+        {index: index_name, id: id}
       end
 
     end  # Percolator

--- a/lib/elastomer/client/repository.rb
+++ b/lib/elastomer/client/repository.rb
@@ -26,7 +26,7 @@ module Elastomer
       #
       # Returns true if the repository exists
       def exists?(params = {})
-        response = client.get "/_snapshot{/repository}", update_params(params, :action => "repository.exists")
+        response = client.get "/_snapshot{/repository}", update_params(params, action: "repository.exists", rest_api: "snapshot.get_repository")
         response.success?
       rescue Elastomer::Client::Error => err
         if err.error && err.error.dig("root_cause", 0, "type") == "repository_missing_exception"
@@ -45,7 +45,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create(body, params = {})
-        response = client.put "/_snapshot/{repository}", update_params(params, :body => body, :action => "repository.create")
+        response = client.put "/_snapshot/{repository}", update_params(params, body: body, action: "repository.create", rest_api: "snapshot.create_repository")
         response.body
       end
 
@@ -56,7 +56,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get(params = {})
-        response = client.get "/_snapshot{/repository}", update_params(params, :action => "repository.get")
+        response = client.get "/_snapshot{/repository}", update_params(params, action: "repository.get", rest_api: "snapshot.get_repository")
         response.body
       end
 
@@ -67,7 +67,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def status(params = {})
-        response = client.get "/_snapshot{/repository}/_status", update_params(params, :action => "repository.status")
+        response = client.get "/_snapshot{/repository}/_status", update_params(params, action: "repository.status", rest_api: "snapshot.status")
         response.body
       end
 
@@ -79,7 +79,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def update(body, params = {})
-        response = client.put "/_snapshot/{repository}", update_params(params, :body => body, :action => "repository.update")
+        response = client.put "/_snapshot/{repository}", update_params(params, body: body, action: "repository.update", rest_api: "snapshot.create_repository")
         response.body
       end
 
@@ -90,7 +90,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete(params = {})
-        response = client.delete "/_snapshot/{repository}", update_params(params, :action => "repository.delete")
+        response = client.delete "/_snapshot/{repository}", update_params(params, action: "repository.delete", rest_api: "snapshot.delete_repository")
         response.body
       end
 
@@ -120,7 +120,7 @@ module Elastomer
 
       # Internal: Returns a Hash containing default parameters.
       def defaults
-        { :repository => name }
+        { repository: name }
       end
     end
   end

--- a/lib/elastomer/client/rest_api_spec.rb
+++ b/lib/elastomer/client/rest_api_spec.rb
@@ -24,7 +24,7 @@ module Elastomer
       # Internal: Load the specific ApiSpec version class for the given version.
       def self.load_api_spec(version)
         path = File.expand_path("../rest_api_spec/api_spec_v#{to_class_version(version)}.rb", __FILE__)
-        if File.exists? path
+        if File.exist? path
           load path
         else
           raise RuntimeError, "Unsupported REST API spec version: #{version}"

--- a/lib/elastomer/client/rest_api_spec.rb
+++ b/lib/elastomer/client/rest_api_spec.rb
@@ -6,3 +6,6 @@ module Elastomer
     end
   end
 end
+
+require_relative "rest_api_spec/api_spec"
+require_relative "rest_api_spec/rest_api"

--- a/lib/elastomer/client/rest_api_spec.rb
+++ b/lib/elastomer/client/rest_api_spec.rb
@@ -2,9 +2,15 @@
 module Elastomer
   class Client
 
-    # Provides access to the versioned RES API specs for Elasticsearch.
+    # Provides access to the versioned REST API specs for Elasticsearch.
     module RestApiSpec
 
+      # Returns an ApiSpec instance for the given Elasticsearcion version. This
+      # method will load the ApiSpec version class if it has not already been
+      # defined. This prevents bloat by only loading the version specs that are
+      # needed.
+      #
+      # Because of this lazy loading, this method is _not_ thread safe.
       #
       # version - the Elasticsearch version String
       #
@@ -15,8 +21,7 @@ module Elastomer
         self.const_get(classname).new
       end
 
-      # Internal:
-      #
+      # Internal: Load the specific ApiSpec version class for the given version.
       def self.load_api_spec(version)
         path = File.expand_path("../rest_api_spec/api_spec_v#{to_class_version(version)}.rb", __FILE__)
         if File.exists? path
@@ -26,12 +31,11 @@ module Elastomer
         end
       end
 
-      # Internal:
-      #
+      # Internal: Convert a dotted version String into an underscore format
+      # suitable for use in Ruby class names.
       def self.to_class_version(version)
         version.to_s.split(".").slice(0,2).join("_")
       end
-
     end
   end
 end

--- a/lib/elastomer/client/rest_api_spec.rb
+++ b/lib/elastomer/client/rest_api_spec.rb
@@ -1,0 +1,8 @@
+
+module Elastomer
+  class Client
+
+    module RestApiSpec
+    end
+  end
+end

--- a/lib/elastomer/client/rest_api_spec.rb
+++ b/lib/elastomer/client/rest_api_spec.rb
@@ -2,7 +2,36 @@
 module Elastomer
   class Client
 
+    # Provides access to the versioned RES API specs for Elasticsearch.
     module RestApiSpec
+
+      #
+      # version - the Elasticsearch version String
+      #
+      # Returns the requested ApiSpec version if available
+      def self.api_spec(version)
+        classname = "ApiSpecV#{to_class_version(version)}"
+        load_api_spec(version) if !self.const_defined? classname
+        self.const_get(classname).new
+      end
+
+      # Internal:
+      #
+      def self.load_api_spec(version)
+        path = File.expand_path("../rest_api_spec/api_spec_v#{to_class_version(version)}.rb", __FILE__)
+        if File.exists? path
+          load path
+        else
+          raise RuntimeError, "Unsupported REST API spec version: #{version}"
+        end
+      end
+
+      # Internal:
+      #
+      def self.to_class_version(version)
+        version.to_s.split(".").slice(0,2).join("_")
+      end
+
     end
   end
 end

--- a/lib/elastomer/client/rest_api_spec/api_spec.rb
+++ b/lib/elastomer/client/rest_api_spec/api_spec.rb
@@ -8,6 +8,7 @@ module Elastomer::Client::RestApiSpec
   class ApiSpec
 
     attr_reader :rest_apis
+    attr_reader :common_params
 
     def initialize
       @rest_apis ||= {}

--- a/lib/elastomer/client/rest_api_spec/api_spec.rb
+++ b/lib/elastomer/client/rest_api_spec/api_spec.rb
@@ -1,0 +1,34 @@
+
+module Elastomer::Client::RestApiSpec
+
+  class ApiSpec
+
+    attr_reader :rest_apis
+
+    def initialize
+      @rest_apis ||= {}
+      @common_params ||= {}
+      @common_params_set = Set.new(@common_params.keys)
+    end
+
+    def get(api:)
+      rest_apis[api]
+    end
+
+    def select_params(api:, params:)
+      rest_api = get(api)
+      return params if rest_api.nil?
+      rest_api.select_params(params)
+    end
+
+    def select_parts(api:, params:)
+      rest_api = get(api)
+      return params if rest_api.nil?
+      rest_api.select_parts(params)
+    end
+
+    def select_common_params(params:)
+      params.select {|k,v| @common_params_set.include?(k.to_s)}
+    end
+  end
+end

--- a/lib/elastomer/client/rest_api_spec/api_spec.rb
+++ b/lib/elastomer/client/rest_api_spec/api_spec.rb
@@ -1,6 +1,10 @@
 
 module Elastomer::Client::RestApiSpec
 
+  # This is the superclass for the version specific API Spec classes that will
+  # be generated using the `script/generate-rest-api-spec` script. Each version
+  # of Elasticsarch we support will have it's own ApiSpec class that will
+  # validate the API request aprams for that particular version.
   class ApiSpec
 
     attr_reader :rest_apis
@@ -11,24 +15,50 @@ module Elastomer::Client::RestApiSpec
       @common_params_set = Set.new(@common_params.keys)
     end
 
-    def get(api:)
+    # Given an API descriptor name and a set of request parameters, select those
+    # params that are accepted by the API endpoint.
+    #
+    # api  - the api descriptor name as a String
+    # from - the Hash containing the request params
+    #
+    # Returns a new Hash containing the valid params for the api
+    def select_params(api:, from:)
+      rest_api = get(api)
+      return from if rest_api.nil?
+      rest_api.select_params(from: from)
+    end
+
+    # Given an API descriptor name and a set of request path parts, select those
+    # parts that are accepted by the API endpoint.
+    #
+    # api  - the api descriptor name as a String
+    # from - the Hash containing the path parts
+    #
+    # Returns a new Hash containing the valid path parts for the api
+    def select_parts(api:, from:)
+      rest_api = get(api)
+      return from if rest_api.nil?
+      rest_api.select_parts(from: from)
+    end
+
+    # Select the common request parameters from the given params.
+    #
+    # from - the Hash containing the request params
+    #
+    # Returns a new Hash containing the valid common request params
+    def select_common_params(from:)
+      return from if @common_params.empty?
+      from.select {|k,v| @common_params_set.include?(k.to_s)}
+    end
+
+    # Internal: Retrieve the `RestApi` descriptor for the given named `api`. If
+    # an unkonwn `api` is passed in, then `nil` is returned.
+    #
+    # api - the api descriptor name as a String
+    #
+    # Returns a RestApi instance or nil.
+    def get(api)
       rest_apis[api]
-    end
-
-    def select_params(api:, params:)
-      rest_api = get(api)
-      return params if rest_api.nil?
-      rest_api.select_params(params)
-    end
-
-    def select_parts(api:, params:)
-      rest_api = get(api)
-      return params if rest_api.nil?
-      rest_api.select_parts(params)
-    end
-
-    def select_common_params(params:)
-      params.select {|k,v| @common_params_set.include?(k.to_s)}
     end
   end
 end

--- a/lib/elastomer/client/rest_api_spec/api_spec.rb
+++ b/lib/elastomer/client/rest_api_spec/api_spec.rb
@@ -29,6 +29,20 @@ module Elastomer::Client::RestApiSpec
       rest_api.select_params(from: from)
     end
 
+    # Given an API descriptor name and a single request parameter, returns
+    # `true` if the parameter is valid for the given API. This method always
+    # returns `true` if the API is unknown.
+    #
+    # api   - the api descriptor name as a String
+    # param - the request parameter name as a String
+    #
+    # Returns `true` if the param is valid for the API.
+    def valid_param?(api:, param:)
+      rest_api = get(api)
+      return true if rest_api.nil?
+      rest_api.valid_param?(param)
+    end
+
     # Given an API descriptor name and a set of request path parts, select those
     # parts that are accepted by the API endpoint.
     #
@@ -40,6 +54,20 @@ module Elastomer::Client::RestApiSpec
       rest_api = get(api)
       return from if rest_api.nil?
       rest_api.select_parts(from: from)
+    end
+
+    # Given an API descriptor name and a single path part, returns `true` if the
+    # path part is valid for the given API. This method always returns `true` if
+    # the API is unknown.
+    #
+    # api  - the api descriptor name as a String
+    # part - the path part name as a String
+    #
+    # Returns `true` if the path part is valid for the API.
+    def valid_part?(api:, part:)
+      rest_api = get(api)
+      return true if rest_api.nil?
+      rest_api.valid_part?(part)
     end
 
     # Select the common request parameters from the given params.

--- a/lib/elastomer/client/rest_api_spec/api_spec_v2_3.rb
+++ b/lib/elastomer/client/rest_api_spec/api_spec_v2_3.rb
@@ -1,0 +1,2231 @@
+# Generated REST API spec file - DO NOT EDIT!
+# Date: 2018-01-10
+# ES version: 2.3
+
+module Elastomer::Client::RestApiSpec
+  class ApiSpecV2_3 < ApiSpec
+    def initialize
+      @rest_apis = {
+        "bulk" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-bulk.html",
+          methods: ["POST", "PUT"],
+          body: {"description"=>"The operation definition and data (action-data pairs), separated by newlines", "required"=>true, "serialize"=>"bulk"},
+          url: {
+            path: "/_bulk",
+            paths: ["/_bulk", "/{index}/_bulk", "/{index}/{type}/_bulk"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"Default index for items which don't provide one"},
+              "type" => {"type"=>"string", "description"=>"Default document type for items which don't provide one"},
+            },
+            params: {
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Explicit write consistency setting for the operation"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the index after performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "type" => {"type"=>"string", "description"=>"Default document type for items which don't provide one"},
+              "fields" => {"type"=>"list", "description"=>"Default comma-separated list of fields to return in the response for updates"},
+            }
+          }
+        ),
+        "cat.aliases" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-alias.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/aliases",
+            paths: ["/_cat/aliases", "/_cat/aliases/{name}"],
+            parts: {
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to return"},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.allocation" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-allocation.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/allocation",
+            paths: ["/_cat/allocation", "/_cat/allocation/{node_id}"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information"},
+            },
+            params: {
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "m", "g"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.count" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-count.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/count",
+            paths: ["/_cat/count", "/_cat/count/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.fielddata" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-fielddata.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/fielddata",
+            paths: ["/_cat/fielddata", "/_cat/fielddata/{fields}"],
+            parts: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return the fielddata size"},
+            },
+            params: {
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "m", "g"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the output"},
+            }
+          }
+        ),
+        "cat.health" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-health.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/health",
+            paths: ["/_cat/health"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "ts" => {"type"=>"boolean", "description"=>"Set to false to disable timestamping", "default"=>true},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.help" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat",
+            paths: ["/_cat"],
+            params: {
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+            }
+          }
+        ),
+        "cat.indices" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-indices.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/indices",
+            paths: ["/_cat/indices", "/_cat/indices/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "m", "g"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "pri" => {"type"=>"boolean", "description"=>"Set to true to return stats only for primary shards", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.master" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-master.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/master",
+            paths: ["/_cat/master"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.nodeattrs" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-nodeattrs.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/nodeattrs",
+            paths: ["/_cat/nodeattrs"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.nodes" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-nodes.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/nodes",
+            paths: ["/_cat/nodes"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.pending_tasks" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-pending-tasks.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/pending_tasks",
+            paths: ["/_cat/pending_tasks"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.plugins" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-plugins.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/plugins",
+            paths: ["/_cat/plugins"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.recovery" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-recovery.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/recovery",
+            paths: ["/_cat/recovery", "/_cat/recovery/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "m", "g"]},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.repositories" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-repositories.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/repositories",
+            paths: ["/_cat/repositories"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node", "default"=>false},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.segments" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-segments.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/segments",
+            paths: ["/_cat/segments", "/_cat/segments/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.shards" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-shards.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/shards",
+            paths: ["/_cat/shards", "/_cat/shards/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.snapshots" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/snapshots/{repository}",
+            paths: ["/_cat/snapshots/{repository}"],
+            parts: {
+              "repository" => {"type"=>"list", "required"=>true, "description"=>"Name of repository from which to fetch the snapshot information"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Set to true to ignore unavailable snapshots", "default"=>false},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.thread_pool" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cat-thread-pool.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/thread_pool",
+            paths: ["/_cat/thread_pool"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+              "full_id" => {"type"=>"boolean", "description"=>"Enables displaying the complete node ids", "default"=>false},
+            }
+          }
+        ),
+        "clear_scroll" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-request-scroll.html",
+          methods: ["DELETE"],
+          body: {"description"=>"A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter"},
+          url: {
+            path: "/_search/scroll/{scroll_id}",
+            paths: ["/_search/scroll/{scroll_id}", "/_search/scroll"],
+            parts: {
+              "scroll_id" => {"type"=>"list", "description"=>"A comma-separated list of scroll IDs to clear"},
+            },
+          }
+        ),
+        "cluster.get_settings" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cluster-update-settings.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/settings",
+            paths: ["/_cluster/settings"],
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "cluster.health" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cluster-health.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/health",
+            paths: ["/_cluster/health", "/_cluster/health/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"Limit the information returned to a specific index"},
+            },
+            params: {
+              "level" => {"type"=>"enum", "options"=>["cluster", "indices", "shards"], "default"=>"cluster", "description"=>"Specify the level of detail for returned information"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "wait_for_active_shards" => {"type"=>"number", "description"=>"Wait until the specified number of shards is active"},
+              "wait_for_nodes" => {"type"=>"string", "description"=>"Wait until the specified number of nodes is available"},
+              "wait_for_relocating_shards" => {"type"=>"number", "description"=>"Wait until the specified number of relocating shards is finished"},
+              "wait_for_status" => {"type"=>"enum", "options"=>["green", "yellow", "red"], "default"=>nil, "description"=>"Wait until cluster is in a specific state"},
+            }
+          }
+        ),
+        "cluster.pending_tasks" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cluster-pending.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/pending_tasks",
+            paths: ["/_cluster/pending_tasks"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "cluster.put_settings" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cluster-update-settings.html",
+          methods: ["PUT"],
+          body: {"description"=>"The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart)."},
+          url: {
+            path: "/_cluster/settings",
+            paths: ["/_cluster/settings"],
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "cluster.reroute" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cluster-reroute.html",
+          methods: ["POST"],
+          body: {"description"=>"The definition of `commands` to perform (`move`, `cancel`, `allocate`)"},
+          url: {
+            path: "/_cluster/reroute",
+            paths: ["/_cluster/reroute"],
+            params: {
+              "dry_run" => {"type"=>"boolean", "description"=>"Simulate the operation only and return the resulting state"},
+              "explain" => {"type"=>"boolean", "description"=>"Return an explanation of why the commands can or cannot be executed"},
+              "metric" => {"type"=>"list", "options"=>["_all", "blocks", "metadata", "nodes", "routing_table", "master_node", "version"], "description"=>"Limit the information returned to the specified metrics. Defaults to all but metadata"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "cluster.state" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cluster-state.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/state",
+            paths: ["/_cluster/state", "/_cluster/state/{metric}", "/_cluster/state/{metric}/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+              "metric" => {"type"=>"list", "options"=>["_all", "blocks", "metadata", "nodes", "routing_table", "routing_nodes", "master_node", "version"], "description"=>"Limit the information returned to the specified metrics"},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "cluster.stats" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cluster-stats.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/stats",
+            paths: ["/_cluster/stats", "/_cluster/stats/nodes/{node_id}"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+            },
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "count" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-count.html",
+          methods: ["POST", "GET"],
+          body: {"description"=>"A query to restrict the results specified with the Query DSL (optional)"},
+          url: {
+            path: "/_count",
+            paths: ["/_count", "/{index}/_count", "/{index}/{type}/_count"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of indices to restrict the results"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of types to restrict the results"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "min_score" => {"type"=>"number", "description"=>"Include only documents with a specific `_score` value in the result"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+            }
+          }
+        ),
+        "count_percolate" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-percolate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The count percolator request definition using the percolate DSL", "required"=>false},
+          url: {
+            path: "/{index}/{type}/_percolate/count",
+            paths: ["/{index}/{type}/_percolate/count", "/{index}/{type}/{id}/_percolate/count"],
+            parts: {
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The index of the document being count percolated."},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document being count percolated."},
+              "id" => {"type"=>"string", "required"=>false, "description"=>"Substitute the document in the request body with a document that is known by the specified id. On top of the id, the index and type parameter will be used to retrieve the document from within the cluster."},
+            },
+            params: {
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "percolate_index" => {"type"=>"string", "description"=>"The index to count percolate the document into. Defaults to index."},
+              "percolate_type" => {"type"=>"string", "description"=>"The type to count percolate document into. Defaults to type."},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "delete" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-delete.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}",
+            paths: ["/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Specific write consistency setting for the operation"},
+              "parent" => {"type"=>"string", "description"=>"ID of parent document"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the index after performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "delete_script" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-scripting.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_scripts/{lang}/{id}",
+            paths: ["/_scripts/{lang}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Script ID", "required"=>true},
+              "lang" => {"type"=>"string", "description"=>"Script language", "required"=>true},
+            },
+            params: {
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "delete_template" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-template.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_search/template/{id}",
+            paths: ["/_search/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Template ID", "required"=>true},
+            },
+            params: {
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "exists" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-get.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}",
+            paths: ["/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document (use `_all` to fetch the first document matching the ID across all types)"},
+            },
+            params: {
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+            }
+          }
+        ),
+        "explain" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-explain.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The query definition using the Query DSL"},
+          url: {
+            path: "/{index}/{type}/{id}/_explain",
+            paths: ["/{index}/{type}/{id}/_explain"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcards and prefix queries in the query string query should be analyzed (default: false)"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer for the query string query"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The default field for query string query (default: _all)"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the response"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+            }
+          }
+        ),
+        "field_stats" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-field-stats.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Field json objects containing the name and optionally a range to filter out indices result, that have results outside the defined bounds", "required"=>false},
+          url: {
+            path: "/_field_stats",
+            paths: ["/_field_stats", "/{index}/_field_stats"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for to get field statistics for (min value, max value, and more)"},
+              "level" => {"type"=>"enum", "options"=>["indices", "cluster"], "default"=>"cluster", "description"=>"Defines if field stats should be returned on a per index level or on a cluster wide level"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "get" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-get.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}",
+            paths: ["/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document (use `_all` to fetch the first document matching the ID across all types)"},
+            },
+            params: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the response"},
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "get_script" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-scripting.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_scripts/{lang}/{id}",
+            paths: ["/_scripts/{lang}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Script ID", "required"=>true},
+              "lang" => {"type"=>"string", "description"=>"Script language", "required"=>true},
+            },
+            params: {
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "get_source" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-get.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}/_source",
+            paths: ["/{index}/{type}/{id}/_source"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document; use `_all` to fetch the first document matching the ID across all types"},
+            },
+            params: {
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "get_template" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-template.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_search/template/{id}",
+            paths: ["/_search/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Template ID", "required"=>true},
+            },
+            params: {
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "index" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-index_.html",
+          methods: ["POST", "PUT"],
+          body: {"description"=>"The document", "required"=>true},
+          url: {
+            path: "/{index}/{type}",
+            paths: ["/{index}/{type}", "/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Explicit write consistency setting for the operation"},
+              "op_type" => {"type"=>"enum", "options"=>["index", "create"], "default"=>"index", "description"=>"Explicit operation type"},
+              "parent" => {"type"=>"string", "description"=>"ID of the parent document"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the index after performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "timestamp" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "ttl" => {"type"=>"duration", "description"=>"Expiration time for the document"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "indices.analyze" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-analyze.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The text on which the analysis should be performed"},
+          url: {
+            path: "/_analyze",
+            paths: ["/_analyze", "/{index}/_analyze"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The name of the index to scope the operation"},
+            },
+            params: {
+              "analyzer" => {"type"=>"string", "description"=>"The name of the analyzer to use"},
+              "char_filters" => {"type"=>"list", "description"=>"Deprecated : A comma-separated list of character filters to use for the analysis"},
+              "char_filter" => {"type"=>"list", "description"=>"A comma-separated list of character filters to use for the analysis"},
+              "field" => {"type"=>"string", "description"=>"Use the analyzer configured for this field (instead of passing the analyzer name)"},
+              "filters" => {"type"=>"list", "description"=>"Deprecated : A comma-separated list of filters to use for the analysis"},
+              "filter" => {"type"=>"list", "description"=>"A comma-separated list of filters to use for the analysis"},
+              "index" => {"type"=>"string", "description"=>"The name of the index to scope the operation"},
+              "prefer_local" => {"type"=>"boolean", "description"=>"With `true`, specify that a local shard should be used if available, with `false`, use a random shard (default: true)"},
+              "text" => {"type"=>"list", "description"=>"The text on which the analysis should be performed (when request body is not used)"},
+              "tokenizer" => {"type"=>"string", "description"=>"The name of the tokenizer to use for the analysis"},
+              "explain" => {"type"=>"boolean", "description"=>"With `true`, outputs more advanced details. (default: false)"},
+              "attributes" => {"type"=>"list", "description"=>"A comma-separated list of token attributes to output, this parameter works only with `explain=true`"},
+              "format" => {"type"=>"enum", "options"=>["detailed", "text"], "default"=>"detailed", "description"=>"Format of the output"},
+            }
+          }
+        ),
+        "indices.clear_cache" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-clearcache.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_cache/clear",
+            paths: ["/_cache/clear", "/{index}/_cache/clear"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index name to limit the operation"},
+            },
+            params: {
+              "field_data" => {"type"=>"boolean", "description"=>"Clear field data"},
+              "fielddata" => {"type"=>"boolean", "description"=>"Clear field data"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to clear when using the `field_data` parameter (default: all)"},
+              "query" => {"type"=>"boolean", "description"=>"Clear query caches"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index name to limit the operation"},
+              "recycler" => {"type"=>"boolean", "description"=>"Clear the recycler cache"},
+              "request" => {"type"=>"boolean", "description"=>"Clear request cache"},
+            }
+          }
+        ),
+        "indices.close" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-open-close.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/{index}/_close",
+            paths: ["/{index}/_close"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma separated list of indices to close"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.create" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-create-index.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The configuration for the index (`settings` and `mappings`)"},
+          url: {
+            path: "/{index}",
+            paths: ["/{index}"],
+            parts: {
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "update_all_types" => {"type"=>"boolean", "description"=>"Whether to update the mapping for all fields with the same name across all types or not"},
+            }
+          }
+        ),
+        "indices.delete" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-delete-index.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}",
+            paths: ["/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.delete_alias" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-aliases.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}/_alias/{name}",
+            paths: ["/{index}/_alias/{name}", "/{index}/_aliases/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names (supports wildcards); use `_all` for all indices"},
+              "name" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices."},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.delete_template" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-templates.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the template"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.delete_warmer" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-warmers.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}/_warmer/{name}",
+            paths: ["/{index}/_warmer/{name}", "/{index}/_warmers/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names to delete warmers from (supports wildcards); use `_all` to perform the operation on all indices."},
+              "name" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters."},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters."},
+            }
+          }
+        ),
+        "indices.exists" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-exists.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/{index}",
+            paths: ["/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of indices to check"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.exists_alias" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-aliases.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/_alias/{name}",
+            paths: ["/_alias/{name}", "/{index}/_alias/{name}", "/{index}/_alias"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to filter aliases"},
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to return"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>["open", "closed"], "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.exists_template" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-templates.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the template"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.exists_type" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-types-exists.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}",
+            paths: ["/{index}/{type}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names; use `_all` to check the types across all indices"},
+              "type" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of document types to check"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.flush" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-flush.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_flush",
+            paths: ["/_flush", "/{index}/_flush"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string for all indices"},
+            },
+            params: {
+              "force" => {"type"=>"boolean", "description"=>"Whether a flush should be forced even if it is not necessarily needed ie. if no changes will be committed to the index. This is useful if transaction log IDs should be incremented even if no uncommitted changes are present. (This setting can be considered as internal)"},
+              "wait_if_ongoing" => {"type"=>"boolean", "description"=>"If set to true the flush operation will block until the flush can be executed if another flush operation is already executing. The default is false and will cause an exception to be thrown on the shard level if another flush operation is already running."},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.flush_synced" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-synced-flush.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_flush/synced",
+            paths: ["/_flush/synced", "/{index}/_flush/synced"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string for all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.forcemerge" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-forcemerge.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_forcemerge",
+            paths: ["/_forcemerge", "/{index}/_forcemerge"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "flush" => {"type"=>"boolean", "description"=>"Specify whether the index should be flushed after performing the operation (default: true)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "max_num_segments" => {"type"=>"number", "description"=>"The number of segments the index should be merged into (default: dynamic)"},
+              "only_expunge_deletes" => {"type"=>"boolean", "description"=>"Specify whether the operation should only expunge deleted documents"},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "wait_for_merge" => {"type"=>"boolean", "description"=>"Specify whether the request should block until the merge process is finished (default: true)"},
+            }
+          }
+        ),
+        "indices.get" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-get-index.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/{index}",
+            paths: ["/{index}", "/{index}/{feature}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names"},
+              "feature" => {"type"=>"list", "description"=>"A comma-separated list of features", "options"=>["_settings", "_mappings", "_warmers", "_aliases"]},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Ignore unavailable indexes (default: false)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Ignore if a wildcard expression resolves to no concrete indices (default: false)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether wildcard expressions should get expanded to open or closed indices (default: open)"},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return version and creation date values in human-readable format.", "default"=>false},
+            }
+          }
+        ),
+        "indices.get_alias" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-aliases.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_alias/",
+            paths: ["/_alias", "/_alias/{name}", "/{index}/_alias/{name}", "/{index}/_alias"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to filter aliases"},
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to return"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_aliases" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-aliases.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_aliases",
+            paths: ["/_aliases", "/{index}/_aliases", "/{index}/_aliases/{name}", "/_aliases/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to filter aliases"},
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to filter"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_field_mapping" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-get-field-mapping.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_mapping/field/{fields}",
+            paths: ["/_mapping/field/{fields}", "/{index}/_mapping/field/{fields}", "/_mapping/{type}/field/{fields}", "/{index}/_mapping/{type}/field/{fields}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields", "required"=>true},
+            },
+            params: {
+              "include_defaults" => {"type"=>"boolean", "description"=>"Whether the default mapping values should be returned as well"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_mapping" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-get-mapping.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_mapping",
+            paths: ["/_mapping", "/{index}/_mapping", "/_mapping/{type}", "/{index}/_mapping/{type}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_settings" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-get-settings.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_settings",
+            paths: ["/_settings", "/{index}/_settings", "/{index}/_settings/{name}", "/_settings/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+              "name" => {"type"=>"list", "description"=>"The name of the settings that should be included"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>["open", "closed"], "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return version and creation date values in human-readable format.", "default"=>false},
+            }
+          }
+        ),
+        "indices.get_template" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-templates.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template", "/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"list", "required"=>false, "description"=>"The comma separated names of the index templates"},
+            },
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_upgrade" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-upgrade.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_upgrade",
+            paths: ["/_upgrade", "/{index}/_upgrade"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+            }
+          }
+        ),
+        "indices.get_warmer" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-warmers.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_warmer",
+            paths: ["/_warmer", "/{index}/_warmer", "/{index}/_warmer/{name}", "/_warmer/{name}", "/{index}/{type}/_warmer/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices"},
+              "name" => {"type"=>"list", "description"=>"The name of the warmer (supports wildcards); leave empty to get all warmers"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.open" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-open-close.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/{index}/_open",
+            paths: ["/{index}/_open"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma separated list of indices to open"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"closed", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.optimize" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-optimize.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_optimize",
+            paths: ["/_optimize", "/{index}/_optimize"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "flush" => {"type"=>"boolean", "description"=>"Specify whether the index should be flushed after performing the operation (default: true)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "max_num_segments" => {"type"=>"number", "description"=>"The number of segments the index should be merged into (default: dynamic)"},
+              "only_expunge_deletes" => {"type"=>"boolean", "description"=>"Specify whether the operation should only expunge deleted documents"},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "wait_for_merge" => {"type"=>"boolean", "description"=>"Specify whether the request should block until the merge process is finished (default: true)"},
+            }
+          }
+        ),
+        "indices.put_alias" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-aliases.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The settings for the alias, such as `routing` or `filter`", "required"=>false},
+          url: {
+            path: "/{index}/_alias/{name}",
+            paths: ["/{index}/_alias/{name}", "/{index}/_aliases/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices."},
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the alias to be created or updated"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.put_mapping" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-put-mapping.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The mapping definition", "required"=>true},
+          url: {
+            path: "/{index}/{type}/_mapping",
+            paths: ["/{index}/{type}/_mapping", "/{index}/_mapping/{type}", "/_mapping/{type}", "/{index}/{type}/_mappings", "/{index}/_mappings/{type}", "/_mappings/{type}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices."},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The name of the document type"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "update_all_types" => {"type"=>"boolean", "description"=>"Whether to update the mapping for all fields with the same name across all types or not"},
+            }
+          }
+        ),
+        "indices.put_settings" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-update-settings.html",
+          methods: ["PUT"],
+          body: {"description"=>"The index settings to be updated", "required"=>true},
+          url: {
+            path: "/_settings",
+            paths: ["/_settings", "/{index}/_settings"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+            }
+          }
+        ),
+        "indices.put_template" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-templates.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The template definition", "required"=>true},
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the template"},
+            },
+            params: {
+              "order" => {"type"=>"number", "description"=>"The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"},
+              "create" => {"type"=>"boolean", "description"=>"Whether the index template should only be added if new or can also replace an existing one", "default"=>false},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+            }
+          }
+        ),
+        "indices.put_warmer" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-warmers.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The search request definition for the warmer (query, filters, facets, sorting, etc)", "required"=>true},
+          url: {
+            path: "/{index}/_warmer/{name}",
+            paths: ["/_warmer/{name}", "/{index}/_warmer/{name}", "/{index}/{type}/_warmer/{name}", "/_warmers/{name}", "/{index}/_warmers/{name}", "/{index}/{type}/_warmers/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices"},
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the warmer"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed) in the search request to warm"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices in the search request to warm. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both, in the search request to warm."},
+              "request_cache" => {"type"=>"boolean", "description"=>"Specify whether the request to be warmed should use the request cache, defaults to index level setting"},
+            }
+          }
+        ),
+        "indices.recovery" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-recovery.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_recovery",
+            paths: ["/_recovery", "/{index}/_recovery"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "detailed" => {"type"=>"boolean", "description"=>"Whether to display detailed information about shard recovery", "default"=>false},
+              "active_only" => {"type"=>"boolean", "description"=>"Display only those recoveries that are currently on-going", "default"=>false},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+            }
+          }
+        ),
+        "indices.refresh" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-refresh.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_refresh",
+            paths: ["/_refresh", "/{index}/_refresh"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "force" => {"type"=>"boolean", "description"=>"Force a refresh even if not required", "default"=>false},
+              "operation_threading" => {"description"=>"TODO: ?"},
+            }
+          }
+        ),
+        "indices.segments" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-segments.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_segments",
+            paths: ["/_segments", "/{index}/_segments"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "verbose" => {"type"=>"boolean", "description"=>"Includes detailed memory usage by Lucene.", "default"=>false},
+            }
+          }
+        ),
+        "indices.shard_stores" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-shards-stores.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_shard_stores",
+            paths: ["/_shard_stores", "/{index}/_shard_stores"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "status" => {"type"=>"list", "options"=>["green", "yellow", "red", "all"], "description"=>"A comma-separated list of statuses used to filter on shards to get store information for"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "operation_threading" => {"description"=>"TODO: ?"},
+            }
+          }
+        ),
+        "indices.stats" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-stats.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_stats",
+            paths: ["/_stats", "/_stats/{metric}", "/{index}/_stats", "/{index}/_stats/{metric}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+              "metric" => {"type"=>"list", "options"=>["_all", "completion", "docs", "fielddata", "query_cache", "flush", "get", "indexing", "merge", "percolate", "request_cache", "refresh", "search", "segments", "store", "warmer", "suggest"], "description"=>"Limit the information returned the specific metrics."},
+            },
+            params: {
+              "completion_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` index metric (supports wildcards)"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)"},
+              "groups" => {"type"=>"list", "description"=>"A comma-separated list of search groups for `search` index metric"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+              "level" => {"type"=>"enum", "description"=>"Return stats aggregated at cluster, index or shard level", "options"=>["cluster", "indices", "shards"], "default"=>"indices"},
+              "types" => {"type"=>"list", "description"=>"A comma-separated list of document types for the `indexing` index metric"},
+            }
+          }
+        ),
+        "indices.update_aliases" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-aliases.html",
+          methods: ["POST"],
+          body: {"description"=>"The definition of `actions` to perform", "required"=>true},
+          url: {
+            path: "/_aliases",
+            paths: ["/_aliases"],
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Request timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.upgrade" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/indices-upgrade.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_upgrade",
+            paths: ["/_upgrade", "/{index}/_upgrade"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Specify whether the request should block until the all segments are upgraded (default: false)"},
+              "only_ancient_segments" => {"type"=>"boolean", "description"=>"If true, only ancient (an older Lucene major release) segments will be upgraded"},
+            }
+          }
+        ),
+        "indices.validate_query" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-validate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The query definition specified with the Query DSL"},
+          url: {
+            path: "/_validate/query",
+            paths: ["/_validate/query", "/{index}/_validate/query", "/{index}/{type}/_validate/query"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "explain" => {"type"=>"boolean", "description"=>"Return detailed information about the error"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+              "rewrite" => {"type"=>"boolean", "description"=>"Provide a more detailed explanation showing the actual Lucene query that will be executed."},
+            }
+          }
+        ),
+        "info" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/",
+            paths: ["/"],
+          }
+        ),
+        "mget" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-multi-get.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.", "required"=>true},
+          url: {
+            path: "/_mget",
+            paths: ["/_mget", "/{index}/_mget", "/{index}/{type}/_mget"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "description"=>"The type of the document"},
+            },
+            params: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the response"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+            }
+          }
+        ),
+        "mpercolate" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-percolate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The percolate request definitions (header & body pair), separated by newlines", "required"=>true, "serialize"=>"bulk"},
+          url: {
+            path: "/_mpercolate",
+            paths: ["/_mpercolate", "/{index}/_mpercolate", "/{index}/{type}/_mpercolate"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The index of the document being count percolated to use as default"},
+              "type" => {"type"=>"string", "description"=>"The type of the document being percolated to use as default."},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "msearch" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-multi-search.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The request definitions (metadata-search request definition pairs), separated by newlines", "required"=>true, "serialize"=>"bulk"},
+          url: {
+            path: "/_msearch",
+            paths: ["/_msearch", "/{index}/_msearch", "/{index}/{type}/_msearch"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to use as default"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to use as default"},
+            },
+            params: {
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch", "count", "scan"], "description"=>"Search operation type"},
+            }
+          }
+        ),
+        "mtermvectors" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-multi-termvectors.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.", "required"=>false},
+          url: {
+            path: "/_mtermvectors",
+            paths: ["/_mtermvectors", "/{index}/_mtermvectors", "/{index}/{type}/_mtermvectors"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The index in which the document resides."},
+              "type" => {"type"=>"string", "description"=>"The type of the document."},
+            },
+            params: {
+              "ids" => {"type"=>"list", "description"=>"A comma-separated list of documents ids. You must define ids as parameter or set \"ids\" or \"docs\" in the request body", "required"=>false},
+              "term_statistics" => {"type"=>"boolean", "description"=>"Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>false, "required"=>false},
+              "field_statistics" => {"type"=>"boolean", "description"=>"Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "offsets" => {"type"=>"boolean", "description"=>"Specifies if term offsets should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "positions" => {"type"=>"boolean", "description"=>"Specifies if term positions should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "payloads" => {"type"=>"boolean", "description"=>"Specifies if term payloads should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random) .Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "parent" => {"type"=>"string", "description"=>"Parent id of documents. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "realtime" => {"type"=>"boolean", "description"=>"Specifies if requests are real-time as opposed to near-real-time (default: true).", "required"=>false},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "nodes.hot_threads" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cluster-nodes-hot-threads.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_nodes/hot_threads",
+            paths: ["/_cluster/nodes/hotthreads", "/_cluster/nodes/hot_threads", "/_cluster/nodes/{node_id}/hotthreads", "/_cluster/nodes/{node_id}/hot_threads", "/_nodes/hotthreads", "/_nodes/hot_threads", "/_nodes/{node_id}/hotthreads", "/_nodes/{node_id}/hot_threads"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+            },
+            params: {
+              "interval" => {"type"=>"time", "description"=>"The interval for the second sampling of threads"},
+              "snapshots" => {"type"=>"number", "description"=>"Number of samples of thread stacktrace (default: 10)"},
+              "threads" => {"type"=>"number", "description"=>"Specify the number of threads to provide information for (default: 3)"},
+              "ignore_idle_threads" => {"type"=>"boolean", "description"=>"Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue (default: true)"},
+              "type" => {"type"=>"enum", "options"=>["cpu", "wait", "block"], "description"=>"The type to sample (default: cpu)"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "nodes.info" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cluster-nodes-info.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_nodes",
+            paths: ["/_nodes", "/_nodes/{node_id}", "/_nodes/{metric}", "/_nodes/{node_id}/{metric}"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+              "metric" => {"type"=>"list", "options"=>["settings", "os", "process", "jvm", "thread_pool", "transport", "http", "plugins"], "description"=>"A comma-separated list of metrics you wish returned. Leave empty to return all."},
+            },
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "nodes.stats" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/cluster-nodes-stats.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_nodes/stats",
+            paths: ["/_nodes/stats", "/_nodes/{node_id}/stats", "/_nodes/stats/{metric}", "/_nodes/{node_id}/stats/{metric}", "/_nodes/stats/{metric}/{index_metric}", "/_nodes/{node_id}/stats/{metric}/{index_metric}"],
+            parts: {
+              "metric" => {"type"=>"list", "options"=>["_all", "breaker", "fs", "http", "indices", "jvm", "os", "process", "thread_pool", "transport"], "description"=>"Limit the information returned to the specified metrics"},
+              "index_metric" => {"type"=>"list", "options"=>["_all", "completion", "docs", "fielddata", "query_cache", "flush", "get", "indexing", "merge", "percolate", "request_cache", "refresh", "search", "segments", "store", "warmer", "suggest"], "description"=>"Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified."},
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+            },
+            params: {
+              "completion_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` index metric (supports wildcards)"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)"},
+              "groups" => {"type"=>"boolean", "description"=>"A comma-separated list of search groups for `search` index metric"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+              "level" => {"type"=>"enum", "description"=>"Return indices stats aggregated at node, index or shard level", "options"=>["node", "indices", "shards"], "default"=>"node"},
+              "types" => {"type"=>"list", "description"=>"A comma-separated list of document types for the `indexing` index metric"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "percolate" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-percolate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The percolator request definition using the percolate DSL", "required"=>false},
+          url: {
+            path: "/{index}/{type}/_percolate",
+            paths: ["/{index}/{type}/_percolate", "/{index}/{type}/{id}/_percolate"],
+            parts: {
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The index of the document being percolated."},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document being percolated."},
+              "id" => {"type"=>"string", "required"=>false, "description"=>"Substitute the document in the request body with a document that is known by the specified id. On top of the id, the index and type parameter will be used to retrieve the document from within the cluster."},
+            },
+            params: {
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "percolate_index" => {"type"=>"string", "description"=>"The index to percolate the document into. Defaults to index."},
+              "percolate_type" => {"type"=>"string", "description"=>"The type to percolate document into. Defaults to type."},
+              "percolate_routing" => {"type"=>"string", "description"=>"The routing value to use when percolating the existing document."},
+              "percolate_preference" => {"type"=>"string", "description"=>"Which shard to prefer when executing the percolate request."},
+              "percolate_format" => {"type"=>"enum", "options"=>["ids"], "description"=>"Return an array of matching query IDs instead of objects"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "ping" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/",
+            paths: ["/"],
+          }
+        ),
+        "put_script" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-scripting.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The document", "required"=>true},
+          url: {
+            path: "/_scripts/{lang}/{id}",
+            paths: ["/_scripts/{lang}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Script ID", "required"=>true},
+              "lang" => {"type"=>"string", "description"=>"Script language", "required"=>true},
+            },
+            params: {
+              "op_type" => {"type"=>"enum", "options"=>["index", "create"], "default"=>"index", "description"=>"Explicit operation type"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "put_template" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-template.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The document", "required"=>true},
+          url: {
+            path: "/_search/template/{id}",
+            paths: ["/_search/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Template ID", "required"=>true},
+            },
+            params: {
+              "op_type" => {"type"=>"enum", "options"=>["index", "create"], "default"=>"index", "description"=>"Explicit operation type"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "reindex" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-reindex.html",
+          methods: ["POST"],
+          body: {"description"=>"The search definition using the Query DSL and the prototype for the index request.", "required"=>true},
+          url: {
+            path: "/_reindex",
+            paths: ["/_reindex"],
+            params: {
+              "refresh" => {"type"=>"boolean", "description"=>"Should the effected indexes be refreshed?"},
+              "timeout" => {"type"=>"time", "default"=>"1m", "description"=>"Time each individual bulk request should wait for shards that are unavailable."},
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Explicit write consistency setting for the operation"},
+              "wait_for_completion" => {"type"=>"boolean", "default"=>false, "description"=>"Should the request should block until the reindex is complete."},
+            }
+          }
+        ),
+        "render_search_template" => RestApi.new(
+          documentation: "http://www.elasticsearch.org/guide/en/elasticsearch/reference/2.3/search-template.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The search definition template and its params"},
+          url: {
+            path: "/_render/template",
+            paths: ["/_render/template", "/_render/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"The id of the stored search template"},
+            },
+          }
+        ),
+        "scroll" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-request-scroll.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The scroll ID if not passed by URL or query parameter."},
+          url: {
+            path: "/_search/scroll",
+            paths: ["/_search/scroll", "/_search/scroll/{scroll_id}"],
+            parts: {
+              "scroll_id" => {"type"=>"string", "description"=>"The scroll ID"},
+            },
+            params: {
+              "scroll" => {"type"=>"duration", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "scroll_id" => {"type"=>"string", "description"=>"The scroll ID for scrolled search"},
+            }
+          }
+        ),
+        "search" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-search.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The search definition using the Query DSL"},
+          url: {
+            path: "/_search",
+            paths: ["/_search", "/{index}/_search", "/{index}/{type}/_search"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "explain" => {"type"=>"boolean", "description"=>"Specify whether to return detailed information about score computation as part of a hit"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return as part of a hit"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return as the field data representation of a field for each hit"},
+              "from" => {"type"=>"number", "description"=>"Starting offset (default: 0)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "scroll" => {"type"=>"duration", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "dfs_query_then_fetch", "count", "scan"], "description"=>"Search operation type"},
+              "size" => {"type"=>"number", "description"=>"Number of hits to return (default: 10)"},
+              "sort" => {"type"=>"list", "description"=>"A comma-separated list of <field>:<direction> pairs"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "terminate_after" => {"type"=>"number", "description"=>"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."},
+              "stats" => {"type"=>"list", "description"=>"Specific 'tag' of the request for logging and statistical purposes"},
+              "suggest_field" => {"type"=>"string", "description"=>"Specify which field to use for suggestions"},
+              "suggest_mode" => {"type"=>"enum", "options"=>["missing", "popular", "always"], "default"=>"missing", "description"=>"Specify suggest mode"},
+              "suggest_size" => {"type"=>"number", "description"=>"How many suggestions to return in response"},
+              "suggest_text" => {"type"=>"text", "description"=>"The source text for which the suggestions should be returned"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "track_scores" => {"type"=>"boolean", "description"=>"Whether to calculate and return scores even if they are not used for sorting"},
+              "version" => {"type"=>"boolean", "description"=>"Specify whether to return document version as part of a hit"},
+              "request_cache" => {"type"=>"boolean", "description"=>"Specify if request cache should be used for this request or not, defaults to index level setting"},
+            }
+          }
+        ),
+        "search_exists" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-exists.html",
+          methods: ["POST", "GET"],
+          body: {"description"=>"A query to restrict the results specified with the Query DSL (optional)"},
+          url: {
+            path: "/_search/exists",
+            paths: ["/_search/exists", "/{index}/_search/exists", "/{index}/{type}/_search/exists"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of indices to restrict the results"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of types to restrict the results"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "min_score" => {"type"=>"number", "description"=>"Include only documents with a specific `_score` value in the result"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+            }
+          }
+        ),
+        "search_shards" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-shards.html",
+          methods: ["GET", "POST"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/_search_shards",
+            paths: ["/_search_shards", "/{index}/_search_shards", "/{index}/{type}/_search_shards"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "search_template" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The search definition template and its params"},
+          url: {
+            path: "/_search/template",
+            paths: ["/_search/template", "/{index}/_search/template", "/{index}/{type}/_search/template"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "scroll" => {"type"=>"duration", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch", "count", "scan"], "description"=>"Search operation type"},
+            }
+          }
+        ),
+        "snapshot.create" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The snapshot definition", "required"=>false},
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}",
+            paths: ["/_snapshot/{repository}/{snapshot}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"string", "required"=>true, "description"=>"A snapshot name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Should this request wait until the operation has completed before returning", "default"=>false},
+            }
+          }
+        ),
+        "snapshot.create_repository" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The repository definition", "required"=>true},
+          url: {
+            path: "/_snapshot/{repository}",
+            paths: ["/_snapshot/{repository}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "verify" => {"type"=>"boolean", "description"=>"Whether to verify the repository after creation"},
+            }
+          }
+        ),
+        "snapshot.delete" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}",
+            paths: ["/_snapshot/{repository}/{snapshot}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"string", "required"=>true, "description"=>"A snapshot name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+            }
+          }
+        ),
+        "snapshot.delete_repository" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}",
+            paths: ["/_snapshot/{repository}"],
+            parts: {
+              "repository" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of repository names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "snapshot.get" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}",
+            paths: ["/_snapshot/{repository}/{snapshot}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of snapshot names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+            }
+          }
+        ),
+        "snapshot.get_repository" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_snapshot",
+            paths: ["/_snapshot", "/_snapshot/{repository}"],
+            parts: {
+              "repository" => {"type"=>"list", "description"=>"A comma-separated list of repository names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "snapshot.restore" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html",
+          methods: ["POST"],
+          body: {"description"=>"Details of what to restore", "required"=>false},
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}/_restore",
+            paths: ["/_snapshot/{repository}/{snapshot}/_restore"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"string", "required"=>true, "description"=>"A snapshot name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Should this request wait until the operation has completed before returning", "default"=>false},
+            }
+          }
+        ),
+        "snapshot.status" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_snapshot/_status",
+            paths: ["/_snapshot/_status", "/_snapshot/{repository}/_status", "/_snapshot/{repository}/{snapshot}/_status"],
+            parts: {
+              "repository" => {"type"=>"string", "description"=>"A repository name"},
+              "snapshot" => {"type"=>"list", "description"=>"A comma-separated list of snapshot names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+            }
+          }
+        ),
+        "snapshot.verify_repository" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-snapshots.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}/_verify",
+            paths: ["/_snapshot/{repository}/_verify"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "suggest" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-suggesters.html",
+          methods: ["POST", "GET"],
+          body: {"description"=>"The request definition", "required"=>true},
+          url: {
+            path: "/_suggest",
+            paths: ["/_suggest", "/{index}/_suggest"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+            }
+          }
+        ),
+        "tasks.cancel" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/tasks.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_tasks",
+            paths: ["/_tasks/_cancel", "/_tasks/{task_id}/_cancel"],
+            parts: {
+              "task_id" => {"type"=>"string", "description"=>"Cancel the task with specified task id (node_id:task_number)"},
+            },
+            params: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+              "actions" => {"type"=>"list", "description"=>"A comma-separated list of actions that should be cancelled. Leave empty to cancel all."},
+              "parent_node" => {"type"=>"string", "description"=>"Cancel tasks with specified parent node."},
+              "parent_task" => {"type"=>"string", "description"=>"Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all."},
+            }
+          }
+        ),
+        "tasks.list" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/tasks.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_tasks",
+            paths: ["/_tasks", "/_tasks/{task_id}"],
+            parts: {
+              "task_id" => {"type"=>"string", "description"=>"Return the task with specified id (node_id:task_number)"},
+            },
+            params: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+              "actions" => {"type"=>"list", "description"=>"A comma-separated list of actions that should be returned. Leave empty to return all."},
+              "detailed" => {"type"=>"boolean", "description"=>"Return detailed task information (default: false)"},
+              "parent_node" => {"type"=>"string", "description"=>"Return tasks with specified parent node."},
+              "parent_task" => {"type"=>"string", "description"=>"Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all."},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Wait for the matching tasks to complete (default: false)"},
+            }
+          }
+        ),
+        "termvectors" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-termvectors.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Define parameters and or supply a document to get termvectors for. See documentation.", "required"=>false},
+          url: {
+            path: "/{index}/{type}/_termvectors",
+            paths: ["/{index}/{type}/_termvectors", "/{index}/{type}/{id}/_termvectors"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The index in which the document resides.", "required"=>true},
+              "type" => {"type"=>"string", "description"=>"The type of the document.", "required"=>true},
+              "id" => {"type"=>"string", "description"=>"The id of the document, when not specified a doc param should be supplied."},
+            },
+            params: {
+              "term_statistics" => {"type"=>"boolean", "description"=>"Specifies if total term frequency and document frequency should be returned.", "default"=>false, "required"=>false},
+              "field_statistics" => {"type"=>"boolean", "description"=>"Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.", "default"=>true, "required"=>false},
+              "dfs" => {"type"=>"boolean", "description"=>"Specifies if distributed frequencies should be returned instead shard frequencies.", "default"=>false, "required"=>false},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return.", "required"=>false},
+              "offsets" => {"type"=>"boolean", "description"=>"Specifies if term offsets should be returned.", "default"=>true, "required"=>false},
+              "positions" => {"type"=>"boolean", "description"=>"Specifies if term positions should be returned.", "default"=>true, "required"=>false},
+              "payloads" => {"type"=>"boolean", "description"=>"Specifies if term payloads should be returned.", "default"=>true, "required"=>false},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random).", "required"=>false},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value.", "required"=>false},
+              "parent" => {"type"=>"string", "description"=>"Parent id of documents.", "required"=>false},
+              "realtime" => {"type"=>"boolean", "description"=>"Specifies if request is real-time as opposed to near-real-time (default: true).", "required"=>false},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "update" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-update.html",
+          methods: ["POST"],
+          body: {"description"=>"The request definition using either `script` or partial `doc`"},
+          url: {
+            path: "/{index}/{type}/{id}/_update",
+            paths: ["/{index}/{type}/{id}/_update"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"Document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Explicit write consistency setting for the operation"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the response"},
+              "lang" => {"type"=>"string", "description"=>"The script language (default: groovy)"},
+              "parent" => {"type"=>"string", "description"=>"ID of the parent document. Is is only used for routing and when for the upsert request"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the index after performing the operation"},
+              "retry_on_conflict" => {"type"=>"number", "description"=>"Specify how many times should the operation be retried when a conflict occurs (default: 0)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "script" => {"description"=>"The URL-encoded script definition (instead of using request body)"},
+              "script_id" => {"description"=>"The id of a stored script"},
+              "scripted_upsert" => {"type"=>"boolean", "description"=>"True if the script referenced in script or script_id should be called to perform inserts - defaults to false"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "timestamp" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "ttl" => {"type"=>"duration", "description"=>"Expiration time for the document"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "update_by_query" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-update-by-query.html",
+          methods: ["POST"],
+          body: {"description"=>"The search definition using the Query DSL"},
+          url: {
+            path: "/{index}/_update_by_query",
+            paths: ["/{index}/_update_by_query", "/{index}/{type}/_update_by_query"],
+            parts: {
+              "index" => {"required"=>true, "type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "explain" => {"type"=>"boolean", "description"=>"Specify whether to return detailed information about score computation as part of a hit"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return as part of a hit"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return as the field data representation of a field for each hit"},
+              "from" => {"type"=>"number", "description"=>"Starting offset (default: 0)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "conflicts" => {"note"=>"This is not copied from search", "type"=>"enum", "options"=>["abort", "proceed"], "default"=>"abort", "description"=>"What to do when the reindex hits version conflicts?"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "scroll" => {"type"=>"duration", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "dfs_query_then_fetch"], "description"=>"Search operation type"},
+              "search_timeout" => {"type"=>"time", "description"=>"Explicit timeout for each search request. Defaults to no timeout."},
+              "size" => {"type"=>"number", "description"=>"Number of hits to return (default: 10)"},
+              "sort" => {"type"=>"list", "description"=>"A comma-separated list of <field>:<direction> pairs"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "terminate_after" => {"type"=>"number", "description"=>"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."},
+              "stats" => {"type"=>"list", "description"=>"Specific 'tag' of the request for logging and statistical purposes"},
+              "suggest_field" => {"type"=>"string", "description"=>"Specify which field to use for suggestions"},
+              "suggest_mode" => {"type"=>"enum", "options"=>["missing", "popular", "always"], "default"=>"missing", "description"=>"Specify suggest mode"},
+              "suggest_size" => {"type"=>"number", "description"=>"How many suggestions to return in response"},
+              "suggest_text" => {"type"=>"text", "description"=>"The source text for which the suggestions should be returned"},
+              "timeout" => {"type"=>"time", "default"=>"1m", "description"=>"Time each individual bulk request should wait for shards that are unavailable."},
+              "track_scores" => {"type"=>"boolean", "description"=>"Whether to calculate and return scores even if they are not used for sorting"},
+              "version" => {"type"=>"boolean", "description"=>"Specify whether to return document version as part of a hit"},
+              "version_type" => {"type"=>"boolean", "description"=>"Should the document increment the version number (internal) on hit or not (reindex)"},
+              "request_cache" => {"type"=>"boolean", "description"=>"Specify if request cache should be used for this request or not, defaults to index level setting"},
+              "refresh" => {"type"=>"boolean", "description"=>"Should the effected indexes be refreshed?"},
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Explicit write consistency setting for the operation"},
+              "scroll_size" => {"type"=>"integer", "defaut_value"=>100, "description"=>"Size on the scroll request powering the update_by_query"},
+              "wait_for_completion" => {"type"=>"boolean", "default"=>false, "description"=>"Should the request should block until the reindex is complete."},
+            }
+          }
+        ),
+      }
+      @common_params = {
+      }
+      super
+    end
+  end
+end

--- a/lib/elastomer/client/rest_api_spec/api_spec_v2_3.rb
+++ b/lib/elastomer/client/rest_api_spec/api_spec_v2_3.rb
@@ -2104,6 +2104,7 @@ module Elastomer::Client::RestApiSpec
               "parent_node" => {"type"=>"string", "description"=>"Return tasks with specified parent node."},
               "parent_task" => {"type"=>"string", "description"=>"Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all."},
               "wait_for_completion" => {"type"=>"boolean", "description"=>"Wait for the matching tasks to complete (default: false)"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
             }
           }
         ),

--- a/lib/elastomer/client/rest_api_spec/api_spec_v2_4.rb
+++ b/lib/elastomer/client/rest_api_spec/api_spec_v2_4.rb
@@ -1,0 +1,2249 @@
+# Generated REST API spec file - DO NOT EDIT!
+# Date: 2018-01-10
+# ES version: 2.4
+
+module Elastomer::Client::RestApiSpec
+  class ApiSpecV2_4 < ApiSpec
+    def initialize
+      @rest_apis = {
+        "bulk" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-bulk.html",
+          methods: ["POST", "PUT"],
+          body: {"description"=>"The operation definition and data (action-data pairs), separated by newlines", "required"=>true, "serialize"=>"bulk"},
+          url: {
+            path: "/_bulk",
+            paths: ["/_bulk", "/{index}/_bulk", "/{index}/{type}/_bulk"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"Default index for items which don't provide one"},
+              "type" => {"type"=>"string", "description"=>"Default document type for items which don't provide one"},
+            },
+            params: {
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Explicit write consistency setting for the operation"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the index after performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "type" => {"type"=>"string", "description"=>"Default document type for items which don't provide one"},
+              "fields" => {"type"=>"list", "description"=>"Default comma-separated list of fields to return in the response for updates"},
+            }
+          }
+        ),
+        "cat.aliases" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-alias.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/aliases",
+            paths: ["/_cat/aliases", "/_cat/aliases/{name}"],
+            parts: {
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to return"},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.allocation" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-allocation.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/allocation",
+            paths: ["/_cat/allocation", "/_cat/allocation/{node_id}"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information"},
+            },
+            params: {
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "m", "g"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.count" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-count.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/count",
+            paths: ["/_cat/count", "/_cat/count/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.fielddata" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-fielddata.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/fielddata",
+            paths: ["/_cat/fielddata", "/_cat/fielddata/{fields}"],
+            parts: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return the fielddata size"},
+            },
+            params: {
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "m", "g"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the output"},
+            }
+          }
+        ),
+        "cat.health" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-health.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/health",
+            paths: ["/_cat/health"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "ts" => {"type"=>"boolean", "description"=>"Set to false to disable timestamping", "default"=>true},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.help" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat",
+            paths: ["/_cat"],
+            params: {
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+            }
+          }
+        ),
+        "cat.indices" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-indices.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/indices",
+            paths: ["/_cat/indices", "/_cat/indices/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "m", "g"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "pri" => {"type"=>"boolean", "description"=>"Set to true to return stats only for primary shards", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.master" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-master.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/master",
+            paths: ["/_cat/master"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.nodeattrs" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-nodeattrs.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/nodeattrs",
+            paths: ["/_cat/nodeattrs"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.nodes" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-nodes.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/nodes",
+            paths: ["/_cat/nodes"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.pending_tasks" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-pending-tasks.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/pending_tasks",
+            paths: ["/_cat/pending_tasks"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.plugins" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-plugins.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/plugins",
+            paths: ["/_cat/plugins"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.recovery" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-recovery.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/recovery",
+            paths: ["/_cat/recovery", "/_cat/recovery/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "m", "g"]},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.repositories" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-repositories.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/repositories",
+            paths: ["/_cat/repositories"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node", "default"=>false},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.segments" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-segments.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/segments",
+            paths: ["/_cat/segments", "/_cat/segments/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.shards" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-shards.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/shards",
+            paths: ["/_cat/shards", "/_cat/shards/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.snapshots" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/snapshots/{repository}",
+            paths: ["/_cat/snapshots/{repository}"],
+            parts: {
+              "repository" => {"type"=>"list", "required"=>true, "description"=>"Name of repository from which to fetch the snapshot information"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Set to true to ignore unavailable snapshots", "default"=>false},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.thread_pool" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cat-thread-pool.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/thread_pool",
+            paths: ["/_cat/thread_pool"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+              "full_id" => {"type"=>"boolean", "description"=>"Enables displaying the complete node ids", "default"=>false},
+            }
+          }
+        ),
+        "clear_scroll" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-request-scroll.html",
+          methods: ["DELETE"],
+          body: {"description"=>"A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter"},
+          url: {
+            path: "/_search/scroll/{scroll_id}",
+            paths: ["/_search/scroll/{scroll_id}", "/_search/scroll"],
+            parts: {
+              "scroll_id" => {"type"=>"list", "description"=>"A comma-separated list of scroll IDs to clear"},
+            },
+          }
+        ),
+        "cluster.get_settings" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-update-settings.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/settings",
+            paths: ["/_cluster/settings"],
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "cluster.health" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-health.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/health",
+            paths: ["/_cluster/health", "/_cluster/health/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"Limit the information returned to a specific index"},
+            },
+            params: {
+              "level" => {"type"=>"enum", "options"=>["cluster", "indices", "shards"], "default"=>"cluster", "description"=>"Specify the level of detail for returned information"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "wait_for_active_shards" => {"type"=>"number", "description"=>"Wait until the specified number of shards is active"},
+              "wait_for_nodes" => {"type"=>"string", "description"=>"Wait until the specified number of nodes is available"},
+              "wait_for_relocating_shards" => {"type"=>"number", "description"=>"Wait until the specified number of relocating shards is finished"},
+              "wait_for_status" => {"type"=>"enum", "options"=>["green", "yellow", "red"], "default"=>nil, "description"=>"Wait until cluster is in a specific state"},
+            }
+          }
+        ),
+        "cluster.pending_tasks" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-pending.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/pending_tasks",
+            paths: ["/_cluster/pending_tasks"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "cluster.put_settings" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-update-settings.html",
+          methods: ["PUT"],
+          body: {"description"=>"The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart)."},
+          url: {
+            path: "/_cluster/settings",
+            paths: ["/_cluster/settings"],
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "cluster.reroute" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-reroute.html",
+          methods: ["POST"],
+          body: {"description"=>"The definition of `commands` to perform (`move`, `cancel`, `allocate`)"},
+          url: {
+            path: "/_cluster/reroute",
+            paths: ["/_cluster/reroute"],
+            params: {
+              "dry_run" => {"type"=>"boolean", "description"=>"Simulate the operation only and return the resulting state"},
+              "explain" => {"type"=>"boolean", "description"=>"Return an explanation of why the commands can or cannot be executed"},
+              "metric" => {"type"=>"list", "options"=>["_all", "blocks", "metadata", "nodes", "routing_table", "master_node", "version"], "description"=>"Limit the information returned to the specified metrics. Defaults to all but metadata"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "cluster.state" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-state.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/state",
+            paths: ["/_cluster/state", "/_cluster/state/{metric}", "/_cluster/state/{metric}/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+              "metric" => {"type"=>"list", "options"=>["_all", "blocks", "metadata", "nodes", "routing_table", "routing_nodes", "master_node", "version"], "description"=>"Limit the information returned to the specified metrics"},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "cluster.stats" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-stats.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/stats",
+            paths: ["/_cluster/stats", "/_cluster/stats/nodes/{node_id}"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+            },
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "count" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-count.html",
+          methods: ["POST", "GET"],
+          body: {"description"=>"A query to restrict the results specified with the Query DSL (optional)"},
+          url: {
+            path: "/_count",
+            paths: ["/_count", "/{index}/_count", "/{index}/{type}/_count"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of indices to restrict the results"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of types to restrict the results"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "min_score" => {"type"=>"number", "description"=>"Include only documents with a specific `_score` value in the result"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+            }
+          }
+        ),
+        "count_percolate" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-percolate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The count percolator request definition using the percolate DSL", "required"=>false},
+          url: {
+            path: "/{index}/{type}/_percolate/count",
+            paths: ["/{index}/{type}/_percolate/count", "/{index}/{type}/{id}/_percolate/count"],
+            parts: {
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The index of the document being count percolated."},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document being count percolated."},
+              "id" => {"type"=>"string", "required"=>false, "description"=>"Substitute the document in the request body with a document that is known by the specified id. On top of the id, the index and type parameter will be used to retrieve the document from within the cluster."},
+            },
+            params: {
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "percolate_index" => {"type"=>"string", "description"=>"The index to count percolate the document into. Defaults to index."},
+              "percolate_type" => {"type"=>"string", "description"=>"The type to count percolate document into. Defaults to type."},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "delete" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-delete.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}",
+            paths: ["/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Specific write consistency setting for the operation"},
+              "parent" => {"type"=>"string", "description"=>"ID of parent document"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the index after performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "delete_script" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-scripting.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_scripts/{lang}/{id}",
+            paths: ["/_scripts/{lang}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Script ID", "required"=>true},
+              "lang" => {"type"=>"string", "description"=>"Script language", "required"=>true},
+            },
+            params: {
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "delete_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-template.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_search/template/{id}",
+            paths: ["/_search/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Template ID", "required"=>true},
+            },
+            params: {
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "exists" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-get.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}",
+            paths: ["/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document (use `_all` to fetch the first document matching the ID across all types)"},
+            },
+            params: {
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+            }
+          }
+        ),
+        "explain" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-explain.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The query definition using the Query DSL"},
+          url: {
+            path: "/{index}/{type}/{id}/_explain",
+            paths: ["/{index}/{type}/{id}/_explain"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcards and prefix queries in the query string query should be analyzed (default: false)"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer for the query string query"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The default field for query string query (default: _all)"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the response"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+            }
+          }
+        ),
+        "field_stats" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-field-stats.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Field json objects containing the name and optionally a range to filter out indices result, that have results outside the defined bounds", "required"=>false},
+          url: {
+            path: "/_field_stats",
+            paths: ["/_field_stats", "/{index}/_field_stats"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for to get field statistics for (min value, max value, and more)"},
+              "level" => {"type"=>"enum", "options"=>["indices", "cluster"], "default"=>"cluster", "description"=>"Defines if field stats should be returned on a per index level or on a cluster wide level"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "get" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-get.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}",
+            paths: ["/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document (use `_all` to fetch the first document matching the ID across all types)"},
+            },
+            params: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the response"},
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "get_script" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-scripting.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_scripts/{lang}/{id}",
+            paths: ["/_scripts/{lang}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Script ID", "required"=>true},
+              "lang" => {"type"=>"string", "description"=>"Script language", "required"=>true},
+            },
+            params: {
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "get_source" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-get.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}/_source",
+            paths: ["/{index}/{type}/{id}/_source"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document; use `_all` to fetch the first document matching the ID across all types"},
+            },
+            params: {
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "get_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-template.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_search/template/{id}",
+            paths: ["/_search/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Template ID", "required"=>true},
+            },
+            params: {
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "index" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-index_.html",
+          methods: ["POST", "PUT"],
+          body: {"description"=>"The document", "required"=>true},
+          url: {
+            path: "/{index}/{type}",
+            paths: ["/{index}/{type}", "/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Explicit write consistency setting for the operation"},
+              "op_type" => {"type"=>"enum", "options"=>["index", "create"], "default"=>"index", "description"=>"Explicit operation type"},
+              "parent" => {"type"=>"string", "description"=>"ID of the parent document"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the affected shards after performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "timestamp" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "ttl" => {"type"=>"time", "description"=>"Expiration time for the document"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "indices.analyze" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-analyze.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The text on which the analysis should be performed"},
+          url: {
+            path: "/_analyze",
+            paths: ["/_analyze", "/{index}/_analyze"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The name of the index to scope the operation"},
+            },
+            params: {
+              "analyzer" => {"type"=>"string", "description"=>"The name of the analyzer to use"},
+              "char_filters" => {"type"=>"list", "description"=>"Deprecated : A comma-separated list of character filters to use for the analysis"},
+              "char_filter" => {"type"=>"list", "description"=>"A comma-separated list of character filters to use for the analysis"},
+              "field" => {"type"=>"string", "description"=>"Use the analyzer configured for this field (instead of passing the analyzer name)"},
+              "filters" => {"type"=>"list", "description"=>"Deprecated : A comma-separated list of filters to use for the analysis"},
+              "filter" => {"type"=>"list", "description"=>"A comma-separated list of filters to use for the analysis"},
+              "index" => {"type"=>"string", "description"=>"The name of the index to scope the operation"},
+              "prefer_local" => {"type"=>"boolean", "description"=>"With `true`, specify that a local shard should be used if available, with `false`, use a random shard (default: true)"},
+              "text" => {"type"=>"list", "description"=>"The text on which the analysis should be performed (when request body is not used)"},
+              "tokenizer" => {"type"=>"string", "description"=>"The name of the tokenizer to use for the analysis"},
+              "explain" => {"type"=>"boolean", "description"=>"With `true`, outputs more advanced details. (default: false)"},
+              "attributes" => {"type"=>"list", "description"=>"A comma-separated list of token attributes to output, this parameter works only with `explain=true`"},
+              "format" => {"type"=>"enum", "options"=>["detailed", "text"], "default"=>"detailed", "description"=>"Format of the output"},
+            }
+          }
+        ),
+        "indices.clear_cache" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-clearcache.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_cache/clear",
+            paths: ["/_cache/clear", "/{index}/_cache/clear"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index name to limit the operation"},
+            },
+            params: {
+              "field_data" => {"type"=>"boolean", "description"=>"Clear field data"},
+              "fielddata" => {"type"=>"boolean", "description"=>"Clear field data"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to clear when using the `field_data` parameter (default: all)"},
+              "query" => {"type"=>"boolean", "description"=>"Clear query caches"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index name to limit the operation"},
+              "recycler" => {"type"=>"boolean", "description"=>"Clear the recycler cache"},
+              "request" => {"type"=>"boolean", "description"=>"Clear request cache"},
+            }
+          }
+        ),
+        "indices.close" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-open-close.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/{index}/_close",
+            paths: ["/{index}/_close"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma separated list of indices to close"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.create" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-create-index.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The configuration for the index (`settings` and `mappings`)"},
+          url: {
+            path: "/{index}",
+            paths: ["/{index}"],
+            parts: {
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "update_all_types" => {"type"=>"boolean", "description"=>"Whether to update the mapping for all fields with the same name across all types or not"},
+            }
+          }
+        ),
+        "indices.delete" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-delete-index.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}",
+            paths: ["/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.delete_alias" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-aliases.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}/_alias/{name}",
+            paths: ["/{index}/_alias/{name}", "/{index}/_aliases/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names (supports wildcards); use `_all` for all indices"},
+              "name" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices."},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.delete_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-templates.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the template"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.delete_warmer" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-warmers.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}/_warmer/{name}",
+            paths: ["/{index}/_warmer/{name}", "/{index}/_warmers/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names to delete warmers from (supports wildcards); use `_all` to perform the operation on all indices."},
+              "name" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters."},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of warmer names to delete (supports wildcards); use `_all` to delete all warmers in the specified indices. You must specify a name either in the uri or in the parameters."},
+            }
+          }
+        ),
+        "indices.exists" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-exists.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/{index}",
+            paths: ["/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of indices to check"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.exists_alias" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-aliases.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/_alias/{name}",
+            paths: ["/_alias/{name}", "/{index}/_alias/{name}", "/{index}/_alias"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to filter aliases"},
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to return"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>["open", "closed"], "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.exists_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-templates.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the template"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.exists_type" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-types-exists.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}",
+            paths: ["/{index}/{type}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names; use `_all` to check the types across all indices"},
+              "type" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of document types to check"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.flush" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-flush.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_flush",
+            paths: ["/_flush", "/{index}/_flush"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string for all indices"},
+            },
+            params: {
+              "force" => {"type"=>"boolean", "description"=>"Whether a flush should be forced even if it is not necessarily needed ie. if no changes will be committed to the index. This is useful if transaction log IDs should be incremented even if no uncommitted changes are present. (This setting can be considered as internal)"},
+              "wait_if_ongoing" => {"type"=>"boolean", "description"=>"If set to true the flush operation will block until the flush can be executed if another flush operation is already executing. The default is false and will cause an exception to be thrown on the shard level if another flush operation is already running."},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.flush_synced" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-synced-flush.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_flush/synced",
+            paths: ["/_flush/synced", "/{index}/_flush/synced"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string for all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.forcemerge" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-forcemerge.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_forcemerge",
+            paths: ["/_forcemerge", "/{index}/_forcemerge"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "flush" => {"type"=>"boolean", "description"=>"Specify whether the index should be flushed after performing the operation (default: true)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "max_num_segments" => {"type"=>"number", "description"=>"The number of segments the index should be merged into (default: dynamic)"},
+              "only_expunge_deletes" => {"type"=>"boolean", "description"=>"Specify whether the operation should only expunge deleted documents"},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "wait_for_merge" => {"type"=>"boolean", "description"=>"Specify whether the request should block until the merge process is finished (default: true)"},
+            }
+          }
+        ),
+        "indices.get" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-get-index.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/{index}",
+            paths: ["/{index}", "/{index}/{feature}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names"},
+              "feature" => {"type"=>"list", "description"=>"A comma-separated list of features", "options"=>["_settings", "_mappings", "_warmers", "_aliases"]},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Ignore unavailable indexes (default: false)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Ignore if a wildcard expression resolves to no concrete indices (default: false)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether wildcard expressions should get expanded to open or closed indices (default: open)"},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return version and creation date values in human-readable format.", "default"=>false},
+            }
+          }
+        ),
+        "indices.get_alias" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-aliases.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_alias/",
+            paths: ["/_alias", "/_alias/{name}", "/{index}/_alias/{name}", "/{index}/_alias"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to filter aliases"},
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to return"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_aliases" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-aliases.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_aliases",
+            paths: ["/_aliases", "/{index}/_aliases", "/{index}/_aliases/{name}", "/_aliases/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to filter aliases"},
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to filter"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_field_mapping" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-get-field-mapping.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_mapping/field/{fields}",
+            paths: ["/_mapping/field/{fields}", "/{index}/_mapping/field/{fields}", "/_mapping/{type}/field/{fields}", "/{index}/_mapping/{type}/field/{fields}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields", "required"=>true},
+            },
+            params: {
+              "include_defaults" => {"type"=>"boolean", "description"=>"Whether the default mapping values should be returned as well"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_mapping" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-get-mapping.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_mapping",
+            paths: ["/_mapping", "/{index}/_mapping", "/_mapping/{type}", "/{index}/_mapping/{type}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_settings" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-get-settings.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_settings",
+            paths: ["/_settings", "/{index}/_settings", "/{index}/_settings/{name}", "/_settings/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+              "name" => {"type"=>"list", "description"=>"The name of the settings that should be included"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>["open", "closed"], "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return version and creation date values in human-readable format.", "default"=>false},
+            }
+          }
+        ),
+        "indices.get_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-templates.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template", "/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"list", "required"=>false, "description"=>"The comma separated names of the index templates"},
+            },
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_upgrade" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-upgrade.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_upgrade",
+            paths: ["/_upgrade", "/{index}/_upgrade"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+            }
+          }
+        ),
+        "indices.get_warmer" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-warmers.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_warmer",
+            paths: ["/_warmer", "/{index}/_warmer", "/{index}/_warmer/{name}", "/_warmer/{name}", "/{index}/{type}/_warmer/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to restrict the operation; use `_all` to perform the operation on all indices"},
+              "name" => {"type"=>"list", "description"=>"The name of the warmer (supports wildcards); leave empty to get all warmers"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.open" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-open-close.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/{index}/_open",
+            paths: ["/{index}/_open"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma separated list of indices to open"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"closed", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.optimize" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-optimize.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_optimize",
+            paths: ["/_optimize", "/{index}/_optimize"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "flush" => {"type"=>"boolean", "description"=>"Specify whether the index should be flushed after performing the operation (default: true)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "max_num_segments" => {"type"=>"number", "description"=>"The number of segments the index should be merged into (default: dynamic)"},
+              "only_expunge_deletes" => {"type"=>"boolean", "description"=>"Specify whether the operation should only expunge deleted documents"},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "wait_for_merge" => {"type"=>"boolean", "description"=>"Specify whether the request should block until the merge process is finished (default: true)"},
+            }
+          }
+        ),
+        "indices.put_alias" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-aliases.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The settings for the alias, such as `routing` or `filter`", "required"=>false},
+          url: {
+            path: "/{index}/_alias/{name}",
+            paths: ["/{index}/_alias/{name}", "/{index}/_aliases/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices."},
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the alias to be created or updated"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.put_mapping" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-put-mapping.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The mapping definition", "required"=>true},
+          url: {
+            path: "/{index}/{type}/_mapping",
+            paths: ["/{index}/{type}/_mapping", "/{index}/_mapping/{type}", "/_mapping/{type}", "/{index}/{type}/_mappings", "/{index}/_mappings/{type}", "/_mappings/{type}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices."},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The name of the document type"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "update_all_types" => {"type"=>"boolean", "description"=>"Whether to update the mapping for all fields with the same name across all types or not"},
+            }
+          }
+        ),
+        "indices.put_settings" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-update-settings.html",
+          methods: ["PUT"],
+          body: {"description"=>"The index settings to be updated", "required"=>true},
+          url: {
+            path: "/_settings",
+            paths: ["/_settings", "/{index}/_settings"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+            }
+          }
+        ),
+        "indices.put_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-templates.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The template definition", "required"=>true},
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the template"},
+            },
+            params: {
+              "order" => {"type"=>"number", "description"=>"The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"},
+              "create" => {"type"=>"boolean", "description"=>"Whether the index template should only be added if new or can also replace an existing one", "default"=>false},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+            }
+          }
+        ),
+        "indices.put_warmer" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-warmers.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The search request definition for the warmer (query, filters, facets, sorting, etc)", "required"=>true},
+          url: {
+            path: "/{index}/_warmer/{name}",
+            paths: ["/_warmer/{name}", "/{index}/_warmer/{name}", "/{index}/{type}/_warmer/{name}", "/_warmers/{name}", "/{index}/_warmers/{name}", "/{index}/{type}/_warmers/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to register the warmer for; use `_all` or omit to perform the operation on all indices"},
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the warmer"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to register the warmer for; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed) in the search request to warm"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices in the search request to warm. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both, in the search request to warm."},
+              "request_cache" => {"type"=>"boolean", "description"=>"Specify whether the request to be warmed should use the request cache, defaults to index level setting"},
+            }
+          }
+        ),
+        "indices.recovery" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-recovery.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_recovery",
+            paths: ["/_recovery", "/{index}/_recovery"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "detailed" => {"type"=>"boolean", "description"=>"Whether to display detailed information about shard recovery", "default"=>false},
+              "active_only" => {"type"=>"boolean", "description"=>"Display only those recoveries that are currently on-going", "default"=>false},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+            }
+          }
+        ),
+        "indices.refresh" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-refresh.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_refresh",
+            paths: ["/_refresh", "/{index}/_refresh"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "force" => {"type"=>"boolean", "description"=>"Force a refresh even if not required", "default"=>false},
+              "operation_threading" => {"description"=>"TODO: ?"},
+            }
+          }
+        ),
+        "indices.segments" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-segments.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_segments",
+            paths: ["/_segments", "/{index}/_segments"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "verbose" => {"type"=>"boolean", "description"=>"Includes detailed memory usage by Lucene.", "default"=>false},
+            }
+          }
+        ),
+        "indices.shard_stores" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-shards-stores.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_shard_stores",
+            paths: ["/_shard_stores", "/{index}/_shard_stores"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "status" => {"type"=>"list", "options"=>["green", "yellow", "red", "all"], "description"=>"A comma-separated list of statuses used to filter on shards to get store information for"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "operation_threading" => {"description"=>"TODO: ?"},
+            }
+          }
+        ),
+        "indices.stats" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-stats.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_stats",
+            paths: ["/_stats", "/_stats/{metric}", "/{index}/_stats", "/{index}/_stats/{metric}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+              "metric" => {"type"=>"list", "options"=>["_all", "completion", "docs", "fielddata", "query_cache", "flush", "get", "indexing", "merge", "percolate", "request_cache", "refresh", "search", "segments", "store", "warmer", "suggest"], "description"=>"Limit the information returned the specific metrics."},
+            },
+            params: {
+              "completion_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` index metric (supports wildcards)"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)"},
+              "groups" => {"type"=>"list", "description"=>"A comma-separated list of search groups for `search` index metric"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+              "level" => {"type"=>"enum", "description"=>"Return stats aggregated at cluster, index or shard level", "options"=>["cluster", "indices", "shards"], "default"=>"indices"},
+              "types" => {"type"=>"list", "description"=>"A comma-separated list of document types for the `indexing` index metric"},
+            }
+          }
+        ),
+        "indices.update_aliases" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-aliases.html",
+          methods: ["POST"],
+          body: {"description"=>"The definition of `actions` to perform", "required"=>true},
+          url: {
+            path: "/_aliases",
+            paths: ["/_aliases"],
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Request timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.upgrade" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-upgrade.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_upgrade",
+            paths: ["/_upgrade", "/{index}/_upgrade"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Specify whether the request should block until the all segments are upgraded (default: false)"},
+              "only_ancient_segments" => {"type"=>"boolean", "description"=>"If true, only ancient (an older Lucene major release) segments will be upgraded"},
+            }
+          }
+        ),
+        "indices.validate_query" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-validate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The query definition specified with the Query DSL"},
+          url: {
+            path: "/_validate/query",
+            paths: ["/_validate/query", "/{index}/_validate/query", "/{index}/{type}/_validate/query"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "explain" => {"type"=>"boolean", "description"=>"Return detailed information about the error"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+              "rewrite" => {"type"=>"boolean", "description"=>"Provide a more detailed explanation showing the actual Lucene query that will be executed."},
+            }
+          }
+        ),
+        "info" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/",
+            paths: ["/"],
+          }
+        ),
+        "mget" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-multi-get.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.", "required"=>true},
+          url: {
+            path: "/_mget",
+            paths: ["/_mget", "/{index}/_mget", "/{index}/{type}/_mget"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "description"=>"The type of the document"},
+            },
+            params: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the response"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+            }
+          }
+        ),
+        "mpercolate" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-percolate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The percolate request definitions (header & body pair), separated by newlines", "required"=>true, "serialize"=>"bulk"},
+          url: {
+            path: "/_mpercolate",
+            paths: ["/_mpercolate", "/{index}/_mpercolate", "/{index}/{type}/_mpercolate"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The index of the document being count percolated to use as default"},
+              "type" => {"type"=>"string", "description"=>"The type of the document being percolated to use as default."},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "msearch" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-multi-search.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The request definitions (metadata-search request definition pairs), separated by newlines", "required"=>true, "serialize"=>"bulk"},
+          url: {
+            path: "/_msearch",
+            paths: ["/_msearch", "/{index}/_msearch", "/{index}/{type}/_msearch"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to use as default"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to use as default"},
+            },
+            params: {
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch", "count", "scan"], "description"=>"Search operation type"},
+            }
+          }
+        ),
+        "mtermvectors" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-multi-termvectors.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.", "required"=>false},
+          url: {
+            path: "/_mtermvectors",
+            paths: ["/_mtermvectors", "/{index}/_mtermvectors", "/{index}/{type}/_mtermvectors"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The index in which the document resides."},
+              "type" => {"type"=>"string", "description"=>"The type of the document."},
+            },
+            params: {
+              "ids" => {"type"=>"list", "description"=>"A comma-separated list of documents ids. You must define ids as parameter or set \"ids\" or \"docs\" in the request body", "required"=>false},
+              "term_statistics" => {"type"=>"boolean", "description"=>"Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>false, "required"=>false},
+              "field_statistics" => {"type"=>"boolean", "description"=>"Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "offsets" => {"type"=>"boolean", "description"=>"Specifies if term offsets should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "positions" => {"type"=>"boolean", "description"=>"Specifies if term positions should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "payloads" => {"type"=>"boolean", "description"=>"Specifies if term payloads should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random) .Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "parent" => {"type"=>"string", "description"=>"Parent id of documents. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "realtime" => {"type"=>"boolean", "description"=>"Specifies if requests are real-time as opposed to near-real-time (default: true).", "required"=>false},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "nodes.hot_threads" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-nodes-hot-threads.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_nodes/hot_threads",
+            paths: ["/_cluster/nodes/hotthreads", "/_cluster/nodes/hot_threads", "/_cluster/nodes/{node_id}/hotthreads", "/_cluster/nodes/{node_id}/hot_threads", "/_nodes/hotthreads", "/_nodes/hot_threads", "/_nodes/{node_id}/hotthreads", "/_nodes/{node_id}/hot_threads"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+            },
+            params: {
+              "interval" => {"type"=>"time", "description"=>"The interval for the second sampling of threads"},
+              "snapshots" => {"type"=>"number", "description"=>"Number of samples of thread stacktrace (default: 10)"},
+              "threads" => {"type"=>"number", "description"=>"Specify the number of threads to provide information for (default: 3)"},
+              "ignore_idle_threads" => {"type"=>"boolean", "description"=>"Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue (default: true)"},
+              "type" => {"type"=>"enum", "options"=>["cpu", "wait", "block"], "description"=>"The type to sample (default: cpu)"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "nodes.info" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-nodes-info.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_nodes",
+            paths: ["/_nodes", "/_nodes/{node_id}", "/_nodes/{metric}", "/_nodes/{node_id}/{metric}"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+              "metric" => {"type"=>"list", "options"=>["settings", "os", "process", "jvm", "thread_pool", "transport", "http", "plugins"], "description"=>"A comma-separated list of metrics you wish returned. Leave empty to return all."},
+            },
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "nodes.stats" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-nodes-stats.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_nodes/stats",
+            paths: ["/_nodes/stats", "/_nodes/{node_id}/stats", "/_nodes/stats/{metric}", "/_nodes/{node_id}/stats/{metric}", "/_nodes/stats/{metric}/{index_metric}", "/_nodes/{node_id}/stats/{metric}/{index_metric}"],
+            parts: {
+              "metric" => {"type"=>"list", "options"=>["_all", "breaker", "fs", "http", "indices", "jvm", "os", "process", "thread_pool", "transport"], "description"=>"Limit the information returned to the specified metrics"},
+              "index_metric" => {"type"=>"list", "options"=>["_all", "completion", "docs", "fielddata", "query_cache", "flush", "get", "indexing", "merge", "percolate", "request_cache", "refresh", "search", "segments", "store", "warmer", "suggest"], "description"=>"Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified."},
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+            },
+            params: {
+              "completion_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` index metric (supports wildcards)"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)"},
+              "groups" => {"type"=>"boolean", "description"=>"A comma-separated list of search groups for `search` index metric"},
+              "human" => {"type"=>"boolean", "description"=>"Whether to return time and byte values in human-readable format.", "default"=>false},
+              "level" => {"type"=>"enum", "description"=>"Return indices stats aggregated at node, index or shard level", "options"=>["node", "indices", "shards"], "default"=>"node"},
+              "types" => {"type"=>"list", "description"=>"A comma-separated list of document types for the `indexing` index metric"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "percolate" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-percolate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The percolator request definition using the percolate DSL", "required"=>false},
+          url: {
+            path: "/{index}/{type}/_percolate",
+            paths: ["/{index}/{type}/_percolate", "/{index}/{type}/{id}/_percolate"],
+            parts: {
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The index of the document being percolated."},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document being percolated."},
+              "id" => {"type"=>"string", "required"=>false, "description"=>"Substitute the document in the request body with a document that is known by the specified id. On top of the id, the index and type parameter will be used to retrieve the document from within the cluster."},
+            },
+            params: {
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "percolate_index" => {"type"=>"string", "description"=>"The index to percolate the document into. Defaults to index."},
+              "percolate_type" => {"type"=>"string", "description"=>"The type to percolate document into. Defaults to type."},
+              "percolate_routing" => {"type"=>"string", "description"=>"The routing value to use when percolating the existing document."},
+              "percolate_preference" => {"type"=>"string", "description"=>"Which shard to prefer when executing the percolate request."},
+              "percolate_format" => {"type"=>"enum", "options"=>["ids"], "description"=>"Return an array of matching query IDs instead of objects"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "ping" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/",
+            paths: ["/"],
+          }
+        ),
+        "put_script" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-scripting.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The document", "required"=>true},
+          url: {
+            path: "/_scripts/{lang}/{id}",
+            paths: ["/_scripts/{lang}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Script ID", "required"=>true},
+              "lang" => {"type"=>"string", "description"=>"Script language", "required"=>true},
+            },
+            params: {
+              "op_type" => {"type"=>"enum", "options"=>["index", "create"], "default"=>"index", "description"=>"Explicit operation type"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "put_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-template.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The document", "required"=>true},
+          url: {
+            path: "/_search/template/{id}",
+            paths: ["/_search/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Template ID", "required"=>true},
+            },
+            params: {
+              "op_type" => {"type"=>"enum", "options"=>["index", "create"], "default"=>"index", "description"=>"Explicit operation type"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "reindex" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-reindex.html",
+          methods: ["POST"],
+          body: {"description"=>"The search definition using the Query DSL and the prototype for the index request.", "required"=>true},
+          url: {
+            path: "/_reindex",
+            paths: ["/_reindex"],
+            params: {
+              "refresh" => {"type"=>"boolean", "description"=>"Should the effected indexes be refreshed?"},
+              "timeout" => {"type"=>"time", "default"=>"1m", "description"=>"Time each individual bulk request should wait for shards that are unavailable."},
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Explicit write consistency setting for the operation"},
+              "wait_for_completion" => {"type"=>"boolean", "default"=>false, "description"=>"Should the request should block until the reindex is complete."},
+              "requests_per_second" => {"type"=>"number", "default"=>0, "description"=>"The throttle for this request in sub-requests per second. 0 means set no throttle."},
+            }
+          }
+        ),
+        "reindex_rethrottle" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-reindex.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_reindex/{task_id}/_rethrottle",
+            paths: ["/_reindex/{task_id}/_rethrottle", "/_update_by_query/{task_id}/_rethrottle"],
+            parts: {
+              "task_id" => {"type"=>"string", "description"=>"The task id to rethrottle"},
+            },
+            params: {
+              "requests_per_second" => {"type"=>"number", "required"=>true, "description"=>"The throttle to set on this request in sub-requests per second. \"unlimited\" means set no throttle, otherwise it must be a float greater than 0."},
+            }
+          }
+        ),
+        "render_search_template" => RestApi.new(
+          documentation: "http://www.elasticsearch.org/guide/en/elasticsearch/reference/2.4/search-template.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The search definition template and its params"},
+          url: {
+            path: "/_render/template",
+            paths: ["/_render/template", "/_render/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"The id of the stored search template"},
+            },
+          }
+        ),
+        "scroll" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-request-scroll.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The scroll ID if not passed by URL or query parameter."},
+          url: {
+            path: "/_search/scroll",
+            paths: ["/_search/scroll", "/_search/scroll/{scroll_id}"],
+            parts: {
+              "scroll_id" => {"type"=>"string", "description"=>"The scroll ID"},
+            },
+            params: {
+              "scroll" => {"type"=>"time", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "scroll_id" => {"type"=>"string", "description"=>"The scroll ID for scrolled search"},
+            }
+          }
+        ),
+        "search" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-search.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The search definition using the Query DSL"},
+          url: {
+            path: "/_search",
+            paths: ["/_search", "/{index}/_search", "/{index}/{type}/_search"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "explain" => {"type"=>"boolean", "description"=>"Specify whether to return detailed information about score computation as part of a hit"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return as part of a hit"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return as the field data representation of a field for each hit"},
+              "from" => {"type"=>"number", "description"=>"Starting offset (default: 0)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "scroll" => {"type"=>"time", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "dfs_query_then_fetch", "count", "scan"], "description"=>"Search operation type"},
+              "size" => {"type"=>"number", "description"=>"Number of hits to return (default: 10)"},
+              "sort" => {"type"=>"list", "description"=>"A comma-separated list of <field>:<direction> pairs"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "terminate_after" => {"type"=>"number", "description"=>"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."},
+              "stats" => {"type"=>"list", "description"=>"Specific 'tag' of the request for logging and statistical purposes"},
+              "suggest_field" => {"type"=>"string", "description"=>"Specify which field to use for suggestions"},
+              "suggest_mode" => {"type"=>"enum", "options"=>["missing", "popular", "always"], "default"=>"missing", "description"=>"Specify suggest mode"},
+              "suggest_size" => {"type"=>"number", "description"=>"How many suggestions to return in response"},
+              "suggest_text" => {"type"=>"string", "description"=>"The source text for which the suggestions should be returned"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "track_scores" => {"type"=>"boolean", "description"=>"Whether to calculate and return scores even if they are not used for sorting"},
+              "version" => {"type"=>"boolean", "description"=>"Specify whether to return document version as part of a hit"},
+              "request_cache" => {"type"=>"boolean", "description"=>"Specify if request cache should be used for this request or not, defaults to index level setting"},
+            }
+          }
+        ),
+        "search_exists" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-exists.html",
+          methods: ["POST", "GET"],
+          body: {"description"=>"A query to restrict the results specified with the Query DSL (optional)"},
+          url: {
+            path: "/_search/exists",
+            paths: ["/_search/exists", "/{index}/_search/exists", "/{index}/{type}/_search/exists"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of indices to restrict the results"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of types to restrict the results"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "min_score" => {"type"=>"number", "description"=>"Include only documents with a specific `_score` value in the result"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+            }
+          }
+        ),
+        "search_shards" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-shards.html",
+          methods: ["GET", "POST"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/_search_shards",
+            paths: ["/_search_shards", "/{index}/_search_shards", "/{index}/{type}/_search_shards"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "search_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The search definition template and its params"},
+          url: {
+            path: "/_search/template",
+            paths: ["/_search/template", "/{index}/_search/template", "/{index}/{type}/_search/template"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "scroll" => {"type"=>"time", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch", "count", "scan"], "description"=>"Search operation type"},
+            }
+          }
+        ),
+        "snapshot.create" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-snapshots.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The snapshot definition", "required"=>false},
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}",
+            paths: ["/_snapshot/{repository}/{snapshot}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"string", "required"=>true, "description"=>"A snapshot name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Should this request wait until the operation has completed before returning", "default"=>false},
+            }
+          }
+        ),
+        "snapshot.create_repository" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-snapshots.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The repository definition", "required"=>true},
+          url: {
+            path: "/_snapshot/{repository}",
+            paths: ["/_snapshot/{repository}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "verify" => {"type"=>"boolean", "description"=>"Whether to verify the repository after creation"},
+            }
+          }
+        ),
+        "snapshot.delete" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-snapshots.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}",
+            paths: ["/_snapshot/{repository}/{snapshot}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"string", "required"=>true, "description"=>"A snapshot name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+            }
+          }
+        ),
+        "snapshot.delete_repository" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-snapshots.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}",
+            paths: ["/_snapshot/{repository}"],
+            parts: {
+              "repository" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of repository names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "snapshot.get" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}",
+            paths: ["/_snapshot/{repository}/{snapshot}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of snapshot names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+            }
+          }
+        ),
+        "snapshot.get_repository" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_snapshot",
+            paths: ["/_snapshot", "/_snapshot/{repository}"],
+            parts: {
+              "repository" => {"type"=>"list", "description"=>"A comma-separated list of repository names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "snapshot.restore" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-snapshots.html",
+          methods: ["POST"],
+          body: {"description"=>"Details of what to restore", "required"=>false},
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}/_restore",
+            paths: ["/_snapshot/{repository}/{snapshot}/_restore"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"string", "required"=>true, "description"=>"A snapshot name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Should this request wait until the operation has completed before returning", "default"=>false},
+            }
+          }
+        ),
+        "snapshot.status" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_snapshot/_status",
+            paths: ["/_snapshot/_status", "/_snapshot/{repository}/_status", "/_snapshot/{repository}/{snapshot}/_status"],
+            parts: {
+              "repository" => {"type"=>"string", "description"=>"A repository name"},
+              "snapshot" => {"type"=>"list", "description"=>"A comma-separated list of snapshot names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+            }
+          }
+        ),
+        "snapshot.verify_repository" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-snapshots.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}/_verify",
+            paths: ["/_snapshot/{repository}/_verify"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "suggest" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-suggesters.html",
+          methods: ["POST", "GET"],
+          body: {"description"=>"The request definition", "required"=>true},
+          url: {
+            path: "/_suggest",
+            paths: ["/_suggest", "/{index}/_suggest"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+            }
+          }
+        ),
+        "tasks.cancel" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/tasks.html#_task_cancellation",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_tasks",
+            paths: ["/_tasks/_cancel", "/_tasks/{task_id}/_cancel"],
+            parts: {
+              "task_id" => {"type"=>"string", "description"=>"Cancel the task with specified id"},
+            },
+            params: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+              "actions" => {"type"=>"list", "description"=>"A comma-separated list of actions that should be cancelled. Leave empty to cancel all."},
+              "parent_node" => {"type"=>"string", "description"=>"Cancel tasks with specified parent node."},
+              "parent_task" => {"type"=>"string", "description"=>"Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all."},
+            }
+          }
+        ),
+        "tasks.list" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/tasks.html#_current_tasks_information",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_tasks",
+            paths: ["/_tasks", "/_tasks/{task_id}"],
+            parts: {
+              "task_id" => {"type"=>"string", "description"=>"Return the task with specified id (node_id:task_number)"},
+            },
+            params: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+              "actions" => {"type"=>"list", "description"=>"A comma-separated list of actions that should be returned. Leave empty to return all."},
+              "detailed" => {"type"=>"boolean", "description"=>"Return detailed task information (default: false)"},
+              "parent_node" => {"type"=>"string", "description"=>"Return tasks with specified parent node."},
+              "parent_task" => {"type"=>"string", "description"=>"Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all."},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Wait for the matching tasks to complete (default: false)"},
+            }
+          }
+        ),
+        "termvectors" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-termvectors.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Define parameters and or supply a document to get termvectors for. See documentation.", "required"=>false},
+          url: {
+            path: "/{index}/{type}/_termvectors",
+            paths: ["/{index}/{type}/_termvectors", "/{index}/{type}/{id}/_termvectors"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The index in which the document resides.", "required"=>true},
+              "type" => {"type"=>"string", "description"=>"The type of the document.", "required"=>true},
+              "id" => {"type"=>"string", "description"=>"The id of the document, when not specified a doc param should be supplied."},
+            },
+            params: {
+              "term_statistics" => {"type"=>"boolean", "description"=>"Specifies if total term frequency and document frequency should be returned.", "default"=>false, "required"=>false},
+              "field_statistics" => {"type"=>"boolean", "description"=>"Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.", "default"=>true, "required"=>false},
+              "dfs" => {"type"=>"boolean", "description"=>"Specifies if distributed frequencies should be returned instead shard frequencies.", "default"=>false, "required"=>false},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return.", "required"=>false},
+              "offsets" => {"type"=>"boolean", "description"=>"Specifies if term offsets should be returned.", "default"=>true, "required"=>false},
+              "positions" => {"type"=>"boolean", "description"=>"Specifies if term positions should be returned.", "default"=>true, "required"=>false},
+              "payloads" => {"type"=>"boolean", "description"=>"Specifies if term payloads should be returned.", "default"=>true, "required"=>false},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random).", "required"=>false},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value.", "required"=>false},
+              "parent" => {"type"=>"string", "description"=>"Parent id of documents.", "required"=>false},
+              "realtime" => {"type"=>"boolean", "description"=>"Specifies if request is real-time as opposed to near-real-time (default: true).", "required"=>false},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "update" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-update.html",
+          methods: ["POST"],
+          body: {"description"=>"The request definition using either `script` or partial `doc`"},
+          url: {
+            path: "/{index}/{type}/{id}/_update",
+            paths: ["/{index}/{type}/{id}/_update"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"Document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Explicit write consistency setting for the operation"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the response"},
+              "lang" => {"type"=>"string", "description"=>"The script language (default: groovy)"},
+              "parent" => {"type"=>"string", "description"=>"ID of the parent document. Is is only used for routing and when for the upsert request"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the index after performing the operation"},
+              "retry_on_conflict" => {"type"=>"number", "description"=>"Specify how many times should the operation be retried when a conflict occurs (default: 0)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "script" => {"type"=>"string", "description"=>"The URL-encoded script definition (instead of using request body)"},
+              "script_id" => {"type"=>"string", "description"=>"The id of a stored script"},
+              "scripted_upsert" => {"type"=>"boolean", "description"=>"True if the script referenced in script or script_id should be called to perform inserts - defaults to false"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "timestamp" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "ttl" => {"type"=>"time", "description"=>"Expiration time for the document"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "update_by_query" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-update-by-query.html",
+          methods: ["POST"],
+          body: {"description"=>"The search definition using the Query DSL"},
+          url: {
+            path: "/{index}/_update_by_query",
+            paths: ["/{index}/_update_by_query", "/{index}/{type}/_update_by_query"],
+            parts: {
+              "index" => {"required"=>true, "type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "explain" => {"type"=>"boolean", "description"=>"Specify whether to return detailed information about score computation as part of a hit"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return as part of a hit"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return as the field data representation of a field for each hit"},
+              "from" => {"type"=>"number", "description"=>"Starting offset (default: 0)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "conflicts" => {"note"=>"This is not copied from search", "type"=>"enum", "options"=>["abort", "proceed"], "default"=>"abort", "description"=>"What to do when the reindex hits version conflicts?"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "lowercase_expanded_terms" => {"type"=>"boolean", "description"=>"Specify whether query terms should be lowercased"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "scroll" => {"type"=>"time", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "dfs_query_then_fetch"], "description"=>"Search operation type"},
+              "search_timeout" => {"type"=>"time", "description"=>"Explicit timeout for each search request. Defaults to no timeout."},
+              "size" => {"type"=>"number", "description"=>"Number of hits to return (default: 10)"},
+              "sort" => {"type"=>"list", "description"=>"A comma-separated list of <field>:<direction> pairs"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "terminate_after" => {"type"=>"number", "description"=>"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."},
+              "stats" => {"type"=>"list", "description"=>"Specific 'tag' of the request for logging and statistical purposes"},
+              "suggest_field" => {"type"=>"string", "description"=>"Specify which field to use for suggestions"},
+              "suggest_mode" => {"type"=>"enum", "options"=>["missing", "popular", "always"], "default"=>"missing", "description"=>"Specify suggest mode"},
+              "suggest_size" => {"type"=>"number", "description"=>"How many suggestions to return in response"},
+              "suggest_text" => {"type"=>"string", "description"=>"The source text for which the suggestions should be returned"},
+              "timeout" => {"type"=>"time", "default"=>"1m", "description"=>"Time each individual bulk request should wait for shards that are unavailable."},
+              "track_scores" => {"type"=>"boolean", "description"=>"Whether to calculate and return scores even if they are not used for sorting"},
+              "version" => {"type"=>"boolean", "description"=>"Specify whether to return document version as part of a hit"},
+              "version_type" => {"type"=>"boolean", "description"=>"Should the document increment the version number (internal) on hit or not (reindex)"},
+              "request_cache" => {"type"=>"boolean", "description"=>"Specify if request cache should be used for this request or not, defaults to index level setting"},
+              "refresh" => {"type"=>"boolean", "description"=>"Should the effected indexes be refreshed?"},
+              "consistency" => {"type"=>"enum", "options"=>["one", "quorum", "all"], "description"=>"Explicit write consistency setting for the operation"},
+              "scroll_size" => {"type"=>"number", "defaut_value"=>100, "description"=>"Size on the scroll request powering the update_by_query"},
+              "wait_for_completion" => {"type"=>"boolean", "default"=>false, "description"=>"Should the request should block until the reindex is complete."},
+              "requests_per_second" => {"type"=>"number", "default"=>0, "description"=>"The throttle for this request in sub-requests per second. 0 means set no throttle."},
+            }
+          }
+        ),
+      }
+      @common_params = {
+      }
+      super
+    end
+  end
+end

--- a/lib/elastomer/client/rest_api_spec/api_spec_v2_4.rb
+++ b/lib/elastomer/client/rest_api_spec/api_spec_v2_4.rb
@@ -2121,6 +2121,7 @@ module Elastomer::Client::RestApiSpec
               "parent_node" => {"type"=>"string", "description"=>"Return tasks with specified parent node."},
               "parent_task" => {"type"=>"string", "description"=>"Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all."},
               "wait_for_completion" => {"type"=>"boolean", "description"=>"Wait for the matching tasks to complete (default: false)"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
             }
           }
         ),

--- a/lib/elastomer/client/rest_api_spec/api_spec_v5_6.rb
+++ b/lib/elastomer/client/rest_api_spec/api_spec_v5_6.rb
@@ -1,0 +1,2489 @@
+# Generated REST API spec file - DO NOT EDIT!
+# Date: 2018-01-10
+# ES version: 5.6
+
+module Elastomer::Client::RestApiSpec
+  class ApiSpecV5_6 < ApiSpec
+    def initialize
+      @rest_apis = {
+        "bulk" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-bulk.html",
+          methods: ["POST", "PUT"],
+          body: {"description"=>"The operation definition and data (action-data pairs), separated by newlines", "required"=>true, "serialize"=>"bulk"},
+          url: {
+            path: "/_bulk",
+            paths: ["/_bulk", "/{index}/_bulk", "/{index}/{type}/_bulk"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"Default index for items which don't provide one"},
+              "type" => {"type"=>"string", "description"=>"Default document type for items which don't provide one"},
+            },
+            params: {
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Sets the number of shard copies that must be active before proceeding with the bulk operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"},
+              "refresh" => {"type"=>"enum", "options"=>["true", "false", "wait_for"], "description"=>"If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "type" => {"type"=>"string", "description"=>"Default document type for items which don't provide one"},
+              "fields" => {"type"=>"list", "description"=>"Default comma-separated list of fields to return in the response for updates, can be overridden on each sub-request"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request"},
+              "_source_exclude" => {"type"=>"list", "description"=>"Default list of fields to exclude from the returned _source field, can be overridden on each sub-request"},
+              "_source_include" => {"type"=>"list", "description"=>"Default list of fields to extract and return from the _source field, can be overridden on each sub-request"},
+              "pipeline" => {"type"=>"string", "description"=>"The pipeline id to preprocess incoming documents with"},
+            }
+          }
+        ),
+        "cat.aliases" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-alias.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/aliases",
+            paths: ["/_cat/aliases", "/_cat/aliases/{name}"],
+            parts: {
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to return"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.allocation" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-allocation.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/allocation",
+            paths: ["/_cat/allocation", "/_cat/allocation/{node_id}"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "kb", "m", "mb", "g", "gb", "t", "tb", "p", "pb"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.count" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-count.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/count",
+            paths: ["/_cat/count", "/_cat/count/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.fielddata" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-fielddata.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/fielddata",
+            paths: ["/_cat/fielddata", "/_cat/fielddata/{fields}"],
+            parts: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return the fielddata size"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "kb", "m", "mb", "g", "gb", "t", "tb", "p", "pb"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the output"},
+            }
+          }
+        ),
+        "cat.health" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-health.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/health",
+            paths: ["/_cat/health"],
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "ts" => {"type"=>"boolean", "description"=>"Set to false to disable timestamping", "default"=>true},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.help" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat",
+            paths: ["/_cat"],
+            params: {
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+            }
+          }
+        ),
+        "cat.indices" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-indices.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/indices",
+            paths: ["/_cat/indices", "/_cat/indices/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "m", "g"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "health" => {"type"=>"enum", "options"=>["green", "yellow", "red"], "default"=>nil, "description"=>"A health status (\"green\", \"yellow\", or \"red\" to filter only indices matching the specified health status"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "pri" => {"type"=>"boolean", "description"=>"Set to true to return stats only for primary shards", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.master" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-master.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/master",
+            paths: ["/_cat/master"],
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.nodeattrs" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-nodeattrs.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/nodeattrs",
+            paths: ["/_cat/nodeattrs"],
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.nodes" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-nodes.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/nodes",
+            paths: ["/_cat/nodes"],
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "full_id" => {"type"=>"boolean", "description"=>"Return the full node ID instead of the shortened version (default: false)"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.pending_tasks" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-pending-tasks.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/pending_tasks",
+            paths: ["/_cat/pending_tasks"],
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.plugins" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-plugins.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/plugins",
+            paths: ["/_cat/plugins"],
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.recovery" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-recovery.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/recovery",
+            paths: ["/_cat/recovery", "/_cat/recovery/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "kb", "m", "mb", "g", "gb", "t", "tb", "p", "pb"]},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.repositories" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-repositories.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/repositories",
+            paths: ["/_cat/repositories"],
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node", "default"=>false},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.segments" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-segments.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/segments",
+            paths: ["/_cat/segments", "/_cat/segments/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "kb", "m", "mb", "g", "gb", "t", "tb", "p", "pb"]},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.shards" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-shards.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/shards",
+            paths: ["/_cat/shards", "/_cat/shards/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to limit the returned information"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "bytes" => {"type"=>"enum", "description"=>"The unit in which to display byte values", "options"=>["b", "k", "kb", "m", "mb", "g", "gb", "t", "tb", "p", "pb"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.snapshots" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/snapshots",
+            paths: ["/_cat/snapshots", "/_cat/snapshots/{repository}"],
+            parts: {
+              "repository" => {"type"=>"list", "required"=>true, "description"=>"Name of repository from which to fetch the snapshot information"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Set to true to ignore unavailable snapshots", "default"=>false},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.tasks" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/tasks.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/tasks",
+            paths: ["/_cat/tasks"],
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+              "actions" => {"type"=>"list", "description"=>"A comma-separated list of actions that should be returned. Leave empty to return all."},
+              "detailed" => {"type"=>"boolean", "description"=>"Return detailed task information (default: false)"},
+              "parent_node" => {"type"=>"string", "description"=>"Return tasks with specified parent node."},
+              "parent_task" => {"type"=>"number", "description"=>"Return tasks with specified parent task id. Set to -1 to return all."},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.templates" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-templates.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/templates",
+            paths: ["/_cat/templates", "/_cat/templates/{name}"],
+            parts: {
+              "name" => {"type"=>"string", "description"=>"A pattern that returned template names must match"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "cat.thread_pool" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cat-thread-pool.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cat/thread_pool",
+            paths: ["/_cat/thread_pool", "/_cat/thread_pool/{thread_pool_patterns}"],
+            parts: {
+              "thread_pool_patterns" => {"type"=>"list", "description"=>"A comma-separated list of regular-expressions to filter the thread pools in the output"},
+            },
+            params: {
+              "format" => {"type"=>"string", "description"=>"a short version of the Accept header, e.g. json, yaml"},
+              "size" => {"type"=>"enum", "description"=>"The multiplier in which to display values", "options"=>["", "k", "m", "g", "t", "p"]},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "h" => {"type"=>"list", "description"=>"Comma-separated list of column names to display"},
+              "help" => {"type"=>"boolean", "description"=>"Return help information", "default"=>false},
+              "s" => {"type"=>"list", "description"=>"Comma-separated list of column names or column aliases to sort by"},
+              "v" => {"type"=>"boolean", "description"=>"Verbose mode. Display column headers", "default"=>false},
+            }
+          }
+        ),
+        "clear_scroll" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-scroll.html",
+          methods: ["DELETE"],
+          body: {"description"=>"A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter"},
+          url: {
+            path: "/_search/scroll/{scroll_id}",
+            paths: ["/_search/scroll/{scroll_id}", "/_search/scroll"],
+            parts: {
+              "scroll_id" => {"type"=>"list", "description"=>"A comma-separated list of scroll IDs to clear"},
+            },
+          }
+        ),
+        "cluster.allocation_explain" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-allocation-explain.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The index, shard, and primary flag to explain. Empty means 'explain the first unassigned shard'"},
+          url: {
+            path: "/_cluster/allocation/explain",
+            paths: ["/_cluster/allocation/explain"],
+            params: {
+              "include_yes_decisions" => {"type"=>"boolean", "description"=>"Return 'YES' decisions in explanation (default: false)"},
+              "include_disk_info" => {"type"=>"boolean", "description"=>"Return information about disk usage and shard sizes (default: false)"},
+            }
+          }
+        ),
+        "cluster.get_settings" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-update-settings.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/settings",
+            paths: ["/_cluster/settings"],
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "include_defaults" => {"type"=>"boolean", "description"=>"Whether to return all default clusters setting.", "default"=>false},
+            }
+          }
+        ),
+        "cluster.health" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-health.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/health",
+            paths: ["/_cluster/health", "/_cluster/health/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"Limit the information returned to a specific index"},
+            },
+            params: {
+              "level" => {"type"=>"enum", "options"=>["cluster", "indices", "shards"], "default"=>"cluster", "description"=>"Specify the level of detail for returned information"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Wait until the specified number of shards is active"},
+              "wait_for_nodes" => {"type"=>"string", "description"=>"Wait until the specified number of nodes is available"},
+              "wait_for_events" => {"type"=>"enum", "options"=>["immediate", "urgent", "high", "normal", "low", "languid"], "description"=>"Wait until all currently queued events with the given priority are processed"},
+              "wait_for_no_relocating_shards" => {"type"=>"boolean", "description"=>"Whether to wait until there are no relocating shards in the cluster"},
+              "wait_for_status" => {"type"=>"enum", "options"=>["green", "yellow", "red"], "default"=>nil, "description"=>"Wait until cluster is in a specific state"},
+            }
+          }
+        ),
+        "cluster.pending_tasks" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-pending.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/pending_tasks",
+            paths: ["/_cluster/pending_tasks"],
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "cluster.put_settings" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-update-settings.html",
+          methods: ["PUT"],
+          body: {"description"=>"The settings to be updated. Can be either `transient` or `persistent` (survives cluster restart)."},
+          url: {
+            path: "/_cluster/settings",
+            paths: ["/_cluster/settings"],
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "cluster.remote_info" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-remote-info.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_remote/info",
+            paths: ["/_remote/info"],
+          }
+        ),
+        "cluster.reroute" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-reroute.html",
+          methods: ["POST"],
+          body: {"description"=>"The definition of `commands` to perform (`move`, `cancel`, `allocate`)"},
+          url: {
+            path: "/_cluster/reroute",
+            paths: ["/_cluster/reroute"],
+            params: {
+              "dry_run" => {"type"=>"boolean", "description"=>"Simulate the operation only and return the resulting state"},
+              "explain" => {"type"=>"boolean", "description"=>"Return an explanation of why the commands can or cannot be executed"},
+              "retry_failed" => {"type"=>"boolean", "description"=>"Retries allocation of shards that are blocked due to too many subsequent allocation failures"},
+              "metric" => {"type"=>"list", "options"=>["_all", "blocks", "metadata", "nodes", "routing_table", "master_node", "version"], "description"=>"Limit the information returned to the specified metrics. Defaults to all but metadata"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "cluster.state" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-state.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/state",
+            paths: ["/_cluster/state", "/_cluster/state/{metric}", "/_cluster/state/{metric}/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+              "metric" => {"type"=>"list", "options"=>["_all", "blocks", "metadata", "nodes", "routing_table", "routing_nodes", "master_node", "version"], "description"=>"Limit the information returned to the specified metrics"},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "cluster.stats" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-stats.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_cluster/stats",
+            paths: ["/_cluster/stats", "/_cluster/stats/nodes/{node_id}"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+            },
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "count" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-count.html",
+          methods: ["POST", "GET"],
+          body: {"description"=>"A query to restrict the results specified with the Query DSL (optional)"},
+          url: {
+            path: "/_count",
+            paths: ["/_count", "/{index}/_count", "/{index}/{type}/_count"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of indices to restrict the results"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of types to restrict the results"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "min_score" => {"type"=>"number", "description"=>"Include only documents with a specific `_score` value in the result"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "terminate_after" => {"type"=>"number", "description"=>"The maximum count for each shard, upon reaching which the query execution will terminate early"},
+            }
+          }
+        ),
+        "count_percolate" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-percolate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The count percolator request definition using the percolate DSL", "required"=>false},
+          url: {
+            path: "/{index}/{type}/_percolate/count",
+            paths: ["/{index}/{type}/_percolate/count", "/{index}/{type}/{id}/_percolate/count"],
+            parts: {
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The index of the document being count percolated."},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document being count percolated."},
+              "id" => {"type"=>"string", "required"=>false, "description"=>"Substitute the document in the request body with a document that is known by the specified id. On top of the id, the index and type parameter will be used to retrieve the document from within the cluster."},
+            },
+            params: {
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "percolate_index" => {"type"=>"string", "description"=>"The index to count percolate the document into. Defaults to index."},
+              "percolate_type" => {"type"=>"string", "description"=>"The type to count percolate document into. Defaults to type."},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "create" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-index_.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The document", "required"=>true},
+          url: {
+            path: "/{index}/{type}/{id}/_create",
+            paths: ["/{index}/{type}/{id}/_create"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"Document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"},
+              "parent" => {"type"=>"string", "description"=>"ID of the parent document"},
+              "refresh" => {"type"=>"enum", "options"=>["true", "false", "wait_for"], "description"=>"If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "timestamp" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "ttl" => {"type"=>"time", "description"=>"Expiration time for the document"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+              "pipeline" => {"type"=>"string", "description"=>"The pipeline id to preprocess incoming documents with"},
+            }
+          }
+        ),
+        "delete" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-delete.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}",
+            paths: ["/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"},
+              "parent" => {"type"=>"string", "description"=>"ID of parent document"},
+              "refresh" => {"type"=>"enum", "options"=>["true", "false", "wait_for"], "description"=>"If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "delete_by_query" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-delete-by-query.html",
+          methods: ["POST"],
+          body: {"description"=>"The search definition using the Query DSL", "required"=>true},
+          url: {
+            path: "/{index}/_delete_by_query",
+            paths: ["/{index}/_delete_by_query", "/{index}/{type}/_delete_by_query"],
+            parts: {
+              "index" => {"required"=>true, "type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "from" => {"type"=>"number", "description"=>"Starting offset (default: 0)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "conflicts" => {"note"=>"This is not copied from search", "type"=>"enum", "options"=>["abort", "proceed"], "default"=>"abort", "description"=>"What to do when the delete-by-query hits version conflicts?"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "scroll" => {"type"=>"time", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "dfs_query_then_fetch"], "description"=>"Search operation type"},
+              "search_timeout" => {"type"=>"time", "description"=>"Explicit timeout for each search request. Defaults to no timeout."},
+              "size" => {"type"=>"number", "description"=>"Number of hits to return (default: 10)"},
+              "sort" => {"type"=>"list", "description"=>"A comma-separated list of <field>:<direction> pairs"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "terminate_after" => {"type"=>"number", "description"=>"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."},
+              "stats" => {"type"=>"list", "description"=>"Specific 'tag' of the request for logging and statistical purposes"},
+              "version" => {"type"=>"boolean", "description"=>"Specify whether to return document version as part of a hit"},
+              "request_cache" => {"type"=>"boolean", "description"=>"Specify if request cache should be used for this request or not, defaults to index level setting"},
+              "refresh" => {"type"=>"boolean", "description"=>"Should the effected indexes be refreshed?"},
+              "timeout" => {"type"=>"time", "default"=>"1m", "description"=>"Time each individual bulk request should wait for shards that are unavailable."},
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"},
+              "scroll_size" => {"type"=>"number", "defaut_value"=>100, "description"=>"Size on the scroll request powering the update_by_query"},
+              "wait_for_completion" => {"type"=>"boolean", "default"=>true, "description"=>"Should the request should block until the delete-by-query is complete."},
+              "requests_per_second" => {"type"=>"number", "default"=>0, "description"=>"The throttle for this request in sub-requests per second. -1 means no throttle."},
+              "slices" => {"type"=>"number", "default"=>1, "description"=>"The number of slices this task should be divided into. Defaults to 1 meaning the task isn't sliced into subtasks."},
+            }
+          }
+        ),
+        "delete_script" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-scripting.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_scripts/{lang}",
+            paths: ["/_scripts/{lang}", "/_scripts/{lang}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Script ID", "required"=>true},
+              "lang" => {"type"=>"string", "description"=>"Script language", "required"=>true},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "delete_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-template.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_search/template/{id}",
+            paths: ["/_search/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Template ID", "required"=>true},
+            },
+          }
+        ),
+        "exists" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-get.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}",
+            paths: ["/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document (use `_all` to fetch the first document matching the ID across all types)"},
+            },
+            params: {
+              "stored_fields" => {"type"=>"list", "description"=>"A comma-separated list of stored fields to return in the response"},
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "exists_source" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}/_source",
+            paths: ["/{index}/{type}/{id}/_source"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document; use `_all` to fetch the first document matching the ID across all types"},
+            },
+            params: {
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "explain" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-explain.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The query definition using the Query DSL"},
+          url: {
+            path: "/{index}/{type}/{id}/_explain",
+            paths: ["/{index}/{type}/{id}/_explain"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcards and prefix queries in the query string query should be analyzed (default: false)"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer for the query string query"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The default field for query string query (default: _all)"},
+              "stored_fields" => {"type"=>"list", "description"=>"A comma-separated list of stored fields to return in the response"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+            }
+          }
+        ),
+        "field_caps" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-field-caps.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Field json objects containing an array of field names", "required"=>false},
+          url: {
+            path: "/_field_caps",
+            paths: ["/_field_caps", "/{index}/_field_caps"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of field names"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "field_stats" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-field-stats.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Field json objects containing the name and optionally a range to filter out indices result, that have results outside the defined bounds", "required"=>false},
+          url: {
+            path: "/_field_stats",
+            paths: ["/_field_stats", "/{index}/_field_stats"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for to get field statistics for (min value, max value, and more)"},
+              "level" => {"type"=>"enum", "options"=>["indices", "cluster"], "default"=>"cluster", "description"=>"Defines if field stats should be returned on a per index level or on a cluster wide level"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "get" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-get.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}",
+            paths: ["/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document (use `_all` to fetch the first document matching the ID across all types)"},
+            },
+            params: {
+              "stored_fields" => {"type"=>"list", "description"=>"A comma-separated list of stored fields to return in the response"},
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "get_script" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-scripting.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_scripts/{lang}",
+            paths: ["/_scripts/{lang}", "/_scripts/{lang}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Script ID", "required"=>true},
+              "lang" => {"type"=>"string", "description"=>"Script language", "required"=>true},
+            },
+          }
+        ),
+        "get_source" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-get.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/{id}/_source",
+            paths: ["/{index}/{type}/{id}/_source"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"The document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document; use `_all` to fetch the first document matching the ID across all types"},
+            },
+            params: {
+              "parent" => {"type"=>"string", "description"=>"The ID of the parent document"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "get_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-template.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_search/template/{id}",
+            paths: ["/_search/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Template ID", "required"=>true},
+            },
+          }
+        ),
+        "index" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-index_.html",
+          methods: ["POST", "PUT"],
+          body: {"description"=>"The document", "required"=>true},
+          url: {
+            path: "/{index}/{type}",
+            paths: ["/{index}/{type}", "/{index}/{type}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"},
+              "op_type" => {"type"=>"enum", "options"=>["index", "create"], "default"=>"index", "description"=>"Explicit operation type"},
+              "parent" => {"type"=>"string", "description"=>"ID of the parent document"},
+              "refresh" => {"type"=>"enum", "options"=>["true", "false", "wait_for"], "description"=>"If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "timestamp" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "ttl" => {"type"=>"time", "description"=>"Expiration time for the document"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+              "pipeline" => {"type"=>"string", "description"=>"The pipeline id to preprocess incoming documents with"},
+            }
+          }
+        ),
+        "indices.analyze" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-analyze.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The text on which the analysis should be performed"},
+          url: {
+            path: "/_analyze",
+            paths: ["/_analyze", "/{index}/_analyze"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The name of the index to scope the operation"},
+            },
+            params: {
+              "analyzer" => {"type"=>"string", "description"=>"The name of the analyzer to use"},
+              "char_filter" => {"type"=>"list", "description"=>"A comma-separated list of character filters to use for the analysis"},
+              "field" => {"type"=>"string", "description"=>"Use the analyzer configured for this field (instead of passing the analyzer name)"},
+              "filter" => {"type"=>"list", "description"=>"A comma-separated list of filters to use for the analysis"},
+              "index" => {"type"=>"string", "description"=>"The name of the index to scope the operation"},
+              "prefer_local" => {"type"=>"boolean", "description"=>"With `true`, specify that a local shard should be used if available, with `false`, use a random shard (default: true)"},
+              "text" => {"type"=>"list", "description"=>"The text on which the analysis should be performed (when request body is not used)"},
+              "tokenizer" => {"type"=>"string", "description"=>"The name of the tokenizer to use for the analysis"},
+              "explain" => {"type"=>"boolean", "description"=>"With `true`, outputs more advanced details. (default: false)"},
+              "attributes" => {"type"=>"list", "description"=>"A comma-separated list of token attributes to output, this parameter works only with `explain=true`"},
+              "format" => {"type"=>"enum", "options"=>["detailed", "text"], "default"=>"detailed", "description"=>"Format of the output"},
+            }
+          }
+        ),
+        "indices.clear_cache" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-clearcache.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_cache/clear",
+            paths: ["/_cache/clear", "/{index}/_cache/clear"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index name to limit the operation"},
+            },
+            params: {
+              "field_data" => {"type"=>"boolean", "description"=>"Clear field data"},
+              "fielddata" => {"type"=>"boolean", "description"=>"Clear field data"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to clear when using the `field_data` parameter (default: all)"},
+              "query" => {"type"=>"boolean", "description"=>"Clear query caches"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index name to limit the operation"},
+              "recycler" => {"type"=>"boolean", "description"=>"Clear the recycler cache"},
+              "request_cache" => {"type"=>"boolean", "description"=>"Clear request cache"},
+              "request" => {"type"=>"boolean", "description"=>"Clear request cache"},
+            }
+          }
+        ),
+        "indices.close" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-open-close.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/{index}/_close",
+            paths: ["/{index}/_close"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma separated list of indices to close"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.create" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-create-index.html",
+          methods: ["PUT"],
+          body: {"description"=>"The configuration for the index (`settings` and `mappings`)"},
+          url: {
+            path: "/{index}",
+            paths: ["/{index}"],
+            parts: {
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+            },
+            params: {
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Set the number of active shards to wait for before the operation returns."},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "update_all_types" => {"type"=>"boolean", "description"=>"Whether to update the mapping for all fields with the same name across all types or not"},
+            }
+          }
+        ),
+        "indices.delete" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-delete-index.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}",
+            paths: ["/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.delete_alias" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-aliases.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/{index}/_alias/{name}",
+            paths: ["/{index}/_alias/{name}", "/{index}/_aliases/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names (supports wildcards); use `_all` for all indices"},
+              "name" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices."},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.delete_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-templates.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the template"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.exists" => RestApi.new(
+          documentation: "http://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-exists.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/{index}",
+            paths: ["/{index}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names"},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Ignore unavailable indexes (default: false)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Ignore if a wildcard expression resolves to no concrete indices (default: false)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether wildcard expressions should get expanded to open or closed indices (default: open)"},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "include_defaults" => {"type"=>"boolean", "description"=>"Whether to return all default setting for each of the indices.", "default"=>false},
+            }
+          }
+        ),
+        "indices.exists_alias" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-aliases.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/_alias/{name}",
+            paths: ["/_alias/{name}", "/{index}/_alias/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to filter aliases"},
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to return"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"all", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.exists_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-templates.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"list", "required"=>true, "description"=>"The comma separated names of the index templates"},
+            },
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.exists_type" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-types-exists.html",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/{index}/_mapping/{type}",
+            paths: ["/{index}/_mapping/{type}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names; use `_all` to check the types across all indices"},
+              "type" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of document types to check"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.flush" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-flush.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_flush",
+            paths: ["/_flush", "/{index}/_flush"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string for all indices"},
+            },
+            params: {
+              "force" => {"type"=>"boolean", "description"=>"Whether a flush should be forced even if it is not necessarily needed ie. if no changes will be committed to the index. This is useful if transaction log IDs should be incremented even if no uncommitted changes are present. (This setting can be considered as internal)"},
+              "wait_if_ongoing" => {"type"=>"boolean", "description"=>"If set to true the flush operation will block until the flush can be executed if another flush operation is already executing. The default is true. If set to false the flush will be skipped iff if another flush operation is already running."},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.flush_synced" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-synced-flush.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_flush/synced",
+            paths: ["/_flush/synced", "/{index}/_flush/synced"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string for all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.forcemerge" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-forcemerge.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_forcemerge",
+            paths: ["/_forcemerge", "/{index}/_forcemerge"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "flush" => {"type"=>"boolean", "description"=>"Specify whether the index should be flushed after performing the operation (default: true)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "max_num_segments" => {"type"=>"number", "description"=>"The number of segments the index should be merged into (default: dynamic)"},
+              "only_expunge_deletes" => {"type"=>"boolean", "description"=>"Specify whether the operation should only expunge deleted documents"},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "wait_for_merge" => {"type"=>"boolean", "description"=>"Specify whether the request should block until the merge process is finished (default: true)"},
+            }
+          }
+        ),
+        "indices.get" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-get-index.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/{index}",
+            paths: ["/{index}", "/{index}/{feature}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names"},
+              "feature" => {"type"=>"list", "description"=>"A comma-separated list of features", "options"=>["_settings", "_mappings", "_aliases"]},
+            },
+            params: {
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Ignore unavailable indexes (default: false)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Ignore if a wildcard expression resolves to no concrete indices (default: false)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether wildcard expressions should get expanded to open or closed indices (default: open)"},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "include_defaults" => {"type"=>"boolean", "description"=>"Whether to return all default setting for each of the indices.", "default"=>false},
+            }
+          }
+        ),
+        "indices.get_alias" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-aliases.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_alias/",
+            paths: ["/_alias", "/_alias/{name}", "/{index}/_alias/{name}", "/{index}/_alias"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to filter aliases"},
+              "name" => {"type"=>"list", "description"=>"A comma-separated list of alias names to return"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"all", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_field_mapping" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-get-field-mapping.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_mapping/field/{fields}",
+            paths: ["/_mapping/field/{fields}", "/{index}/_mapping/field/{fields}", "/_mapping/{type}/field/{fields}", "/{index}/_mapping/{type}/field/{fields}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields", "required"=>true},
+            },
+            params: {
+              "include_defaults" => {"type"=>"boolean", "description"=>"Whether the default mapping values should be returned as well"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_mapping" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-get-mapping.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_mapping",
+            paths: ["/_mapping", "/{index}/_mapping", "/_mapping/{type}", "/{index}/_mapping/{type}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_settings" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-get-settings.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_settings",
+            paths: ["/_settings", "/{index}/_settings", "/{index}/_settings/{name}", "/_settings/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+              "name" => {"type"=>"list", "description"=>"The name of the settings that should be included"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>["open", "closed"], "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "include_defaults" => {"type"=>"boolean", "description"=>"Whether to return all default setting for each of the indices.", "default"=>false},
+            }
+          }
+        ),
+        "indices.get_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-templates.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template", "/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"list", "required"=>false, "description"=>"The comma separated names of the index templates"},
+            },
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "indices.get_upgrade" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-upgrade.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_upgrade",
+            paths: ["/_upgrade", "/{index}/_upgrade"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.open" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-open-close.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/{index}/_open",
+            paths: ["/{index}/_open"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma separated list of indices to open"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"closed", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.put_alias" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-aliases.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The settings for the alias, such as `routing` or `filter`", "required"=>false},
+          url: {
+            path: "/{index}/_alias/{name}",
+            paths: ["/{index}/_alias/{name}", "/{index}/_aliases/{name}"],
+            parts: {
+              "index" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices."},
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the alias to be created or updated"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.put_mapping" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-put-mapping.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The mapping definition", "required"=>true},
+          url: {
+            path: "/{index}/{type}/_mapping",
+            paths: ["/{index}/{type}/_mapping", "/{index}/_mapping/{type}", "/_mapping/{type}", "/{index}/{type}/_mappings", "/{index}/_mappings/{type}", "/_mappings/{type}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices."},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The name of the document type"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "update_all_types" => {"type"=>"boolean", "description"=>"Whether to update the mapping for all fields with the same name across all types or not"},
+            }
+          }
+        ),
+        "indices.put_settings" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-update-settings.html",
+          methods: ["PUT"],
+          body: {"description"=>"The index settings to be updated", "required"=>true},
+          url: {
+            path: "/_settings",
+            paths: ["/_settings", "/{index}/_settings"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "preserve_existing" => {"type"=>"boolean", "description"=>"Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+            }
+          }
+        ),
+        "indices.put_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-templates.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The template definition", "required"=>true},
+          url: {
+            path: "/_template/{name}",
+            paths: ["/_template/{name}"],
+            parts: {
+              "name" => {"type"=>"string", "required"=>true, "description"=>"The name of the template"},
+            },
+            params: {
+              "order" => {"type"=>"number", "description"=>"The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"},
+              "create" => {"type"=>"boolean", "description"=>"Whether the index template should only be added if new or can also replace an existing one", "default"=>false},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+            }
+          }
+        ),
+        "indices.recovery" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-recovery.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_recovery",
+            paths: ["/_recovery", "/{index}/_recovery"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "detailed" => {"type"=>"boolean", "description"=>"Whether to display detailed information about shard recovery", "default"=>false},
+              "active_only" => {"type"=>"boolean", "description"=>"Display only those recoveries that are currently on-going", "default"=>false},
+            }
+          }
+        ),
+        "indices.refresh" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-refresh.html",
+          methods: ["POST", "GET"],
+          body: nil,
+          url: {
+            path: "/_refresh",
+            paths: ["/_refresh", "/{index}/_refresh"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "indices.rollover" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-rollover-index.html",
+          methods: ["POST"],
+          body: {"description"=>"The conditions that needs to be met for executing rollover"},
+          url: {
+            path: "/{alias}/_rollover",
+            paths: ["/{alias}/_rollover", "/{alias}/_rollover/{new_index}"],
+            parts: {
+              "alias" => {"type"=>"string", "required"=>true, "description"=>"The name of the alias to rollover"},
+              "new_index" => {"type"=>"string", "required"=>false, "description"=>"The name of the rollover index"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "dry_run" => {"type"=>"boolean", "description"=>"If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Set the number of active shards to wait for on the newly created rollover index before the operation returns."},
+            }
+          }
+        ),
+        "indices.segments" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-segments.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_segments",
+            paths: ["/_segments", "/{index}/_segments"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "verbose" => {"type"=>"boolean", "description"=>"Includes detailed memory usage by Lucene.", "default"=>false},
+            }
+          }
+        ),
+        "indices.shard_stores" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-shards-stores.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_shard_stores",
+            paths: ["/_shard_stores", "/{index}/_shard_stores"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "status" => {"type"=>"list", "options"=>["green", "yellow", "red", "all"], "description"=>"A comma-separated list of statuses used to filter on shards to get store information for"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "operation_threading" => {"description"=>"TODO: ?"},
+            }
+          }
+        ),
+        "indices.shrink" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-shrink-index.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The configuration for the target index (`settings` and `aliases`)"},
+          url: {
+            path: "/{index}/_shrink/{target}",
+            paths: ["/{index}/_shrink/{target}"],
+            parts: {
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the source index to shrink"},
+              "target" => {"type"=>"string", "required"=>true, "description"=>"The name of the target index to shrink into"},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Set the number of active shards to wait for on the shrunken index before the operation returns."},
+            }
+          }
+        ),
+        "indices.stats" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-stats.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_stats",
+            paths: ["/_stats", "/_stats/{metric}", "/{index}/_stats", "/{index}/_stats/{metric}"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+              "metric" => {"type"=>"list", "options"=>["_all", "completion", "docs", "fielddata", "query_cache", "flush", "get", "indexing", "merge", "percolate", "request_cache", "refresh", "search", "segments", "store", "warmer", "suggest"], "description"=>"Limit the information returned the specific metrics."},
+            },
+            params: {
+              "completion_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` index metric (supports wildcards)"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)"},
+              "groups" => {"type"=>"list", "description"=>"A comma-separated list of search groups for `search` index metric"},
+              "level" => {"type"=>"enum", "description"=>"Return stats aggregated at cluster, index or shard level", "options"=>["cluster", "indices", "shards"], "default"=>"indices"},
+              "types" => {"type"=>"list", "description"=>"A comma-separated list of document types for the `indexing` index metric"},
+              "include_segment_file_sizes" => {"type"=>"boolean", "description"=>"Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)", "default"=>false},
+            }
+          }
+        ),
+        "indices.update_aliases" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-aliases.html",
+          methods: ["POST"],
+          body: {"description"=>"The definition of `actions` to perform", "required"=>true},
+          url: {
+            path: "/_aliases",
+            paths: ["/_aliases"],
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Request timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "indices.upgrade" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/indices-upgrade.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_upgrade",
+            paths: ["/_upgrade", "/{index}/_upgrade"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Specify whether the request should block until the all segments are upgraded (default: false)"},
+              "only_ancient_segments" => {"type"=>"boolean", "description"=>"If true, only ancient (an older Lucene major release) segments will be upgraded"},
+            }
+          }
+        ),
+        "indices.validate_query" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-validate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The query definition specified with the Query DSL"},
+          url: {
+            path: "/_validate/query",
+            paths: ["/_validate/query", "/{index}/_validate/query", "/{index}/{type}/_validate/query"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "explain" => {"type"=>"boolean", "description"=>"Return detailed information about the error"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "operation_threading" => {"description"=>"TODO: ?"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "rewrite" => {"type"=>"boolean", "description"=>"Provide a more detailed explanation showing the actual Lucene query that will be executed."},
+              "all_shards" => {"type"=>"boolean", "description"=>"Execute validation on all shards instead of one random shard per index"},
+            }
+          }
+        ),
+        "info" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/",
+            paths: ["/"],
+          }
+        ),
+        "ingest.delete_pipeline" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/plugins/5.x/ingest.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_ingest/pipeline/{id}",
+            paths: ["/_ingest/pipeline/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Pipeline ID", "required"=>true},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "ingest.get_pipeline" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/plugins/5.x/ingest.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_ingest/pipeline/{id}",
+            paths: ["/_ingest/pipeline", "/_ingest/pipeline/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Comma separated list of pipeline ids. Wildcards supported"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+            }
+          }
+        ),
+        "ingest.processor_grok" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/plugins/master/ingest.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_ingest/processor/grok",
+            paths: ["/_ingest/processor/grok"],
+          }
+        ),
+        "ingest.put_pipeline" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/plugins/5.x/ingest.html",
+          methods: ["PUT"],
+          body: {"description"=>"The ingest definition", "required"=>true},
+          url: {
+            path: "/_ingest/pipeline/{id}",
+            paths: ["/_ingest/pipeline/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Pipeline ID", "required"=>true},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "ingest.simulate" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/plugins/5.x/ingest.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The simulate definition", "required"=>true},
+          url: {
+            path: "/_ingest/pipeline/_simulate",
+            paths: ["/_ingest/pipeline/_simulate", "/_ingest/pipeline/{id}/_simulate"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Pipeline ID", "required"=>false},
+            },
+            params: {
+              "verbose" => {"type"=>"boolean", "description"=>"Verbose mode. Display data output for each processor in executed pipeline", "default"=>false},
+            }
+          }
+        ),
+        "mget" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-multi-get.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Document identifiers; can be either `docs` (containing full document information) or `ids` (when index and type is provided in the URL.", "required"=>true},
+          url: {
+            path: "/_mget",
+            paths: ["/_mget", "/{index}/_mget", "/{index}/{type}/_mget"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "description"=>"The type of the document"},
+            },
+            params: {
+              "stored_fields" => {"type"=>"list", "description"=>"A comma-separated list of stored fields to return in the response"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "realtime" => {"type"=>"boolean", "description"=>"Specify whether to perform the operation in realtime or search mode"},
+              "refresh" => {"type"=>"boolean", "description"=>"Refresh the shard containing the document before performing the operation"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+            }
+          }
+        ),
+        "mpercolate" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-percolate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The percolate request definitions (header & body pair), separated by newlines", "required"=>true, "serialize"=>"bulk"},
+          url: {
+            path: "/_mpercolate",
+            paths: ["/_mpercolate", "/{index}/_mpercolate", "/{index}/{type}/_mpercolate"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The index of the document being count percolated to use as default"},
+              "type" => {"type"=>"string", "description"=>"The type of the document being percolated to use as default."},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "msearch" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-multi-search.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The request definitions (metadata-search request definition pairs), separated by newlines", "required"=>true, "serialize"=>"bulk"},
+          url: {
+            path: "/_msearch",
+            paths: ["/_msearch", "/{index}/_msearch", "/{index}/{type}/_msearch"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to use as default"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to use as default"},
+            },
+            params: {
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch"], "description"=>"Search operation type"},
+              "max_concurrent_searches" => {"type"=>"number", "description"=>"Controls the maximum number of concurrent searches the multi search api will execute"},
+              "typed_keys" => {"type"=>"boolean", "description"=>"Specify whether aggregation and suggester names should be prefixed by their respective types in the response"},
+              "pre_filter_shard_size" => {"type"=>"number", "description"=>"A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on it's rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.", "default"=>128},
+            }
+          }
+        ),
+        "msearch_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The request definitions (metadata-search request definition pairs), separated by newlines", "required"=>true, "serialize"=>"bulk"},
+          url: {
+            path: "/_msearch/template",
+            paths: ["/_msearch/template", "/{index}/_msearch/template", "/{index}/{type}/_msearch/template"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to use as default"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to use as default"},
+            },
+            params: {
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch"], "description"=>"Search operation type"},
+              "typed_keys" => {"type"=>"boolean", "description"=>"Specify whether aggregation and suggester names should be prefixed by their respective types in the response"},
+              "max_concurrent_searches" => {"type"=>"number", "description"=>"Controls the maximum number of concurrent searches the multi search api will execute"},
+            }
+          }
+        ),
+        "mtermvectors" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-multi-termvectors.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.", "required"=>false},
+          url: {
+            path: "/_mtermvectors",
+            paths: ["/_mtermvectors", "/{index}/_mtermvectors", "/{index}/{type}/_mtermvectors"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The index in which the document resides."},
+              "type" => {"type"=>"string", "description"=>"The type of the document."},
+            },
+            params: {
+              "ids" => {"type"=>"list", "description"=>"A comma-separated list of documents ids. You must define ids as parameter or set \"ids\" or \"docs\" in the request body", "required"=>false},
+              "term_statistics" => {"type"=>"boolean", "description"=>"Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>false, "required"=>false},
+              "field_statistics" => {"type"=>"boolean", "description"=>"Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "offsets" => {"type"=>"boolean", "description"=>"Specifies if term offsets should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "positions" => {"type"=>"boolean", "description"=>"Specifies if term positions should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "payloads" => {"type"=>"boolean", "description"=>"Specifies if term payloads should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "default"=>true, "required"=>false},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random) .Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "parent" => {"type"=>"string", "description"=>"Parent id of documents. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".", "required"=>false},
+              "realtime" => {"type"=>"boolean", "description"=>"Specifies if requests are real-time as opposed to near-real-time (default: true).", "required"=>false},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "nodes.hot_threads" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-nodes-hot-threads.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_nodes/hot_threads",
+            paths: ["/_cluster/nodes/hotthreads", "/_cluster/nodes/hot_threads", "/_cluster/nodes/{node_id}/hotthreads", "/_cluster/nodes/{node_id}/hot_threads", "/_nodes/hotthreads", "/_nodes/hot_threads", "/_nodes/{node_id}/hotthreads", "/_nodes/{node_id}/hot_threads"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+            },
+            params: {
+              "interval" => {"type"=>"time", "description"=>"The interval for the second sampling of threads"},
+              "snapshots" => {"type"=>"number", "description"=>"Number of samples of thread stacktrace (default: 10)"},
+              "threads" => {"type"=>"number", "description"=>"Specify the number of threads to provide information for (default: 3)"},
+              "ignore_idle_threads" => {"type"=>"boolean", "description"=>"Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue (default: true)"},
+              "type" => {"type"=>"enum", "options"=>["cpu", "wait", "block"], "description"=>"The type to sample (default: cpu)"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "nodes.info" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-nodes-info.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_nodes",
+            paths: ["/_nodes", "/_nodes/{node_id}", "/_nodes/{metric}", "/_nodes/{node_id}/{metric}"],
+            parts: {
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+              "metric" => {"type"=>"list", "options"=>["settings", "os", "process", "jvm", "thread_pool", "transport", "http", "plugins", "ingest"], "description"=>"A comma-separated list of metrics you wish returned. Leave empty to return all."},
+            },
+            params: {
+              "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "nodes.stats" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-nodes-stats.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_nodes/stats",
+            paths: ["/_nodes/stats", "/_nodes/{node_id}/stats", "/_nodes/stats/{metric}", "/_nodes/{node_id}/stats/{metric}", "/_nodes/stats/{metric}/{index_metric}", "/_nodes/{node_id}/stats/{metric}/{index_metric}"],
+            parts: {
+              "metric" => {"type"=>"list", "options"=>["_all", "breaker", "fs", "http", "indices", "jvm", "os", "process", "thread_pool", "transport", "discovery"], "description"=>"Limit the information returned to the specified metrics"},
+              "index_metric" => {"type"=>"list", "options"=>["_all", "completion", "docs", "fielddata", "query_cache", "flush", "get", "indexing", "merge", "percolate", "request_cache", "refresh", "search", "segments", "store", "warmer", "suggest"], "description"=>"Limit the information returned for `indices` metric to the specific index metrics. Isn't used if `indices` (or `all`) metric isn't specified."},
+              "node_id" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+            },
+            params: {
+              "completion_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` index metric (supports wildcards)"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)"},
+              "groups" => {"type"=>"boolean", "description"=>"A comma-separated list of search groups for `search` index metric"},
+              "level" => {"type"=>"enum", "description"=>"Return indices stats aggregated at index, node or shard level", "options"=>["indices", "node", "shards"], "default"=>"node"},
+              "types" => {"type"=>"list", "description"=>"A comma-separated list of document types for the `indexing` index metric"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "include_segment_file_sizes" => {"type"=>"boolean", "description"=>"Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)", "default"=>false},
+            }
+          }
+        ),
+        "percolate" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-percolate.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The percolator request definition using the percolate DSL", "required"=>false},
+          url: {
+            path: "/{index}/{type}/_percolate",
+            paths: ["/{index}/{type}/_percolate", "/{index}/{type}/{id}/_percolate"],
+            parts: {
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The index of the document being percolated."},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document being percolated."},
+              "id" => {"type"=>"string", "required"=>false, "description"=>"Substitute the document in the request body with a document that is known by the specified id. On top of the id, the index and type parameter will be used to retrieve the document from within the cluster."},
+            },
+            params: {
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "percolate_index" => {"type"=>"string", "description"=>"The index to percolate the document into. Defaults to index."},
+              "percolate_type" => {"type"=>"string", "description"=>"The type to percolate document into. Defaults to type."},
+              "percolate_routing" => {"type"=>"string", "description"=>"The routing value to use when percolating the existing document."},
+              "percolate_preference" => {"type"=>"string", "description"=>"Which shard to prefer when executing the percolate request."},
+              "percolate_format" => {"type"=>"enum", "options"=>["ids"], "description"=>"Return an array of matching query IDs instead of objects"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "ping" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/",
+          methods: ["HEAD"],
+          body: nil,
+          url: {
+            path: "/",
+            paths: ["/"],
+          }
+        ),
+        "put_script" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-scripting.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The document", "required"=>true},
+          url: {
+            path: "/_scripts/{lang}",
+            paths: ["/_scripts/{lang}", "/_scripts/{lang}/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Script ID", "required"=>true},
+              "lang" => {"type"=>"string", "description"=>"Script language", "required"=>true},
+            },
+            params: {
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            }
+          }
+        ),
+        "put_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-template.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The document", "required"=>true},
+          url: {
+            path: "/_search/template/{id}",
+            paths: ["/_search/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"Template ID", "required"=>true},
+            },
+          }
+        ),
+        "reindex" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-reindex.html",
+          methods: ["POST"],
+          body: {"description"=>"The search definition using the Query DSL and the prototype for the index request.", "required"=>true},
+          url: {
+            path: "/_reindex",
+            paths: ["/_reindex"],
+            params: {
+              "refresh" => {"type"=>"boolean", "description"=>"Should the effected indexes be refreshed?"},
+              "timeout" => {"type"=>"time", "default"=>"1m", "description"=>"Time each individual bulk request should wait for shards that are unavailable."},
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Sets the number of shard copies that must be active before proceeding with the reindex operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"},
+              "wait_for_completion" => {"type"=>"boolean", "default"=>true, "description"=>"Should the request should block until the reindex is complete."},
+              "requests_per_second" => {"type"=>"number", "default"=>0, "description"=>"The throttle to set on this request in sub-requests per second. -1 means no throttle."},
+              "slices" => {"type"=>"number", "default"=>1, "description"=>"The number of slices this task should be divided into. Defaults to 1 meaning the task isn't sliced into subtasks."},
+            }
+          }
+        ),
+        "reindex_rethrottle" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-reindex.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_reindex/{task_id}/_rethrottle",
+            paths: ["/_reindex/{task_id}/_rethrottle", "/_update_by_query/{task_id}/_rethrottle", "/_delete_by_query/{task_id}/_rethrottle"],
+            parts: {
+              "task_id" => {"type"=>"string", "description"=>"The task id to rethrottle"},
+            },
+            params: {
+              "requests_per_second" => {"type"=>"number", "required"=>true, "description"=>"The throttle to set on this request in floating sub-requests per second. -1 means set no throttle."},
+            }
+          }
+        ),
+        "render_search_template" => RestApi.new(
+          documentation: "http://www.elasticsearch.org/guide/en/elasticsearch/reference/5.x/search-template.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The search definition template and its params"},
+          url: {
+            path: "/_render/template",
+            paths: ["/_render/template", "/_render/template/{id}"],
+            parts: {
+              "id" => {"type"=>"string", "description"=>"The id of the stored search template"},
+            },
+          }
+        ),
+        "scroll" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-scroll.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The scroll ID if not passed by URL or query parameter."},
+          url: {
+            path: "/_search/scroll",
+            paths: ["/_search/scroll", "/_search/scroll/{scroll_id}"],
+            parts: {
+              "scroll_id" => {"type"=>"string", "description"=>"The scroll ID"},
+            },
+            params: {
+              "scroll" => {"type"=>"time", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "scroll_id" => {"type"=>"string", "description"=>"The scroll ID for scrolled search"},
+            }
+          }
+        ),
+        "search" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-search.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The search definition using the Query DSL"},
+          url: {
+            path: "/_search",
+            paths: ["/_search", "/{index}/_search", "/{index}/{type}/_search"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "explain" => {"type"=>"boolean", "description"=>"Specify whether to return detailed information about score computation as part of a hit"},
+              "stored_fields" => {"type"=>"list", "description"=>"A comma-separated list of stored fields to return as part of a hit"},
+              "docvalue_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return as the docvalue representation of a field for each hit"},
+              "fielddata_fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return as the docvalue representation of a field for each hit"},
+              "from" => {"type"=>"number", "description"=>"Starting offset (default: 0)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "scroll" => {"type"=>"time", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "dfs_query_then_fetch"], "description"=>"Search operation type"},
+              "size" => {"type"=>"number", "description"=>"Number of hits to return (default: 10)"},
+              "sort" => {"type"=>"list", "description"=>"A comma-separated list of <field>:<direction> pairs"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "terminate_after" => {"type"=>"number", "description"=>"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."},
+              "stats" => {"type"=>"list", "description"=>"Specific 'tag' of the request for logging and statistical purposes"},
+              "suggest_field" => {"type"=>"string", "description"=>"Specify which field to use for suggestions"},
+              "suggest_mode" => {"type"=>"enum", "options"=>["missing", "popular", "always"], "default"=>"missing", "description"=>"Specify suggest mode"},
+              "suggest_size" => {"type"=>"number", "description"=>"How many suggestions to return in response"},
+              "suggest_text" => {"type"=>"string", "description"=>"The source text for which the suggestions should be returned"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "track_scores" => {"type"=>"boolean", "description"=>"Whether to calculate and return scores even if they are not used for sorting"},
+              "typed_keys" => {"type"=>"boolean", "description"=>"Specify whether aggregation and suggester names should be prefixed by their respective types in the response"},
+              "version" => {"type"=>"boolean", "description"=>"Specify whether to return document version as part of a hit"},
+              "request_cache" => {"type"=>"boolean", "description"=>"Specify if request cache should be used for this request or not, defaults to index level setting"},
+              "batched_reduce_size" => {"type"=>"number", "description"=>"The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.", "default"=>512},
+              "max_concurrent_shard_requests" => {"type"=>"number", "description"=>"The number of concurrent shard requests this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests", "default"=>"The default grows with the number of nodes in the cluster but is at most 256."},
+              "pre_filter_shard_size" => {"type"=>"number", "description"=>"A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on it's rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.", "default"=>128},
+            }
+          }
+        ),
+        "search_shards" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-shards.html",
+          methods: ["GET", "POST"],
+          body: nil,
+          url: {
+            path: "/{index}/{type}/_search_shards",
+            paths: ["/_search_shards", "/{index}/_search_shards", "/{index}/{type}/_search_shards"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+            }
+          }
+        ),
+        "search_template" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"The search definition template and its params"},
+          url: {
+            path: "/_search/template",
+            paths: ["/_search/template", "/{index}/_search/template", "/{index}/{type}/_search/template"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "scroll" => {"type"=>"time", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "query_and_fetch", "dfs_query_then_fetch", "dfs_query_and_fetch"], "description"=>"Search operation type"},
+              "explain" => {"type"=>"boolean", "description"=>"Specify whether to return detailed information about score computation as part of a hit"},
+              "profile" => {"type"=>"boolean", "description"=>"Specify whether to profile the query execution"},
+              "typed_keys" => {"type"=>"boolean", "description"=>"Specify whether aggregation and suggester names should be prefixed by their respective types in the response"},
+            }
+          }
+        ),
+        "snapshot.create" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The snapshot definition", "required"=>false},
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}",
+            paths: ["/_snapshot/{repository}/{snapshot}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"string", "required"=>true, "description"=>"A snapshot name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Should this request wait until the operation has completed before returning", "default"=>false},
+            }
+          }
+        ),
+        "snapshot.create_repository" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html",
+          methods: ["PUT", "POST"],
+          body: {"description"=>"The repository definition", "required"=>true},
+          url: {
+            path: "/_snapshot/{repository}",
+            paths: ["/_snapshot/{repository}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "verify" => {"type"=>"boolean", "description"=>"Whether to verify the repository after creation"},
+            }
+          }
+        ),
+        "snapshot.delete" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}",
+            paths: ["/_snapshot/{repository}/{snapshot}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"string", "required"=>true, "description"=>"A snapshot name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+            }
+          }
+        ),
+        "snapshot.delete_repository" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html",
+          methods: ["DELETE"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}",
+            paths: ["/_snapshot/{repository}"],
+            parts: {
+              "repository" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of repository names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "snapshot.get" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}",
+            paths: ["/_snapshot/{repository}/{snapshot}"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"list", "required"=>true, "description"=>"A comma-separated list of snapshot names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown"},
+              "verbose" => {"type"=>"boolean", "description"=>"Whether to show verbose snapshot info or only show the basic info found in the repository index blob"},
+            }
+          }
+        ),
+        "snapshot.get_repository" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_snapshot",
+            paths: ["/_snapshot", "/_snapshot/{repository}"],
+            parts: {
+              "repository" => {"type"=>"list", "description"=>"A comma-separated list of repository names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            }
+          }
+        ),
+        "snapshot.restore" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html",
+          methods: ["POST"],
+          body: {"description"=>"Details of what to restore", "required"=>false},
+          url: {
+            path: "/_snapshot/{repository}/{snapshot}/_restore",
+            paths: ["/_snapshot/{repository}/{snapshot}/_restore"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+              "snapshot" => {"type"=>"string", "required"=>true, "description"=>"A snapshot name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Should this request wait until the operation has completed before returning", "default"=>false},
+            }
+          }
+        ),
+        "snapshot.status" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_snapshot/_status",
+            paths: ["/_snapshot/_status", "/_snapshot/{repository}/_status", "/_snapshot/{repository}/{snapshot}/_status"],
+            parts: {
+              "repository" => {"type"=>"string", "description"=>"A repository name"},
+              "snapshot" => {"type"=>"list", "description"=>"A comma-separated list of snapshot names"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown"},
+            }
+          }
+        ),
+        "snapshot.verify_repository" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/modules-snapshots.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_snapshot/{repository}/_verify",
+            paths: ["/_snapshot/{repository}/_verify"],
+            parts: {
+              "repository" => {"type"=>"string", "required"=>true, "description"=>"A repository name"},
+            },
+            params: {
+              "master_timeout" => {"type"=>"time", "description"=>"Explicit operation timeout for connection to master node"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+            }
+          }
+        ),
+        "suggest" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-suggesters.html",
+          methods: ["POST"],
+          body: {"description"=>"The request definition", "required"=>true},
+          url: {
+            path: "/_suggest",
+            paths: ["/_suggest", "/{index}/_suggest"],
+            parts: {
+              "index" => {"type"=>"list", "description"=>"A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices"},
+            },
+            params: {
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+            }
+          }
+        ),
+        "tasks.cancel" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/tasks.html",
+          methods: ["POST"],
+          body: nil,
+          url: {
+            path: "/_tasks",
+            paths: ["/_tasks/_cancel", "/_tasks/{task_id}/_cancel"],
+            parts: {
+              "task_id" => {"type"=>"string", "description"=>"Cancel the task with specified task id (node_id:task_number)"},
+            },
+            params: {
+              "nodes" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+              "actions" => {"type"=>"list", "description"=>"A comma-separated list of actions that should be cancelled. Leave empty to cancel all."},
+              "parent_node" => {"type"=>"string", "description"=>"Cancel tasks with specified parent node."},
+              "parent_task_id" => {"type"=>"string", "description"=>"Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all."},
+            }
+          }
+        ),
+        "tasks.get" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/tasks.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_tasks/{task_id}",
+            paths: ["/_tasks/{task_id}"],
+            parts: {
+              "task_id" => {"type"=>"string", "description"=>"Return the task with specified id (node_id:task_number)"},
+            },
+            params: {
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Wait for the matching tasks to complete (default: false)"},
+            }
+          }
+        ),
+        "tasks.list" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/tasks.html",
+          methods: ["GET"],
+          body: nil,
+          url: {
+            path: "/_tasks",
+            paths: ["/_tasks"],
+            params: {
+              "nodes" => {"type"=>"list", "description"=>"A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes"},
+              "actions" => {"type"=>"list", "description"=>"A comma-separated list of actions that should be returned. Leave empty to return all."},
+              "detailed" => {"type"=>"boolean", "description"=>"Return detailed task information (default: false)"},
+              "parent_node" => {"type"=>"string", "description"=>"Return tasks with specified parent node."},
+              "parent_task_id" => {"type"=>"string", "description"=>"Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all."},
+              "wait_for_completion" => {"type"=>"boolean", "description"=>"Wait for the matching tasks to complete (default: false)"},
+              "group_by" => {"type"=>"enum", "description"=>"Group tasks by nodes or parent/child relationships", "options"=>["nodes", "parents"], "default"=>"nodes"},
+            }
+          }
+        ),
+        "termvectors" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-termvectors.html",
+          methods: ["GET", "POST"],
+          body: {"description"=>"Define parameters and or supply a document to get termvectors for. See documentation.", "required"=>false},
+          url: {
+            path: "/{index}/{type}/_termvectors",
+            paths: ["/{index}/{type}/_termvectors", "/{index}/{type}/{id}/_termvectors"],
+            parts: {
+              "index" => {"type"=>"string", "description"=>"The index in which the document resides.", "required"=>true},
+              "type" => {"type"=>"string", "description"=>"The type of the document.", "required"=>true},
+              "id" => {"type"=>"string", "description"=>"The id of the document, when not specified a doc param should be supplied."},
+            },
+            params: {
+              "term_statistics" => {"type"=>"boolean", "description"=>"Specifies if total term frequency and document frequency should be returned.", "default"=>false, "required"=>false},
+              "field_statistics" => {"type"=>"boolean", "description"=>"Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.", "default"=>true, "required"=>false},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return.", "required"=>false},
+              "offsets" => {"type"=>"boolean", "description"=>"Specifies if term offsets should be returned.", "default"=>true, "required"=>false},
+              "positions" => {"type"=>"boolean", "description"=>"Specifies if term positions should be returned.", "default"=>true, "required"=>false},
+              "payloads" => {"type"=>"boolean", "description"=>"Specifies if term payloads should be returned.", "default"=>true, "required"=>false},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random).", "required"=>false},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value.", "required"=>false},
+              "parent" => {"type"=>"string", "description"=>"Parent id of documents.", "required"=>false},
+              "realtime" => {"type"=>"boolean", "description"=>"Specifies if request is real-time as opposed to near-real-time (default: true).", "required"=>false},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "external", "external_gte", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "update" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-update.html",
+          methods: ["POST"],
+          body: {"description"=>"The request definition using either `script` or partial `doc`"},
+          url: {
+            path: "/{index}/{type}/{id}/_update",
+            paths: ["/{index}/{type}/{id}/_update"],
+            parts: {
+              "id" => {"type"=>"string", "required"=>true, "description"=>"Document ID"},
+              "index" => {"type"=>"string", "required"=>true, "description"=>"The name of the index"},
+              "type" => {"type"=>"string", "required"=>true, "description"=>"The type of the document"},
+            },
+            params: {
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Sets the number of shard copies that must be active before proceeding with the update operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"},
+              "fields" => {"type"=>"list", "description"=>"A comma-separated list of fields to return in the response"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "lang" => {"type"=>"string", "description"=>"The script language (default: painless)"},
+              "parent" => {"type"=>"string", "description"=>"ID of the parent document. Is is only used for routing and when for the upsert request"},
+              "refresh" => {"type"=>"enum", "options"=>["true", "false", "wait_for"], "description"=>"If `true` then refresh the effected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."},
+              "retry_on_conflict" => {"type"=>"number", "description"=>"Specify how many times should the operation be retried when a conflict occurs (default: 0)"},
+              "routing" => {"type"=>"string", "description"=>"Specific routing value"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
+              "timestamp" => {"type"=>"time", "description"=>"Explicit timestamp for the document"},
+              "ttl" => {"type"=>"time", "description"=>"Expiration time for the document"},
+              "version" => {"type"=>"number", "description"=>"Explicit version number for concurrency control"},
+              "version_type" => {"type"=>"enum", "options"=>["internal", "force"], "description"=>"Specific version type"},
+            }
+          }
+        ),
+        "update_by_query" => RestApi.new(
+          documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-update-by-query.html",
+          methods: ["POST"],
+          body: {"description"=>"The search definition using the Query DSL"},
+          url: {
+            path: "/{index}/_update_by_query",
+            paths: ["/{index}/_update_by_query", "/{index}/{type}/_update_by_query"],
+            parts: {
+              "index" => {"required"=>true, "type"=>"list", "description"=>"A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices"},
+              "type" => {"type"=>"list", "description"=>"A comma-separated list of document types to search; leave empty to perform the operation on all types"},
+            },
+            params: {
+              "analyzer" => {"type"=>"string", "description"=>"The analyzer to use for the query string"},
+              "analyze_wildcard" => {"type"=>"boolean", "description"=>"Specify whether wildcard and prefix queries should be analyzed (default: false)"},
+              "default_operator" => {"type"=>"enum", "options"=>["AND", "OR"], "default"=>"OR", "description"=>"The default operator for query string query (AND or OR)"},
+              "df" => {"type"=>"string", "description"=>"The field to use as default where no field prefix is given in the query string"},
+              "from" => {"type"=>"number", "description"=>"Starting offset (default: 0)"},
+              "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+              "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+              "conflicts" => {"note"=>"This is not copied from search", "type"=>"enum", "options"=>["abort", "proceed"], "default"=>"abort", "description"=>"What to do when the update by query hits version conflicts?"},
+              "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+              "lenient" => {"type"=>"boolean", "description"=>"Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"},
+              "pipeline" => {"type"=>"string", "description"=>"Ingest pipeline to set on index requests made by this action. (default: none)"},
+              "preference" => {"type"=>"string", "description"=>"Specify the node or shard the operation should be performed on (default: random)"},
+              "q" => {"type"=>"string", "description"=>"Query in the Lucene query string syntax"},
+              "routing" => {"type"=>"list", "description"=>"A comma-separated list of specific routing values"},
+              "scroll" => {"type"=>"time", "description"=>"Specify how long a consistent view of the index should be maintained for scrolled search"},
+              "search_type" => {"type"=>"enum", "options"=>["query_then_fetch", "dfs_query_then_fetch"], "description"=>"Search operation type"},
+              "search_timeout" => {"type"=>"time", "description"=>"Explicit timeout for each search request. Defaults to no timeout."},
+              "size" => {"type"=>"number", "description"=>"Number of hits to return (default: 10)"},
+              "sort" => {"type"=>"list", "description"=>"A comma-separated list of <field>:<direction> pairs"},
+              "_source" => {"type"=>"list", "description"=>"True or false to return the _source field or not, or a list of fields to return"},
+              "_source_exclude" => {"type"=>"list", "description"=>"A list of fields to exclude from the returned _source field"},
+              "_source_include" => {"type"=>"list", "description"=>"A list of fields to extract and return from the _source field"},
+              "terminate_after" => {"type"=>"number", "description"=>"The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."},
+              "stats" => {"type"=>"list", "description"=>"Specific 'tag' of the request for logging and statistical purposes"},
+              "version" => {"type"=>"boolean", "description"=>"Specify whether to return document version as part of a hit"},
+              "version_type" => {"type"=>"boolean", "description"=>"Should the document increment the version number (internal) on hit or not (reindex)"},
+              "request_cache" => {"type"=>"boolean", "description"=>"Specify if request cache should be used for this request or not, defaults to index level setting"},
+              "refresh" => {"type"=>"boolean", "description"=>"Should the effected indexes be refreshed?"},
+              "timeout" => {"type"=>"time", "default"=>"1m", "description"=>"Time each individual bulk request should wait for shards that are unavailable."},
+              "wait_for_active_shards" => {"type"=>"string", "description"=>"Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"},
+              "scroll_size" => {"type"=>"number", "defaut_value"=>100, "description"=>"Size on the scroll request powering the update_by_query"},
+              "wait_for_completion" => {"type"=>"boolean", "default"=>true, "description"=>"Should the request should block until the update by query operation is complete."},
+              "requests_per_second" => {"type"=>"number", "default"=>0, "description"=>"The throttle to set on this request in sub-requests per second. -1 means no throttle."},
+              "slices" => {"type"=>"number", "default"=>1, "description"=>"The number of slices this task should be divided into. Defaults to 1 meaning the task isn't sliced into subtasks."},
+            }
+          }
+        ),
+      }
+      @common_params = {
+        "pretty" => {"type"=>"boolean", "description"=>"Pretty format the returned JSON response.", "default"=>false},
+        "human" => {"type"=>"boolean", "description"=>"Return human readable values for statistics.", "default"=>true},
+        "error_trace" => {"type"=>"boolean", "description"=>"Include the stack trace of returned errors.", "default"=>false},
+        "source" => {"type"=>"string", "description"=>"The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests."},
+        "filter_path" => {"type"=>"list", "description"=>"A comma-separated list of filters used to reduce the respone."},
+      }
+      super
+    end
+  end
+end

--- a/lib/elastomer/client/rest_api_spec/api_spec_v5_6.rb
+++ b/lib/elastomer/client/rest_api_spec/api_spec_v5_6.rb
@@ -2346,6 +2346,7 @@ module Elastomer::Client::RestApiSpec
             },
             params: {
               "wait_for_completion" => {"type"=>"boolean", "description"=>"Wait for the matching tasks to complete (default: false)"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
             }
           }
         ),
@@ -2364,6 +2365,7 @@ module Elastomer::Client::RestApiSpec
               "parent_task_id" => {"type"=>"string", "description"=>"Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all."},
               "wait_for_completion" => {"type"=>"boolean", "description"=>"Wait for the matching tasks to complete (default: false)"},
               "group_by" => {"type"=>"enum", "description"=>"Group tasks by nodes or parent/child relationships", "options"=>["nodes", "parents"], "default"=>"nodes"},
+              "timeout" => {"type"=>"time", "description"=>"Explicit operation timeout"},
             }
           }
         ),

--- a/lib/elastomer/client/rest_api_spec/rest_api.rb
+++ b/lib/elastomer/client/rest_api_spec/rest_api.rb
@@ -1,0 +1,51 @@
+require "forwardable"
+
+module Elastomer::Client::RestApiSpec
+  class RestApi
+    extend Forwardable
+
+    attr_reader :documentation
+    attr_reader :methods
+    attr_reader :url
+    attr_reader :body
+
+    def_delegators :@url,
+        :select_parts, :select_params
+
+    def initialize(documentation:, methods:, url:, body:)
+      @documentation = documentation
+      @methods = Array(methods)
+      @url = Url.new(url)
+      @body = body
+    end
+
+    def body?
+      !body.nil?
+    end
+
+    class Url
+      attr_reader :path
+      attr_reader :paths
+      attr_reader :parts
+      attr_reader :params
+
+      def initialize(path:, paths:, parts:, params:)
+        @path = path
+        @paths = Array(paths)
+        @parts = parts
+        @params = params
+
+        @parts_set  = Set.new(@parts.keys)
+        @params_set = Set.new(@params.keys)
+      end
+
+      def select_parts(params:)
+        params.select {|k,v| @parts_set.include?(k.to_s)}
+      end
+
+      def select_params(params:)
+        params.select {|k,v| @params_set.include?(k.to_s)}
+      end
+    end
+  end
+end

--- a/lib/elastomer/client/rest_api_spec/rest_api.rb
+++ b/lib/elastomer/client/rest_api_spec/rest_api.rb
@@ -12,7 +12,7 @@ module Elastomer::Client::RestApiSpec
     def_delegators :@url,
         :select_parts, :select_params
 
-    def initialize(documentation:, methods:, url:, body:)
+    def initialize(documentation:, methods:, url:, body: nil)
       @documentation = documentation
       @methods = Array(methods)
       @url = Url.new(url)
@@ -29,7 +29,7 @@ module Elastomer::Client::RestApiSpec
       attr_reader :parts
       attr_reader :params
 
-      def initialize(path:, paths:, parts:, params:)
+      def initialize(path:, paths: [], parts: {}, params: {})
         @path = path
         @paths = Array(paths)
         @parts = parts

--- a/lib/elastomer/client/rest_api_spec/rest_api.rb
+++ b/lib/elastomer/client/rest_api_spec/rest_api.rb
@@ -10,7 +10,7 @@ module Elastomer::Client::RestApiSpec
     attr_reader :body
 
     def_delegators :@url,
-        :select_parts, :select_params
+        :select_parts, :select_params, :valid_part?, :valid_param?
 
     def initialize(documentation:, methods:, url:, body: nil)
       @documentation = documentation
@@ -40,11 +40,19 @@ module Elastomer::Client::RestApiSpec
       end
 
       def select_parts(from:)
-        from.select {|k,v| @parts_set.include?(k.to_s)}
+        from.select {|k,v| valid_part?(k)}
+      end
+
+      def valid_part?(part)
+        @parts_set.include?(part.to_s)
       end
 
       def select_params(from:)
-        from.select {|k,v| @params_set.include?(k.to_s)}
+        from.select {|k,v| valid_param?(k)}
+      end
+
+      def valid_param?(param)
+        @params_set.include?(param.to_s)
       end
     end
   end

--- a/lib/elastomer/client/rest_api_spec/rest_api.rb
+++ b/lib/elastomer/client/rest_api_spec/rest_api.rb
@@ -39,12 +39,12 @@ module Elastomer::Client::RestApiSpec
         @params_set = Set.new(@params.keys)
       end
 
-      def select_parts(params:)
-        params.select {|k,v| @parts_set.include?(k.to_s)}
+      def select_parts(from:)
+        from.select {|k,v| @parts_set.include?(k.to_s)}
       end
 
-      def select_params(params:)
-        params.select {|k,v| @params_set.include?(k.to_s)}
+      def select_params(from:)
+        from.select {|k,v| @params_set.include?(k.to_s)}
       end
     end
   end

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -12,7 +12,7 @@ module Elastomer
     #
     # Examples
     #
-    #   scroll = client.scroll('{"query":{"match_all":{}}}', :index => 'test')
+    #   scroll = client.scroll('{"query":{"match_all":{}}}', index: 'test')
     #   scroll.each_document do |document|
     #     document['_id']
     #     document['_source']
@@ -35,7 +35,7 @@ module Elastomer
     #
     # Examples
     #
-    #   scan = client.scan('{"query":{"match_all":{}}}', :index => 'test')
+    #   scan = client.scan('{"query":{"match_all":{}}}', index: 'test')
     #   scan.each_document do |document|
     #     document['_id']
     #     document['_source']
@@ -59,7 +59,7 @@ module Elastomer
     #
     # Examples
     #
-    #   h = client.start_scroll(:body => '{"query":{"match_all":{}},"sort":{"created":"desc"}}', :index => 'test')
+    #   h = client.start_scroll(body: '{"query":{"match_all":{}},"sort":{"created":"desc"}}', index: 'test')
     #   scroll_id = h['_scroll_id']
     #   h['hits']['hits'].each { |doc| ... }
     #
@@ -71,7 +71,7 @@ module Elastomer
     #
     # Returns the response body as a Hash.
     def start_scroll( opts = {} )
-      opts = opts.merge :action => "search.start_scroll"
+      opts = opts.merge action: "search.start_scroll", rest_api: "search"
       response = get "{/index}{/type}/_search", opts
       response.body
     end
@@ -84,7 +84,7 @@ module Elastomer
     #
     # Examples
     #
-    #   scroll_id = client.start_scroll(:body => '{"query":{"match_all":{}}}', :index => 'test')['_scroll_id']
+    #   scroll_id = client.start_scroll(body: '{"query":{"match_all":{}}}', index: 'test')['_scroll_id']
     #
     #   h = client.continue_scroll scroll_id   # scroll to get the next set of results
     #   scroll_id = h['_scroll_id']            # and store the scroll_id to use later
@@ -96,7 +96,7 @@ module Elastomer
     #
     # Returns the response body as a Hash.
     def continue_scroll( scroll_id, scroll = "5m" )
-      response = get "/_search/scroll", :body => {:scroll_id => scroll_id}, :scroll => scroll, :action => "search.scroll"
+      response = get "/_search/scroll", body: {scroll_id: scroll_id}, scroll: scroll, action: "search.scroll", rest_api: "scroll"
       response.body
     rescue RequestError => err
       if err.error && err.error["caused_by"]["type"] == "search_context_missing_exception"
@@ -113,7 +113,7 @@ module Elastomer
     #
     # Returns the response body as a Hash.
     def clear_scroll( scroll_ids )
-      response = delete "/_search/scroll", :body => {scroll_id: Array(scroll_ids)}, :action => "search.clear_scroll"
+      response = delete "/_search/scroll", body: {scroll_id: Array(scroll_ids)}, action: "search.clear_scroll", rest_api: "clear_scroll"
       response.body
     end
 
@@ -132,7 +132,7 @@ module Elastomer
          raise ArgumentError, "Query cannot contain a sort (found sort '#{query[:sort]}' in query: #{query})"
       end
 
-      query.merge(:sort => [:_doc])
+      query.merge(sort: [:_doc])
     end
 
     DEFAULT_OPTS = {
@@ -161,7 +161,7 @@ module Elastomer
       #
       # Examples
       #
-      #   scan = Scroller.new(client, {:query => {:match_all => {}}}, :index => 'test-1')
+      #   scan = Scroller.new(client, {query: {match_all: {}}}, index: 'test-1')
       #   scan.each_document { |doc|
       #     doc['_id']
       #     doc['_source']
@@ -170,7 +170,7 @@ module Elastomer
       def initialize( client, query, opts = {} )
         @client = client
 
-        @opts = DEFAULT_OPTS.merge({ :body => query }).merge(opts)
+        @opts = DEFAULT_OPTS.merge({ body: query }).merge(opts)
 
         @scroll_id = nil
         @offset = 0

--- a/lib/elastomer/client/snapshot.rb
+++ b/lib/elastomer/client/snapshot.rb
@@ -35,7 +35,7 @@ module Elastomer
       #
       # Returns true if the snapshot exists
       def exists?(params = {})
-        response = client.get "/_snapshot/{repository}/{snapshot}", update_params(params, :action => "snapshot.exists")
+        response = client.get "/_snapshot/{repository}/{snapshot}", update_params(params, action: "snapshot.exists", rest_api: "snapshot.get")
         response.success?
       rescue Elastomer::Client::Error => err
         if err.error && err.error.dig("root_cause", 0, "type") == "snapshot_missing_exception"
@@ -54,7 +54,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create(body = {}, params = {})
-        response = client.put "/_snapshot/{repository}/{snapshot}", update_params(params, :body => body, :action => "snapshot.create")
+        response = client.put "/_snapshot/{repository}/{snapshot}", update_params(params, body: body, action: "snapshot.create", rest_api: "snapshot.create")
         response.body
       end
 
@@ -67,7 +67,7 @@ module Elastomer
       def get(params = {})
         # Set snapshot name or we'll get the repository instead
         snapshot = name || "_all"
-        response = client.get "/_snapshot/{repository}/{snapshot}", update_params(params, :snapshot => snapshot, :action => "snapshot.get")
+        response = client.get "/_snapshot/{repository}/{snapshot}", update_params(params, snapshot: snapshot, action: "snapshot.get", rest_api: "snapshot.get")
         response.body
       end
 
@@ -78,7 +78,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def status(params = {})
-        response = client.get "/_snapshot{/repository}{/snapshot}/_status", update_params(params, :action => "snapshot.status")
+        response = client.get "/_snapshot{/repository}{/snapshot}/_status", update_params(params, action: "snapshot.status", rest_api: "snapshot.status")
         response.body
       end
 
@@ -90,7 +90,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def restore(body = {}, params = {})
-        response = client.post "/_snapshot/{repository}/{snapshot}/_restore", update_params(params, :body => body, :action => "snapshot.restore")
+        response = client.post "/_snapshot/{repository}/{snapshot}/_restore", update_params(params, body: body, action: "snapshot.restore", rest_api: "snapshot.restore")
         response.body
       end
 
@@ -101,7 +101,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete(params = {})
-        response = client.delete "/_snapshot/{repository}/{snapshot}", update_params(params, :action => "snapshot.delete")
+        response = client.delete "/_snapshot/{repository}/{snapshot}", update_params(params, action: "snapshot.delete", rest_api: "snapshot.delete")
         response.body
       end
 
@@ -120,7 +120,7 @@ module Elastomer
 
       # Internal: Returns a Hash containing default parameters.
       def defaults
-        { :repository => repository, :snapshot => name }
+        { repository: repository, snapshot: name }
       end
     end
   end

--- a/lib/elastomer/client/tasks.rb
+++ b/lib/elastomer/client/tasks.rb
@@ -12,18 +12,6 @@ module Elastomer
 
     class Tasks
 
-      # TODO - validate params from this whitelist
-      PARAMETERS = %i[
-        nodes
-        actions
-        parent_task_id
-        wait_for_completion
-        pretty
-        detailed
-        timeout
-        group_by
-      ].to_set.freeze
-
       # Create a new Tasks for introspecting on internal cluster activity.
       # More context: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/tasks.html
       #

--- a/lib/elastomer/client/tasks.rb
+++ b/lib/elastomer/client/tasks.rb
@@ -38,21 +38,21 @@ module Elastomer
 
       # Fetch results from the generic _tasks endpoint.
       #
-      # params       - Hash of request parameters, including:
+      # params - Hash of request parameters, including:
       #
       # Examples
       #
       #   tasks.get
-      #   tasks.get :nodes => "DmteLdw1QmSgW3GZmjmoKA,DmteLdw1QmSgW3GZmjmoKB", :actions => "cluster:*", :detailed => true
+      #   tasks.get nodes: "DmteLdw1QmSgW3GZmjmoKA,DmteLdw1QmSgW3GZmjmoKB", actions: "cluster:*", detailed: true
       #
       # Examples (ES 5+ only)
       #
-      #   tasks.get :group_by => "parents"
-      #   tasks.get :group_by => "parents", :actions => "*reindex", ...
+      #   tasks.get group_by: "parents"
+      #   tasks.get group_by: "parents", actions: "*reindex", ...
       #
       # Returns the response body as a Hash
       def get(params = {})
-        response = client.get "/_tasks", params
+        response = client.get "/_tasks", params.merge(action: "tasks.list", rest_api: "tasks.list")
         response.body
       end
 
@@ -61,22 +61,24 @@ module Elastomer
       # where "node_id" is a value from the "nodes" hash returned from the /_tasks endpoint, and "task_id" is
       # from the "tasks" child hash of any of the "nodes" entries of the /_tasks endpoint
       #
-      # node_id         - the name of the ES cluster node hosting the target task
-      # task_id         - the numerical ID of the task to return data about in the response
-      # params          - Hash of request parameters to include
+      # node_id - the name of the ES cluster node hosting the target task
+      # task_id - the numerical ID of the task to return data about in the response
+      # params  - Hash of request parameters to include
       #
       # Examples
       #
       #  tasks.get_by_id "DmteLdw1QmSgW3GZmjmoKA", 123
-      #  tasks.get_by_id "DmteLdw1QmSgW3GZmjmoKA", 456, :pretty => true
+      #  tasks.get_by_id "DmteLdw1QmSgW3GZmjmoKA", 456, pretty: true
       #
       # Returns the response body as a Hash
       def get_by_id(node_id, task_id, params = {})
         raise ArgumentError, "invalid node ID provided: #{node_id.inspect}" if node_id.to_s.empty?
         raise ArgumentError, "invalid task ID provided: #{task_id.inspect}" unless task_id.is_a?(Integer)
 
+        rest_api = client.version_support.supports_tasks_get? ? "tasks.get" : "tasks.list"
+
         # in this API, the task ID is included in the path, not as a request parameter.
-        response = client.get "/_tasks/#{node_id}:#{task_id}", params
+        response = client.get "/_tasks/{task_id}", params.merge(task_id: "#{node_id}:#{task_id}", action: "tasks.get", rest_api: rest_api)
         response.body
       end
 
@@ -85,9 +87,9 @@ module Elastomer
       # is not the correct syntax for the parent_task_id param value. The correct
       # value syntax is "<parent_node_id>:<parent_task_id>"
       #
-      # parent_node_id  - ID of the node the parent task is hosted by
-      # parent_task_id  - ID of a parent task who's child tasks' data will be returned in the response
-      # params          - Hash of request parameters to include
+      # parent_node_id - ID of the node the parent task is hosted by
+      # parent_task_id - ID of a parent task who's child tasks' data will be returned in the response
+      # params         - Hash of request parameters to include
       #
       # Examples
       #
@@ -99,50 +101,55 @@ module Elastomer
         raise ArgumentError, "invalid parent node ID provided: #{parent_node_id.inspect}" if node_id.to_s.empty?
         raise ArgumentError, "invalid parent task ID provided: #{parent_task_id.inspect}" unless parent_task_id.is_a?(Integer)
 
-        # in this API, we pass the parent task ID as a formatted parameter in a request to the _tasks endpoint
-        formatted_parent = { :parent_task_id => "#{parent_node_id}:#{parent_task_id}" }
-        response = client.get "/_tasks", params.merge(formatted_parent)
+        parent_task_id = "#{parent_node_id}:#{parent_task_id}"
+        params = params.merge(action: "tasks.parent", rest_api: "tasks.list")
+
+        if client.version_support.supports_parent_task_id?
+          params[:parent_task_id] = parent_task_id
+        else
+          params[:parent_task] = parent_task_id
+        end
+
+        response = client.get "/_tasks", params
         response.body
       end
 
       # Wait for the specified amount of time (10 seconds by default) for some task(s) to complete.
       # Filters for task(s) to wait upon using same filter params as Tasks#get(params)
       #
-      # timeout         - maximum time to wait for target task to complete before returning, example: "5s"
-      # params          - Hash of request params to include (mostly task filters in this context)
+      # timeout - maximum time to wait for target task to complete before returning, example: "5s"
+      # params  - Hash of request params to include (mostly task filters in this context)
       #
       # Examples
       #
-      # tasks.wait_for "5s", :actions => "*health"
-      # tasks.wait_for("30s", :actions => "*reindex", :nodes => "DmteLdw1QmSgW3GZmjmoKA,DmteLdw1QmSgW3GZmjmoKB")
+      # tasks.wait_for "5s", actions: "*health"
+      # tasks.wait_for("30s", actions: "*reindex", nodes: "DmteLdw1QmSgW3GZmjmoKA,DmteLdw1QmSgW3GZmjmoKB")
       #
       # Returns the response body as a Hash when timeout expires or target tasks complete
       # COMPATIBILITY WARNING: the response body differs between ES versions for this API
       def wait_for(timeout = "10s", params = {}) 
-        params_with_wait = params.merge({ :wait_for_completion => true, :timeout => timeout })
-        self.get(params_with_wait)
+        self.get params.merge(wait_for_completion: true, timeout: timeout)
       end
 
       # Wait for the specified amount of time (10 seconds by default) for some task(s) to complete.
       # Filters for task(s) to wait upon using same IDs and filter params as Tasks#get_by_id(params)
       #
-      # node_id                 - the ID of the node on which the target task is hosted
-      # task_id                 - the ID of the task to wait on
-      # timeout                 - time for call to await target tasks completion before returning
-      # params                  - Hash of request params to include (mostly task filters in this context)
+      # node_id - the ID of the node on which the target task is hosted
+      # task_id - the ID of the task to wait on
+      # timeout - time for call to await target tasks completion before returning
+      # params  - Hash of request params to include (mostly task filters in this context)
       #
       # Examples
       #
       # tasks.wait_by_id "DmteLdw1QmSgW3GZmjmoKA", 123, "15s"
-      # tasks.wait_by_id "DmteLdw1QmSgW3GZmjmoKA", 456, "30s", :actions => "*search"
+      # tasks.wait_by_id "DmteLdw1QmSgW3GZmjmoKA", 456, "30s", actions: "*search"
       #
       # Returns the response body as a Hash when timeout expires or target tasks complete
       def wait_by_id(node_id, task_id, timeout = "10s", params = {})
         raise ArgumentError, "invalid node ID provided: #{node_id.inspect}" if node_id.to_s.empty?
         raise ArgumentError, "invalid task ID provided: #{task_id.inspect}" unless task_id.is_a?(Integer)
 
-        params_with_wait = params.merge({ :wait_for_completion => true, :timeout => timeout })
-        self.get_by_id(node_id, task_id, params_with_wait)
+        self.get_by_id(node_id, task_id, params.merge(wait_for_completion: true, timeout: timeout))
       end
 
       # Cancels a task running on a particular node.
@@ -157,32 +164,31 @@ module Elastomer
       # Examples
       #
       #   tasks.cancel_by_id "DmteLdw1QmSgW3GZmjmoKA", 123
-      #   tasks.cancel_by_id "DmteLdw1QmSgW3GZmjmoKA", 456, :pretty => true
+      #   tasks.cancel_by_id "DmteLdw1QmSgW3GZmjmoKA", 456, pretty: true
       #
       # Returns the response body as a Hash
       def cancel_by_id(node_id, task_id, params = {})
         raise ArgumentError, "invalid node ID provided: #{node_id.inspect}" if node_id.to_s.empty?
         raise ArgumentError, "invalid task ID provided: #{task_id.inspect}" unless task_id.is_a?(Integer)
 
-        response = client.post "/_tasks/#{node_id}:#{task_id}/_cancel", params
-        response.body
+        self.cancel(params.merge(task_id: "#{node_id}:#{task_id}"))
       end
 
       # Cancels a task or group of tasks using various filtering parameters.
       #
-      # params          - Hash of request parameters to include
+      # params - Hash of request parameters to include
       #
       # Examples
       #
-      #   tasks.cancel :actions => "*reindex"
-      #   tasks.cancel :actions => "*search", :nodes => "DmteLdw1QmSgW3GZmjmoKA,DmteLdw1QmSgW3GZmjmoKB,DmteLdw1QmSgW3GZmjmoKC"
+      #   tasks.cancel actions: "*reindex"
+      #   tasks.cancel actions: "*search", nodes: "DmteLdw1QmSgW3GZmjmoKA,DmteLdw1QmSgW3GZmjmoKB,DmteLdw1QmSgW3GZmjmoKC"
       #
       # Returns the response body as a Hash
       def cancel(params = {})
-        response = client.post "/_tasks/_cancel", params
+        response = client.post "/_tasks{/task_id}/_cancel", params.merge(action: "tasks.cancel", rest_api: "tasks.cancel")
         response.body
       end
 
-    end # end class Tasks
-  end # end class Client
-end # end module Elastomer
+    end
+  end
+end

--- a/lib/elastomer/client/template.rb
+++ b/lib/elastomer/client/template.rb
@@ -25,7 +25,7 @@ module Elastomer
 
       # Returns true if the template already exists on the cluster.
       def exists?( params = {} )
-        response = client.head "/_template/{template}", update_params(params, action: "template.exists")
+        response = client.head "/_template/{template}", update_params(params, action: "template.exists", rest_api: "indices.exists_template")
         response.success?
       end
       alias_method :exist?, :exists?
@@ -37,7 +37,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get( params = {} )
-        response = client.get "/_template/{template}", update_params(params, :action => "template.get")
+        response = client.get "/_template/{template}", update_params(params, action: "template.get", rest_api: "indices.get_template")
         response.body
       end
 
@@ -49,7 +49,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create( template, params = {} )
-        response = client.put "/_template/{template}", update_params(params, :body => template, :action => "template.create")
+        response = client.put "/_template/{template}", update_params(params, body: template, action: "template.create", rest_api: "indices.put_template")
         response.body
       end
 
@@ -60,7 +60,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete( params = {} )
-        response = client.delete "/_template/{template}", update_params(params, :action => "template.delete")
+        response = client.delete "/_template/{template}", update_params(params, action: "template.delete", rest_api: "indices.delete_template")
         response.body
       end
 
@@ -79,8 +79,8 @@ module Elastomer
 
       # Internal: Returns a Hash containing default parameters.
       def defaults
-        { :template => name }
+        { template: name }
       end
-    end  # Template
-  end  # Client
-end  # Elastomer
+    end
+  end
+end

--- a/lib/elastomer/client/warmer.rb
+++ b/lib/elastomer/client/warmer.rb
@@ -34,7 +34,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def create(query, params = {})
-        response = client.put "/{index}{/type}/_warmer/{warmer}", defaults.update(params.update(:body => query))
+        response = client.put "/{index}{/type}/_warmer/{warmer}", update_params(params, body: query, action: "warmer.create", rest_api: "indices.put_warmer")
         response.body
       end
 
@@ -45,7 +45,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def delete(params = {})
-        response = client.delete "/{index}{/type}/_warmer/{warmer}", defaults.update(params)
+        response = client.delete "/{index}{/type}/_warmer/{warmer}", update_params(params, action: "warmer.delete", rest_api: "indices.delete_warmer")
         response.body
       end
 
@@ -56,7 +56,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def get(params = {})
-        response = client.get "/{index}{/type}/_warmer/{warmer}", defaults.update(params)
+        response = client.get "/{index}{/type}/_warmer/{warmer}", update_params(params, action: "warmer.get", rest_api: "indices.get_warmer")
         response.body
       end
 
@@ -82,9 +82,16 @@ module Elastomer
       end
       alias_method :exist?, :exists?
 
+      # Internal:
+      def update_params(params, overrides = nil)
+        h = defaults.update params
+        h.update overrides unless overrides.nil?
+        h
+      end
+
       # Internal: Returns a Hash containing default parameters.
       def defaults
-        {:index => index_name, :warmer => name}
+        {index: index_name, warmer: name}
       end
     end
   end

--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -43,6 +43,18 @@ module Elastomer
       es_version_5_x?
     end
 
+    # COMPATIBILITY: Return a boolean indicating if this version supports the
+    # `tasks.get` API - https://www.elastic.co/guide/en/elasticsearch/reference/5.x/tasks.html
+    def supports_tasks_get?
+      es_version_5_x?
+    end
+
+    # COMPATIBILITY: Return a boolean indicating if this version supports the
+    # `parent_task_id` param in the tasks API - https://www.elastic.co/guide/en/elasticsearch/reference/5.x/tasks.html
+    def supports_parent_task_id?
+      es_version_5_x?
+    end
+
     # COMPATIBILITY: Return a "text"-type mapping for a field.
     #
     # On ES 2.x, this will be a string field. On ES 5+, it will be a text field.

--- a/script/generate-rest-api-spec
+++ b/script/generate-rest-api-spec
@@ -1,0 +1,113 @@
+#!/usr/bin/env ruby
+
+require "rubygems"
+require "bundler/setup"
+
+$LOAD_PATH.unshift "lib"
+require "elastomer/client"
+
+require "erb"
+
+class RestApiSpecGenerator
+  WORKING_DIR = "vendor/elasticsearch"
+
+  attr_reader :version, :class_version
+
+  def initialize
+    @version = "5.6.4"
+    @class_version = @version.split(".").slice(0,2).join("_")
+  end
+
+  def run
+    setup
+    ERB.new(DATA.read, 0, "-").result(binding)
+  ensure
+    reset
+  end
+
+  def working_dir_exists?
+    File.directory?(WORKING_DIR) && File.exists?(WORKING_DIR)
+  end
+
+  def setup
+    if !working_dir_exists?
+      system <<-SH
+        mkdir -p #{WORKING_DIR} &&
+        cd #{WORKING_DIR} &&
+        git init . &&
+        git remote add -f origin https://github.com/elastic/elasticsearch.git &&
+        git config core.sparsecheckout true &&
+        echo /rest-api-spec/src/main/resources/rest-api-spec/api/ >> .git/info/sparse-checkout &&
+        git pull origin master
+      SH
+    end
+
+    system <<-SH
+      cd #{WORKING_DIR} &&
+      git pull origin master &&
+      git checkout -q origin/#{version.split(".").slice(0,2).join(".")}
+    SH
+  end
+
+  def reset
+    system <<-SH
+      cd #{WORKING_DIR} &&
+      git checkout master
+    SH
+  end
+
+  def each_api
+    Dir.glob("#{WORKING_DIR}/rest-api-spec/src/main/resources/rest-api-spec/api/*.json").each do |filename|
+      next if filename =~ /\/_common\.json\Z/
+
+      hash = MultiJson.load(File.read(filename))
+      key = hash.keys.first
+      value = hash.values.first
+      yield(key, value)
+    end
+  end
+
+end
+
+
+puts RestApiSpecGenerator.new.run
+
+__END__
+module Elastomer::Client::RestApiSpec
+  class V<%= class_version %> < ApiSpec
+    def initialize
+      @rest_apis = {
+<% each_api do |name,data| -%>
+        "<%= name %>" => RestApi.new(
+          documentation: "<%= data["documentation"].to_s %>",
+          methods: <%= Array(data["methods"]).to_s %>,
+          body: <%= data["body"] ? data["body"].to_s : "nil" %>,
+<% url = data["url"] -%>
+          url: {
+            path: "<%= url["path"] %>",
+            paths: <%= Array(url["paths"]).to_s %>,
+<% if (parts = url["parts"]) && !parts.empty? -%>
+            parts: {
+<% parts.each do |k,v| -%>
+              "<%= k %>" => <%= v.to_s %>,
+<% end -%>
+            },
+<% end -%>
+<% if (params = url["params"]) && !params.empty? -%>
+            params: {
+<% params.each do |k,v| -%>
+              "<%= k %>" => <%= v.to_s %>,
+<% end -%>
+            }
+<% end -%>
+          }
+        ),
+<% end -%>
+      }
+
+      @common_params = {
+      }
+      super
+    end
+  end
+end

--- a/script/generate-rest-api-spec
+++ b/script/generate-rest-api-spec
@@ -1,19 +1,25 @@
 #!/usr/bin/env ruby
+# Usage:
+#
+#   script/generate-rest-api-spec <elasticsearch-version>
+#
+# Use this script to generate a REST API spec for the given
+# `elasticserach-version`. This will create a new `ApiSpec` class configured
+# to validate the request parameters for the particular Elasticsearch version.
 
+require "erb"
 require "rubygems"
 require "bundler/setup"
 
 $LOAD_PATH.unshift "lib"
 require "elastomer/client"
 
-require "erb"
-
 class RestApiSpecGenerator
   WORKING_DIR = "vendor/elasticsearch"
 
   attr_reader :version, :short_version, :class_version
 
-  def initialize(version = "5.6.4")
+  def initialize(version = "5.6")
     @version = version
 
     sliced = @version.split(".").slice(0,2)
@@ -21,6 +27,8 @@ class RestApiSpecGenerator
     @class_version = sliced.join("_")
   end
 
+  # Setup the working directory and generate the Ruby API spec for the
+  # elasticsearch version.
   def run
     setup
     File.open(ruby_spec_filename, "w") do |fd|
@@ -30,14 +38,41 @@ class RestApiSpecGenerator
     reset
   end
 
+  # The name of the Ruby API spec file for this particular Elasticsearch version.
   def ruby_spec_filename
-    "lib/elastomer/client/rest_api_spec/v#{class_version}.rb"
+    "lib/elastomer/client/rest_api_spec/api_spec_v#{class_version}.rb"
   end
 
+  # Returns true if the elasticserach working directory exists.
   def working_dir_exists?
     File.directory?(WORKING_DIR) && File.exists?(WORKING_DIR)
   end
 
+  # Iterate over each of the REST API specs yield the name and the descriptor
+  # hash for that particular API spec.
+  def each_api
+    Dir.glob("#{WORKING_DIR}/rest-api-spec/src/main/resources/rest-api-spec/api/*.json").each do |filename|
+      next if filename =~ /\/_common\.json\Z/
+
+      hash = MultiJson.load(File.read(filename))
+      key = hash.keys.first
+      value = hash.values.first
+      yield(key, value)
+    end
+  end
+
+  # Iterate over each of the common request parameters and yield them as key /
+  # value pairs.
+  def each_common
+    filename = "#{WORKING_DIR}/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json"
+    if File.exists? filename
+      hash = MultiJson.load(File.read(filename))
+      hash["params"].each {|k,v| yield(k,v)}
+    end
+  end
+
+  # Perform a sparse checkout of the elasticsearch git repository and then check
+  # out the branch corresponding to the ES version passed to this script.
   def setup
     if !working_dir_exists?
       system <<-SH
@@ -58,30 +93,14 @@ class RestApiSpecGenerator
     SH
   end
 
+  # Reset the elasticsearch working directory back to the master branch of the
+  # git repository.
   def reset
     system <<-SH
       cd #{WORKING_DIR} &&
       git checkout master
     SH
   end
-
-  def each_api
-    Dir.glob("#{WORKING_DIR}/rest-api-spec/src/main/resources/rest-api-spec/api/*.json").each do |filename|
-      next if filename =~ /\/_common\.json\Z/
-
-      hash = MultiJson.load(File.read(filename))
-      key = hash.keys.first
-      value = hash.values.first
-      yield(key, value)
-    end
-  end
-
-  def each_common
-    filename = "#{WORKING_DIR}/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json"
-    hash = MultiJson.load(File.read(filename))
-    hash["params"].each {|k,v| yield(k,v)}
-  end
-
 end
 
 puts RestApiSpecGenerator.new(*ARGV).run
@@ -92,7 +111,7 @@ __END__
 # ES version: <%= version %>
 
 module Elastomer::Client::RestApiSpec
-  class V<%= class_version %> < ApiSpec
+  class ApiSpecV<%= class_version %> < ApiSpec
     def initialize
       @rest_apis = {
 <% each_api do |name,data| -%>

--- a/script/generate-rest-api-spec
+++ b/script/generate-rest-api-spec
@@ -11,18 +11,27 @@ require "erb"
 class RestApiSpecGenerator
   WORKING_DIR = "vendor/elasticsearch"
 
-  attr_reader :version, :class_version
+  attr_reader :version, :short_version, :class_version
 
-  def initialize
-    @version = "5.6.4"
-    @class_version = @version.split(".").slice(0,2).join("_")
+  def initialize(version = "5.6.4")
+    @version = version
+
+    sliced = @version.split(".").slice(0,2)
+    @short_version = sliced.join(".")
+    @class_version = sliced.join("_")
   end
 
   def run
     setup
-    ERB.new(DATA.read, 0, "-").result(binding)
+    File.open(ruby_spec_filename, "w") do |fd|
+      fd.puts ERB.new(DATA.read, 0, "-").result(binding)
+    end
   ensure
     reset
+  end
+
+  def ruby_spec_filename
+    "lib/elastomer/client/rest_api_spec/v#{class_version}.rb"
   end
 
   def working_dir_exists?
@@ -45,7 +54,7 @@ class RestApiSpecGenerator
     system <<-SH
       cd #{WORKING_DIR} &&
       git pull origin master &&
-      git checkout -q origin/#{version.split(".").slice(0,2).join(".")}
+      git checkout -q origin/#{short_version}
     SH
   end
 
@@ -67,12 +76,21 @@ class RestApiSpecGenerator
     end
   end
 
+  def each_common
+    filename = "#{WORKING_DIR}/rest-api-spec/src/main/resources/rest-api-spec/api/_common.json"
+    hash = MultiJson.load(File.read(filename))
+    hash["params"].each {|k,v| yield(k,v)}
+  end
+
 end
 
-
-puts RestApiSpecGenerator.new.run
+puts RestApiSpecGenerator.new(*ARGV).run
 
 __END__
+# Generated REST API spec file - DO NOT EDIT!
+# Date: <%= Time.now.strftime("%Y-%m-%d") %>
+# ES version: <%= version %>
+
 module Elastomer::Client::RestApiSpec
   class V<%= class_version %> < ApiSpec
     def initialize
@@ -104,8 +122,10 @@ module Elastomer::Client::RestApiSpec
         ),
 <% end -%>
       }
-
       @common_params = {
+<% each_common do |k,v| -%>
+        "<%= k %>" => <%= v.to_s %>,
+<% end -%>
       }
       super
     end

--- a/test/client/rest_api_spec/api_spec_test.rb
+++ b/test/client/rest_api_spec/api_spec_test.rb
@@ -1,0 +1,55 @@
+require_relative "../../test_helper"
+
+describe Elastomer::Client::RestApiSpec::ApiSpec do
+  before do
+    @api_spec = Elastomer::Client::RestApiSpec.api_spec("5.6.4")
+  end
+
+  it "selects valid path parts" do
+    parts  = {index: "test", "type" => "doc", foo: "bar"}
+    result = @api_spec.select_parts(api: "search", from: parts)
+
+    assert_equal({index: "test", "type" => "doc"}, result)
+  end
+
+  it "identifies valid path parts" do
+    assert @api_spec.valid_part?(api: "search", part: "index")
+    assert @api_spec.valid_part?(api: "search", part: :type)
+    refute @api_spec.valid_part?(api: "search", part: :id)
+  end
+
+  it "selects valid request params" do
+    params = {explain: true, "preference" => "local", nope: "invalid"}
+    result = @api_spec.select_params(api: "search", from: params)
+
+    assert_equal({explain: true, "preference" => "local"}, result)
+  end
+
+  it "identifies valid request params" do
+    assert @api_spec.valid_param?(api: "search", param: "explain")
+    assert @api_spec.valid_param?(api: "search", param: :preference)
+    assert @api_spec.valid_param?(api: "search", param: :routing)
+    refute @api_spec.valid_param?(api: "search", param: "pretty")
+  end
+
+  it "selects common request params" do
+    params = {pretty: true, "human" => true, nope: "invalid"}
+    result = @api_spec.select_common_params(from: params)
+
+    assert_equal({pretty: true, "human" => true}, result)
+  end
+
+  it "identifies common request params" do
+    assert @api_spec.valid_common_param?("pretty")
+    assert @api_spec.valid_common_param?(:human)
+    assert @api_spec.valid_common_param?(:source)
+    refute @api_spec.valid_common_param?("nope")
+  end
+
+  it "validates request params" do
+    assert_raises(Elastomer::Client::IllegalArgument, "'nope' is not a valid parameter for the 'search' API") {
+      params = {q: "*:*", pretty: true, "nope": false}
+      @api_spec.validate_params!(api: "search", params: params)
+    }
+  end
+end

--- a/test/client/rest_api_spec/rest_api_test.rb
+++ b/test/client/rest_api_spec/rest_api_test.rb
@@ -1,0 +1,84 @@
+require_relative "../../test_helper"
+
+describe Elastomer::Client::RestApiSpec::RestApi do
+  before do
+    @rest_api = Elastomer::Client::RestApiSpec::RestApi.new \
+        documentation: "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-state.html",
+        methods: ["GET"],
+        body: nil,
+        url: {
+          path: "/_cluster/state",
+          paths: ["/_cluster/state", "/_cluster/state/{metric}", "/_cluster/state/{metric}/{index}"],
+          parts: {
+            "index" => {"type"=>"list", "description"=>"A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices"},
+            "metric" => {"type"=>"list", "options"=>["_all", "blocks", "metadata", "nodes", "routing_table", "routing_nodes", "master_node", "version"], "description"=>"Limit the information returned to the specified metrics"},
+          },
+          params: {
+            "local" => {"type"=>"boolean", "description"=>"Return local information, do not retrieve the state from master node (default: false)"},
+            "master_timeout" => {"type"=>"time", "description"=>"Specify timeout for connection to master"},
+            "flat_settings" => {"type"=>"boolean", "description"=>"Return settings in flat format (default: false)"},
+            "ignore_unavailable" => {"type"=>"boolean", "description"=>"Whether specified concrete indices should be ignored when unavailable (missing or closed)"},
+            "allow_no_indices" => {"type"=>"boolean", "description"=>"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"},
+            "expand_wildcards" => {"type"=>"enum", "options"=>["open", "closed", "none", "all"], "default"=>"open", "description"=>"Whether to expand wildcard expression to concrete indices that are open, closed or both."},
+          }
+        }
+  end
+
+  it "selects valid path parts" do
+    hash = {
+      index: "test",
+      "metric" => "os",
+      nope: "not selected"
+    }
+    selected = @rest_api.select_parts(from: hash)
+
+    refute selected.key?(:nope)
+    assert selected.key?(:index)
+    assert selected.key?("metric")
+  end
+
+  it "selects valid request params" do
+    hash = {
+      local: true,
+      "flat_settings" => true,
+      expand_wildcards: "all",
+      nope: "not selected"
+    }
+    selected = @rest_api.select_params(from: hash)
+
+    refute selected.key?(:nope)
+    assert selected.key?(:local)
+    assert selected.key?("flat_settings")
+    assert selected.key?(:expand_wildcards)
+  end
+
+  it "accesses the documentation url" do
+    assert_equal "https://www.elastic.co/guide/en/elasticsearch/reference/5.x/cluster-state.html", @rest_api.documentation
+  end
+
+  it "exposes the HTTP methods as an Array" do
+    assert_equal %w[GET], @rest_api.methods
+  end
+
+  it "accesses the body settings" do
+    assert_nil @rest_api.body
+  end
+
+  describe "accessing the url" do
+    it "accesses the path" do
+      assert_equal "/_cluster/state", @rest_api.url.path
+    end
+
+    it "exposes the paths as an Array" do
+      assert_equal %w[/_cluster/state /_cluster/state/{metric} /_cluster/state/{metric}/{index}], @rest_api.url.paths
+    end
+
+    it "accesses the path parts" do
+      assert_equal %w[index metric], @rest_api.url.parts.keys
+    end
+
+    it "accesses the request params" do
+      assert_equal %w[local master_timeout flat_settings ignore_unavailable allow_no_indices expand_wildcards], @rest_api.url.params.keys
+    end
+  end
+end

--- a/test/client/rest_api_spec/rest_api_test.rb
+++ b/test/client/rest_api_spec/rest_api_test.rb
@@ -37,6 +37,12 @@ describe Elastomer::Client::RestApiSpec::RestApi do
     assert selected.key?("metric")
   end
 
+  it "identifies valid parts" do
+    assert @rest_api.valid_part? :index
+    assert @rest_api.valid_part? "metric"
+    refute @rest_api.valid_part? :nope
+  end
+
   it "selects valid request params" do
     hash = {
       local: true,
@@ -50,6 +56,12 @@ describe Elastomer::Client::RestApiSpec::RestApi do
     assert selected.key?(:local)
     assert selected.key?("flat_settings")
     assert selected.key?(:expand_wildcards)
+  end
+
+  it "identifies valid params" do
+    assert @rest_api.valid_param? :local
+    assert @rest_api.valid_param? "flat_settings"
+    refute @rest_api.valid_param? :nope
   end
 
   it "accesses the documentation url" do

--- a/test/client/stubbed_client_test.rb
+++ b/test/client/stubbed_client_test.rb
@@ -19,17 +19,4 @@ describe "stubbed client tests" do
       assert_acknowledged h
     end
   end
-
-  describe Elastomer::Client::Nodes do
-    it "performs a shutdown of the node(s)" do
-      @stubs.post("/_cluster/nodes/_all/_shutdown")  { [200, {"Content-Type" => "application/json"}, '{"nodes":{"1":{"name":"Node1"}}}'] }
-      @stubs.post("/_cluster/nodes/node2/_shutdown") { [200, {"Content-Type" => "application/json"}, '{"nodes":{"2":{"name":"Node2"}}}'] }
-
-      h = @client.nodes("_all").shutdown
-      assert_equal "Node1", h["nodes"]["1"]["name"]
-
-      h = @client.nodes("node2").shutdown
-      assert_equal "Node2", h["nodes"]["2"]["name"]
-    end
-  end
 end

--- a/test/client/stubbed_client_test.rb
+++ b/test/client/stubbed_client_test.rb
@@ -4,6 +4,7 @@ describe "stubbed client tests" do
   before do
     @stubs  = Faraday::Adapter.lookup_middleware(:test)::Stubs.new
     @client = Elastomer::Client.new :adapter => [:test, @stubs]
+    @client.instance_variable_set(:@version, "5.6.4")
   end
 
   describe Elastomer::Client::Cluster do
@@ -16,12 +17,6 @@ describe "stubbed client tests" do
       commands = { :move => { :index => "test", :shard => 0, :from_node => "node1", :to_node => "node2" }}
       h = @client.cluster.reroute commands, :dry_run => true
       assert_acknowledged h
-    end
-
-    it "performs a shutdown of the cluster" do
-      @stubs.post("/_shutdown") { [200, {"Content-Type" => "application/json"}, '{"cluster_name":"elasticsearch"}'] }
-      h = @client.cluster.shutdown
-      assert_equal "elasticsearch", h["cluster_name"]
     end
   end
 

--- a/test/middleware/opaque_id_test.rb
+++ b/test/middleware/opaque_id_test.rb
@@ -15,9 +15,6 @@ describe Elastomer::Middleware::OpaqueId do
         ]
       }
 
-      stub.get("/") { |env|
-        [ 200, {}, {"version" => {"number" => "1.0.0"}}  ]
-      }
       stub.get("/_cluster/state") { |env|
         [ 200, {"X-Opaque-Id" => "00000000-0000-0000-0000-000000000000"}, %q[{"foo":"bar"}] ]
       }
@@ -28,6 +25,7 @@ describe Elastomer::Middleware::OpaqueId do
         :adapter   => [:test, stubs]
 
     @client = Elastomer::Client.new opts
+    @client.instance_variable_set(:@version, "5.6.4")
   end
 
   it 'generates an "X-Opaque-Id" header' do

--- a/test/notifications_test.rb
+++ b/test/notifications_test.rb
@@ -39,11 +39,6 @@ describe Elastomer::Notifications do
     nodes.hot_threads; assert_action_event("nodes.hot_threads")
   end
 
-  it "instruments node shutdown" do
-    client = stub_client(:post, "/_cluster/nodes/_shutdown")
-    client.nodes.shutdown; assert_action_event("nodes.shutdown")
-  end
-
   it "instruments index actions" do
     @index.exists?; assert_action_event("index.exists")
     @index.create(default_index_settings)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,10 +30,11 @@ require "elastomer/client"
 # we are going to use the same client instance everywhere!
 # the client should always be stateless
 $client_params = {
-  :port => ENV.fetch("ES_PORT", 9200),
-  :read_timeout => 10,
-  :open_timeout => 1,
-  :opaque_id => false
+  port: ENV.fetch("ES_PORT", 9200),
+  read_timeout: 10,
+  open_timeout: 1,
+  opaque_id: false,
+  strict_params: true
 }
 $client = Elastomer::Client.new $client_params
 


### PR DESCRIPTION
This PR implements validation of the request parameters before sending requests to the Elasticsearch REST API endpoints. Specifically, it ensures that we only send parameters that Elasticsearch is expecting.

There are two parts to this implementation.

### REST API Spec Generator

Elasticsearch declares a [REST API Spec](https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/api) which is a collection of JSON files describing the URLs and parameters that Elasticsearch understands. This PR introduces the [`script/generate-rest-api-spec`](https://github.com/github/elastomer-client/blob/parameter-validation/script/generate-rest-api-spec) script which downloads these JSON documents and parses them into Ruby classes usable by `elastomer-client`.

The generator script produces an [`ApiSpec`](https://github.com/github/elastomer-client/blob/parameter-validation/lib/elastomer/client/rest_api_spec/api_spec.rb) class that contains descriptions of all the [`RestApi`](https://github.com/github/elastomer-client/blob/parameter-validation/lib/elastomer/client/rest_api_spec/rest_api.rb) endpoints. The versions generated thus far are:

* [`ApiSpecV2_3`](https://github.com/github/elastomer-client/blob/parameter-validation/lib/elastomer/client/rest_api_spec/api_spec_v2_3.rb)
* [`ApiSpecV2_4`](https://github.com/github/elastomer-client/blob/parameter-validation/lib/elastomer/client/rest_api_spec/api_spec_v2_4.rb)
* [`ApiSpecV5_6`](https://github.com/github/elastomer-client/blob/parameter-validation/lib/elastomer/client/rest_api_spec/api_spec_v5_6.rb)

The specific API spec version is lazily loaded by the [`Elastomer::Client#api_spec`](https://github.com/github/elastomer-client/blob/parameter-validation/lib/elastomer/client.rb#L102) method. 

### Selecting Params

Each invocation of the [`Elastomer::Client#request`](https://github.com/github/elastomer-client/blob/parameter-validation/lib/elastomer/client.rb#L204) method now passes along a `:rest_api` identifier. This identifier is used to lookup the appropriate `RestApi` descriptor from the `ApiSpec`. The request parameters are filtered according the API spec.

You can find this filtering in the [`Elastomer::Client#expand_path`](https://github.com/github/elastomer-client/blob/parameter-validation/lib/elastomer/client.rb#L343) method.

### Remaining Tasks

What remains now is to add this `:rest_api` identifier to **all** the client requests made in the `elastomer-client` gem. This is a bit of detail work and it should be done in a day.

With this parameter validation in place, we can revisit the logic implemented in the [`VersionSupport`](https://github.com/github/elastomer-client/blob/parameter-validation/lib/elastomer/version_support.rb) class.

/cc @elireisman && @look 