### PR TITLE
Request compressed responses from Elasticsearch

### DIFF
--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", "~> 2.5"
   spec.add_dependency "faraday",     "~> 0.8"
+  spec.add_dependency "faraday_middleware", "~> 0.12"
   spec.add_dependency "multi_json",  "~> 1.12"
   spec.add_dependency "semantic",    "~> 1.6"
 

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -1,5 +1,6 @@
 require "addressable/template"
 require "faraday"
+require "faraday_middleware"
 require "multi_json"
 require "semantic"
 
@@ -113,8 +114,10 @@ module Elastomer
     # Returns a Faraday::Connection
     def connection
       @connection ||= Faraday.new(url) do |conn|
-        conn.request(:encode_json)
         conn.response(:parse_json)
+        # Request compressed responses from ES and decompress them
+        conn.use(:gzip)
+        conn.request(:encode_json)
         conn.request(:opaque_id) if @opaque_id
         conn.request(:limit_size, max_request_size: max_request_size) if max_request_size
 


### PR DESCRIPTION
Add Faraday::Middleware::Gzip to the client to request compressed responses from
Elasticsearch if it is configured to allow that.

This should improve network transfer time at the cost of CPU on the client and
server.