### PR TITLE
Filter basic_auth and token_auth params on client inspection

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -3,6 +3,7 @@ require "faraday"
 require "faraday_middleware"
 require "multi_json"
 require "semantic"
+require "zlib"
 
 require "elastomer/version"
 require "elastomer/version_support"
@@ -10,6 +11,8 @@ require "elastomer/version_support"
 module Elastomer
 
   class Client
+    IVAR_BLACK_LIST = [:@basic_auth, :@token_auth]
+
     MAX_REQUEST_SIZE = 250 * 2**20  # 250 MB
 
     RETRYABLE_METHODS = %i[get head].freeze
@@ -471,6 +474,12 @@ module Elastomer
       @version_support ||= VersionSupport.new(version)
     end
 
+    def inspect
+      public_vars = self.instance_variables.map do |var|
+        "#{var}=#{IVAR_BLACK_LIST.include?(var) ? "[FILTERED]" : instance_variable_get(var).inspect}"
+      end.join(", ")
+      "<##{self.class}:#{self.object_id.to_s(16)} #{public_vars}>"
+    end
   end  # Client
 end  # Elastomer
 

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -88,6 +88,19 @@ describe Elastomer::Client do
     }
   end
 
+  it "hides basic_auth and token_auth params from inspection" do
+    client_params = $client_params.merge(basic_auth: {
+      username: "my_user",
+      password: "my_secret_password"
+    }, token_auth: "my_secret_token")
+    client = Elastomer::Client.new client_params
+    refute_match(/my_user/, client.inspect)
+    refute_match(/my_secret_password/, client.inspect)
+    refute_match(/my_secret_token/, client.inspect)
+    assert_match(/@basic_auth=\[FILTERED\]/, client.inspect)
+    assert_match(/@token_auth=\[FILTERED\]/, client.inspect)
+  end
+
   describe "authorization" do
     it "can use basic authentication" do
       client_params = $client_params.merge(basic_auth: {


### PR DESCRIPTION
- Overrides `Elastomer::Client#inspect` to hide `basic_auth` and `token_auth` params from console output

Depends on #214 
Fixes #212 
