### PR TITLE
Compress request bodies

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -117,6 +117,7 @@ module Elastomer
         conn.response(:parse_json)
         conn.request(:opaque_id) if @opaque_id
         conn.request(:limit_size, max_request_size: max_request_size) if max_request_size
+        conn.request(:elastomer_compress, lazy_supports_gzip: lambda { version_support.supports_gzip? })
 
         if @adapter.is_a?(Array)
           conn.adapter(*@adapter)

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -32,11 +32,14 @@ module Elastomer
     #   :max_retries      - the maximum number of request retires (defaults to 0)
     #   :retry_delay      - delay in seconds between retries (defaults to 0.075)
     #   :strict_params    - set to `true` to raise exceptions when invalid request params are used
+    #   :es_version       - set to the Elasticsearch version (example: "5.6.6") to avoid an HTTP request to get the version.
+    #   :compress_body    - set to true to enable request body compression (default: false)
+    #   :compression      - The compression level (0-9) when request body compression is enabled (default: Zlib::DEFAULT_COMPRESSION)
     #
     def initialize(host: "localhost", port: 9200, url: nil,
                    read_timeout: 5, open_timeout: 2, max_retries: 0, retry_delay: 0.075,
                    opaque_id: false, adapter: Faraday.default_adapter, max_request_size: MAX_REQUEST_SIZE,
-                   strict_params: false)
+                   strict_params: false, es_version: nil, compress_body: false, compression: Zlib::DEFAULT_COMPRESSION)
 
       @url = url || "http://#{host}:#{port}"
 
@@ -52,12 +55,18 @@ module Elastomer
       @opaque_id        = opaque_id
       @max_request_size = max_request_size
       @strict_params    = strict_params
+      @es_version       = es_version
+      @compress_body    = compress_body
+      @compression      = compression
     end
 
     attr_reader :host, :port, :url
     attr_reader :read_timeout, :open_timeout
     attr_reader :max_retries, :retry_delay, :max_request_size
     attr_reader :strict_params
+    attr_reader :es_version
+    attr_reader :compress_body
+    attr_reader :compression
     alias :strict_params? :strict_params
 
     # Returns a duplicate of this Client connection configured in the exact same
@@ -83,6 +92,8 @@ module Elastomer
 
     # Returns the version String of the attached Elasticsearch instance.
     def version
+      return es_version unless es_version.nil?
+
       @version ||= begin
         response = get "/"
         response.body.dig("version", "number")
@@ -117,7 +128,7 @@ module Elastomer
         conn.response(:parse_json)
         conn.request(:opaque_id) if @opaque_id
         conn.request(:limit_size, max_request_size: max_request_size) if max_request_size
-        conn.request(:elastomer_compress, lazy_supports_gzip: lambda { version_support.supports_gzip? })
+        conn.request(:elastomer_compress, compression: compression) if compress_body
 
         if @adapter.is_a?(Array)
           conn.adapter(*@adapter)

--- a/lib/elastomer/middleware/compress.rb
+++ b/lib/elastomer/middleware/compress.rb
@@ -11,6 +11,8 @@ module Elastomer
     class Compress < Faraday::Middleware
       CONTENT_ENCODING = "Content-Encoding"
       GZIP = "gzip"
+      # An Ethernet packet can hold 1500 bytes. No point in compressing anything smaller than that (plus some wiggle room).
+      MIN_BYTES_FOR_COMPRESSION = 1400
 
       attr_reader :compression
 
@@ -23,7 +25,7 @@ module Elastomer
 
       def call(env)
         if body = env[:body]
-          if body.is_a?(String)
+          if body.is_a?(String) && body.bytesize > MIN_BYTES_FOR_COMPRESSION
             output = StringIO.new
             output.set_encoding("BINARY")
             gz = Zlib::GzipWriter.new(output, compression, Zlib::DEFAULT_STRATEGY)

--- a/lib/elastomer/middleware/compress.rb
+++ b/lib/elastomer/middleware/compress.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "stringio"
-require "zlib"
 
 module Elastomer
   module Middleware
@@ -9,33 +8,25 @@ module Elastomer
     #
     # It will only compress when there is a request body that is a String. This
     # middleware should be inserted after JSON serialization.
-    #
-    # The check for whether or not this is supported is lazy because you can't
-    # get a VersionSupport without fetching the ES version from the server,
-    # which requires a connection.
     class Compress < Faraday::Middleware
       CONTENT_ENCODING = "Content-Encoding"
       GZIP = "gzip"
 
-      attr_reader :lazy_supports_gzip
+      attr_reader :compression
 
       # options - The Hash of "keyword" arguments.
-      #           :lazy_supports_gzip - a lambda that returns true or false.
+      #           :compression - the compression level (0-9, default Zlib::DEFAULT_COMPRESSION)
       def initialize(app, options = {})
         super(app)
-        @lazy_supports_gzip = options.fetch(:lazy_supports_gzip)
-      end
-
-      def es_supports_gzip?
-        @es_supports_gzip ||= lazy_supports_gzip.call
+        @compression = options[:compression] || Zlib::DEFAULT_COMPRESSION
       end
 
       def call(env)
-        if body = env[:body] && es_supports_gzip?
+        if body = env[:body]
           if body.is_a?(String)
             output = StringIO.new
             output.set_encoding("BINARY")
-            gz = Zlib::GzipWriter.new(output, Zlib::DEFAULT_COMPRESSION, Zlib::DEFAULT_STRATEGY)
+            gz = Zlib::GzipWriter.new(output, compression, Zlib::DEFAULT_STRATEGY)
             gz.write(env[:body])
             gz.close
             env[:body] = output.string

--- a/lib/elastomer/middleware/compress.rb
+++ b/lib/elastomer/middleware/compress.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "stringio"
+require "zlib"
+
+module Elastomer
+  module Middleware
+    # Request middleware that compresses request bodies with GZip for supported
+    # versions of Elasticsearch.
+    #
+    # It will only compress when there is a request body that is a String. This
+    # middleware should be inserted after JSON serialization.
+    #
+    # The check for whether or not this is supported is lazy because you can't
+    # get a VersionSupport without fetching the ES version from the server,
+    # which requires a connection.
+    class Compress < Faraday::Middleware
+      CONTENT_ENCODING = "Content-Encoding"
+      GZIP = "gzip"
+
+      attr_reader :lazy_supports_gzip
+
+      # options - The Hash of "keyword" arguments.
+      #           :lazy_supports_gzip - a lambda that returns true or false.
+      def initialize(app, options = {})
+        super(app)
+        @lazy_supports_gzip = options.fetch(:lazy_supports_gzip)
+      end
+
+      def es_supports_gzip?
+        @es_supports_gzip ||= lazy_supports_gzip.call
+      end
+
+      def call(env)
+        if body = env[:body] && es_supports_gzip?
+          if body.is_a?(String)
+            output = StringIO.new
+            output.set_encoding("BINARY")
+            gz = Zlib::GzipWriter.new(output, Zlib::DEFAULT_COMPRESSION, Zlib::DEFAULT_STRATEGY)
+            gz.write(env[:body])
+            gz.close
+            env[:body] = output.string
+            env[:request_headers][CONTENT_ENCODING] = GZIP
+          end
+        end
+
+        @app.call(env)
+      end
+    end
+  end
+end
+
+Faraday::Request.register_middleware(elastomer_compress: ::Elastomer::Middleware::Compress)

--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -161,6 +161,11 @@ module Elastomer
       end
     end
 
+    # ES 5.X supports GZip-compressed request bodies, but ES 2.4 doesn't?
+    def supports_gzip?
+      es_version_5_x?
+    end
+
     private
 
     # Internal: Helper to reject arguments that shouldn't be passed because

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -171,6 +171,15 @@ describe Elastomer::Client do
       assert_match(/[\d\.]+/, $client.version)
     end
 
+    it "does not make an HTTP request for version if it is provided at create time" do
+      request = stub_request(:get, "#{$client.url}/")
+
+      client = Elastomer::Client.new $client_params.merge(es_version: "5.6.6")
+      assert_equal "5.6.6", client.version
+
+      assert_not_requested request
+    end
+
     it "gets semantic version" do
       version_string = $client.version
       assert_equal Semantic::Version.new(version_string), $client.semantic_version

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,6 +43,17 @@ raise "No server available at #{$client.url}" unless $client.available?
 
 puts "Elasticsearch version is #{$client.version}"
 
+# COMPATIBILITY
+# Returns true if the Elasticsearch cluster defaults to supporting compression.
+def supports_compressed_bodies_by_default?
+  $client.version_support.es_version_5_x?
+end
+
+# Now that we have the version, re-create the client with compression if supported.
+if supports_compressed_bodies_by_default?
+  $client = Elastomer::Client.new $client_params.merge(compress_body: true)
+end
+
 # remove any lingering test indices from the cluster
 MiniTest.after_run do
   $client.cluster.indices.keys.each do |name|


### PR DESCRIPTION
This unconditionally compresses request bodies for requests to ES 5.x servers.

Some thoughts about this code:

* ~Since this is a configurable behavior in ES, it'd probably be better to pass in whether or not you want compression as a flag to the client.~ UPDATE: I have made this change.
* ~It probably makes sense to only compress request bodies over a certain size. Thoughts on what that should be?~ UPDATE: I used roughly the MTU for an Ethernet packet (1500 bytes, I went with 1400).
* ~The compression level is `Zlib::DEFAULT_COMPRESSION` which is level 6. If we're worried about CPU we may want to compress at level 1. Or we could make this configurable, too so we can experiment.~ UPDATE: This is now configurable.

