### PR TITLE
Add DocumentAlreadyExistsError exception

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -408,7 +408,10 @@ module Elastomer
         when "index_not_found_exception"; raise IndexNotFoundError, response
         when "illegal_argument_exception"; raise IllegalArgument, response
         when "es_rejected_execution_exception"; raise RejectedExecutionError, response
+        # Elasticsearch 2.x.x root_cause type for document already existing
         when "document_already_exists_exception"; raise DocumentAlreadyExistsError, response
+        # Elasticsearch 5.x.x root_cause type for document already existing
+        when "version_conflict_engine_exception"; raise DocumentAlreadyExistsError, response
         when *version_support.query_parse_exception; raise QueryParsingError, response
         end
 

--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -408,6 +408,7 @@ module Elastomer
         when "index_not_found_exception"; raise IndexNotFoundError, response
         when "illegal_argument_exception"; raise IllegalArgument, response
         when "es_rejected_execution_exception"; raise RejectedExecutionError, response
+        when "document_already_exists_exception"; raise DocumentAlreadyExistsError, response
         when *version_support.query_parse_exception; raise QueryParsingError, response
         end
 

--- a/lib/elastomer/client/errors.rb
+++ b/lib/elastomer/client/errors.rb
@@ -85,10 +85,11 @@ module Elastomer
 
     # Provide some nice errors for common Elasticsearch exceptions. These are
     # all subclasses of the more general RequestError
-    IndexNotFoundError     = Class.new RequestError
-    QueryParsingError      = Class.new RequestError
-    SearchContextMissing   = Class.new RequestError
+    IndexNotFoundError = Class.new RequestError
+    QueryParsingError = Class.new RequestError
+    SearchContextMissing = Class.new RequestError
     RejectedExecutionError = Class.new RequestError
+    DocumentAlreadyExistsError = Class.new RequestError
 
     ServerError.fatal            = false
     TimeoutError.fatal           = false

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -41,6 +41,24 @@ describe Elastomer::Client::Docs do
     @index.delete if @index.exists?
   end
 
+  it "raises error when writing same document twice" do
+    document = {
+      :_id => "documentid",
+      :_type => "doc2",
+      :_op_type => "create",
+      :title => "the author of logging",
+      :author => "pea53"
+    }
+    h = @docs.index document.dup
+
+    assert_created h
+
+    exception = assert_raises(Elastomer::Client::DocumentAlreadyExistsError) do
+      @docs.index document.dup
+    end
+    assert_equal "[doc2][documentid]: document already exists", exception.error["reason"]
+  end
+
   it "autogenerates IDs for documents" do
     h = @docs.index \
           :_type  => "doc2",

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -53,10 +53,9 @@ describe Elastomer::Client::Docs do
 
     assert_created h
 
-    exception = assert_raises(Elastomer::Client::DocumentAlreadyExistsError) do
+    assert_raises(Elastomer::Client::DocumentAlreadyExistsError) do
       @docs.index document.dup
     end
-    assert_equal "[doc2][documentid]: document already exists", exception.error["reason"]
   end
 
   it "autogenerates IDs for documents" do

--- a/test/client/errors_test.rb
+++ b/test/client/errors_test.rb
@@ -65,7 +65,7 @@ describe Elastomer::Client::Error do
     assert Elastomer::Client::ParsingError.fatal, "Parsing error is fatal"
     assert Elastomer::Client::SSLError.fatal, "SSL error is fatal"
     assert Elastomer::Client::RequestError.fatal, "Request error is fatal"
-    assert Elastomer::Client::DocumentAlreadyExistsError.fatal, "Request error is fatal"
+    assert Elastomer::Client::DocumentAlreadyExistsError.fatal, "DocumentAlreadyExistsError error is fatal"
   end
 
   it "has some non-fatal subclasses" do

--- a/test/client/errors_test.rb
+++ b/test/client/errors_test.rb
@@ -65,6 +65,7 @@ describe Elastomer::Client::Error do
     assert Elastomer::Client::ParsingError.fatal, "Parsing error is fatal"
     assert Elastomer::Client::SSLError.fatal, "SSL error is fatal"
     assert Elastomer::Client::RequestError.fatal, "Request error is fatal"
+    assert Elastomer::Client::DocumentAlreadyExistsError.fatal, "Request error is fatal"
   end
 
   it "has some non-fatal subclasses" do


### PR DESCRIPTION
This PR adds a new type of `Elastomer::Errors::RequestError` called `Elastomer::Errors:: DocumentAlreadyExistsError` for when duplicate documents are indexed when `op_type: "create"` is passed along with the document to be indexed.

/cc @elireisman 