### PR TITLE
Bump Elastomer-Client to v3.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.5 (2019-06-26)
+- Add new more granular exception type
+
 ## 3.1.1 (2018-02-24)
 - Output opaque ID information when a conflict is detected
 - Updating the `semantic` gem

--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,5 +1,5 @@
 module Elastomer
-  VERSION = "3.1.4"
+  VERSION = "3.1.5"
 
   def self.version
     VERSION


### PR DESCRIPTION
Hi! this is to bump the version and add a 3.1.5 tag as a prereq to releasing the new RubyGems version 🎉 

I am still battling some problems with my local env that I'm going to ask about in #friction (feel free to drop ideas here if this rings a bell) before I push the release, as I can't even run the test suite locally right now.
