### PR TITLE
Ignore basic_auth unless username and password are present

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -147,10 +147,10 @@ module Elastomer
         conn.options[:timeout]      = read_timeout
         conn.options[:open_timeout] = open_timeout
 
-        if @token_auth.present?
+        if token_auth?
           conn.token_auth(@token_auth)
-        elsif @basic_auth.present?
-          conn.basic_auth(@basic_auth.fetch(:username), @basic_auth.fetch(:password))
+        elsif basic_auth?
+          conn.basic_auth(@basic_auth[:username], @basic_auth[:password])
         end
 
         if @adapter.is_a?(Array)
@@ -482,6 +482,23 @@ module Elastomer
         "#{var}=#{IVAR_BLACK_LIST.include?(var) ? "[FILTERED]" : instance_variable_get(var).inspect}"
       end.join(", ")
       "<##{self.class}:#{self.object_id.to_s(16)} #{public_vars}>"
+    end
+
+    private
+
+    def token_auth?
+      present_for_auth?(@token_auth)
+    end
+
+    def basic_auth?
+      @basic_auth.is_a?(Hash) &&
+        present_for_auth?(@basic_auth[:username]) &&
+        present_for_auth?(@basic_auth[:password])
+    end
+
+    # Cheap implementation of ActiveSupport's Object#present?
+    def present_for_auth?(object)
+      object.respond_to?(:empty?) ? !object.empty? : !!object
     end
   end  # Client
 end  # Elastomer

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -119,6 +119,38 @@ describe Elastomer::Client do
       assert basic_auth_spy.has_been_called_with?("my_user", "my_secret_password")
     end
 
+    it "ignores basic authentication if password is missing" do
+      client_params = $client_params.merge(basic_auth: {
+        username: "my_user"
+      })
+      client = Elastomer::Client.new client_params
+
+      connection = Faraday::Connection.new
+      basic_auth_spy = Spy.on(connection, :basic_auth).and_return(nil)
+
+      Faraday.stub(:new, $client_params[:url], connection) do
+        client.ping
+      end
+
+      refute basic_auth_spy.has_been_called?
+    end
+
+    it "ignores basic authentication if username is missing" do
+      client_params = $client_params.merge(basic_auth: {
+        password: "my_secret_password"
+      })
+      client = Elastomer::Client.new client_params
+
+      connection = Faraday::Connection.new
+      basic_auth_spy = Spy.on(connection, :basic_auth).and_return(nil)
+
+      Faraday.stub(:new, $client_params[:url], connection) do
+        client.ping
+      end
+
+      refute basic_auth_spy.has_been_called?
+    end
+
     it "can use token authentication" do
       client_params = $client_params.merge(token_auth: "my_secret_token")
       client = Elastomer::Client.new client_params


### PR DESCRIPTION
Make sure basic auth is only triggered if there is a username and password present. This will be helpful for folks that are defining their params like so:

```
params = {
  # ...
  basic_auth: {
    username: ENV["basic_auth_username"],
    password: ENV["basic_auth_password"]
  }
}
```

where the `ENV` vars may be blank or nil in some environments.

Fixes #217