### PR TITLE
Bundler version bump and updated bootstrap script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
-  - rm Gemfile.lock
+  - pwd
   - bundle install
   - wget --quiet --waitretry=1 --retry-connrefused --timeout=10 --output-document=- http://127.0.0.1:9200
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-jdk:
- - oraclejdk8
 rvm:
   - 2.3.8
 env:
@@ -27,3 +25,9 @@ notifications:
   email: false
 
 sudo: false
+jdk:
+ - oraclejdk8
+addons:
+  apt:
+    packages:
+    - oracle-java8-installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 # See: https://docs.travis-ci.com/user/database-setup/#Installing-ElasticSearch-on-trusty-container-based-infrastructure
 install:
   - sudo apt install openjdk-8-jdk
-  - sudo update-java-alternatives --set java-1.8.0-openjdk-amd64
+  - update-java-alternatives -l
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 # See: https://docs.travis-ci.com/user/database-setup/#Installing-ElasticSearch-on-trusty-container-based-infrastructure
 install:
   - sudo apt install openjdk-8-jdk
+  - sudo update-java-alternatives --set openjdk-8-jdk
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 # Configure a specific version of Elasticsearch
 # See: https://docs.travis-ci.com/user/database-setup/#Installing-ElasticSearch-on-trusty-container-based-infrastructure
 install:
+  - sudo apt install openjdk-8-jdk
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 # See: https://docs.travis-ci.com/user/database-setup/#Installing-ElasticSearch-on-trusty-container-based-infrastructure
 install:
   - sudo apt install openjdk-8-jdk
-  - update-java-alternatives -l
+  - sudo update-java-alternatives -l
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ notifications:
   email: false
 
 sudo: false
+dist: trusty
 jdk:
  - oraclejdk8
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 # See: https://docs.travis-ci.com/user/database-setup/#Installing-ElasticSearch-on-trusty-container-based-infrastructure
 install:
   - sudo apt install openjdk-8-jdk
-  - sudo update-java-alternatives --set openjdk-8-jdk
+  - sudo update-java-alternatives --set java-1.8.0-openjdk-amd64
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
 rvm:
-  - 2.3.3
+  - 2.3.8
 env:
   # NOTE: Ancient versions of Elasticsearch have different download URLs
   - ES_VERSION=2.3.5 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz
-  - ES_VERSION=5.6.4 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+  - ES_VERSION=2.4.6 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz
+  - ES_VERSION=5.6.15 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
 
 # Configure a specific version of Elasticsearch
 # See: https://docs.travis-ci.com/user/database-setup/#Installing-ElasticSearch-on-trusty-container-based-infrastructure

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
+  - gem install bundler -v '~> 2.0'
   - bundle install
   - wget --quiet --waitretry=1 --retry-connrefused --timeout=10 --output-document=- http://127.0.0.1:9200
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+jdk:
+ - oraclejdk8
 rvm:
   - 2.3.8
 env:
@@ -10,8 +12,8 @@ env:
 # Configure a specific version of Elasticsearch
 # See: https://docs.travis-ci.com/user/database-setup/#Installing-ElasticSearch-on-trusty-container-based-infrastructure
 install:
-  - sudo apt install openjdk-8-jdk
-  - sudo update-java-alternatives -l
+  # - sudo apt install openjdk-8-jdk
+  # - sudo update-java-alternatives -l
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
-  - gem install bundler -v '~> 2.0'
+  - rm Gemfile.lock
   - bundle install
   - wget --quiet --waitretry=1 --retry-connrefused --timeout=10 --output-document=- http://127.0.0.1:9200
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
-  - pwd
+  - gem install bundler
   - bundle install
   - wget --quiet --waitretry=1 --retry-connrefused --timeout=10 --output-document=- http://127.0.0.1:9200
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Get started by cloning and running a few scripts:
 $ git clone https://github.com/github/elastomer-client.git
 $ cd elastomer-client
 $ script/bootstrap
-$ rake test
+$ bundle exec rake test
 ```
 
 ## Client

--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "multi_json",  "~> 1.12"
   spec.add_dependency "semantic",    "~> 1.6"
 
-  spec.add_development_dependency "bundler",            "~> 1.14"
+  spec.add_development_dependency "bundler",            "~> 2.0"
   spec.add_development_dependency "activesupport",      ">= 3.0"
   spec.add_development_dependency "minitest",           "~> 5.10"
   spec.add_development_dependency "minitest-fail-fast", "~> 0.1.0"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0:a")/.."
 if bundle check 1>/dev/null 2>&1; then
     echo "Gem environment up-to-date"
 else


### PR DESCRIPTION
- Bump the bundler version
- Update the bootstrap `cd` line to use `dirname "$0:a"` which is compatible with both zsh and bash
- make sure to specify `bundle exec` for running tests
