### PR TITLE
Show conflicting opaque IDs in exception message

### DIFF
--- a/docker/docker-compose.cibuild.yml
+++ b/docker/docker-compose.cibuild.yml
@@ -4,5 +4,5 @@ networks:
   default:
     ipam:
       config:
-        - subnet: 192.168.42.0/26
-          gateway: 192.168.42.1
+        - subnet: 192.168.0.0/26
+          gateway: 192.168.0.1

--- a/docker/docker-compose.cibuild.yml
+++ b/docker/docker-compose.cibuild.yml
@@ -4,5 +4,5 @@ networks:
   default:
     ipam:
       config:
-        - subnet: 192.168.0.0/26
-          gateway: 192.168.0.1
+        - subnet: 192.168.42.0/26
+          gateway: 192.168.42.1

--- a/lib/elastomer/middleware/opaque_id.rb
+++ b/lib/elastomer/middleware/opaque_id.rb
@@ -32,8 +32,10 @@ module Elastomer
         env[:request_headers][X_OPAQUE_ID] = uuid
 
         @app.call(env).on_complete do |renv|
-          if uuid != renv[:response_headers][X_OPAQUE_ID]
-            raise ::Elastomer::Client::OpaqueIdError, "conflicting 'X-Opaque-Id' headers"
+          response_uuid = renv[:response_headers][X_OPAQUE_ID]
+          if uuid != response_uuid
+            raise ::Elastomer::Client::OpaqueIdError,
+                  "Conflicting 'X-Opaque-Id' headers: request #{uuid.inspect}, response #{response_uuid.inspect}"
           end
         end
       end


### PR DESCRIPTION
To help debug Opaque ID exceptions, this PR includes the request and response UUIDs in the exception message raised when conflicting Opaque IDs are detected.