### PR TITLE
Add custom non-fatal error for rejected execution exceptions

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -407,6 +407,7 @@ module Elastomer
         case root_cause["type"]
         when "index_not_found_exception"; raise IndexNotFoundError, response
         when "illegal_argument_exception"; raise IllegalArgument, response
+        when "es_rejected_execution_exception"; raise RejectedExecutionError, response
         when *version_support.query_parse_exception; raise QueryParsingError, response
         end
 

--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -85,13 +85,15 @@ module Elastomer
 
     # Provide some nice errors for common Elasticsearch exceptions. These are
     # all subclasses of the more general RequestError
-    IndexNotFoundError   = Class.new RequestError
-    QueryParsingError    = Class.new RequestError
-    SearchContextMissing = Class.new RequestError
+    IndexNotFoundError     = Class.new RequestError
+    QueryParsingError      = Class.new RequestError
+    SearchContextMissing   = Class.new RequestError
+    RejectedExecutionError = Class.new RequestError
 
-    ServerError.fatal      = false
-    TimeoutError.fatal     = false
-    ConnectionFailed.fatal = false
+    ServerError.fatal            = false
+    TimeoutError.fatal           = false
+    ConnectionFailed.fatal       = false
+    RejectedExecutionError.fatal = false
 
     # Define an Elastomer::Client exception class on the fly for
     # Faraday exception classes that we don't specifically wrap.

--- a/test/client/errors_test.rb
+++ b/test/client/errors_test.rb
@@ -71,6 +71,7 @@ describe Elastomer::Client::Error do
     assert !Elastomer::Client::TimeoutError.fatal, "Timeouts are not fatal"
     assert !Elastomer::Client::ConnectionFailed.fatal, "Connection failures are not fatal"
     assert !Elastomer::Client::ServerError.fatal, "Server errors are not fatal"
+    assert !Elastomer::Client::RejectedExecutionError.fatal, "Rejected execution errors are not fatal"
   end
 
   if parameter_validation?


### PR DESCRIPTION
This pull requests adds a custom `RequestError` subclass for `es_rejected_execution_exception` exceptions.

This error is marked as non-fatal.

* https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/common/util/concurrent/EsRejectedExecutionException.java
* https://aws.amazon.com/premiumsupport/knowledge-center/resolve-429-error-es/