### PR TITLE
Bump Webmock version to support Ruby 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.2 (2020-02-25)
+- Update Webmock to ~> 3.5 to support Ruby 2.6+ (#222)
+
 ## 3.2.1 (2019-08-27)
 - Ignore basic_auth unless username and password are present
 

--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest",           "~> 5.10"
   spec.add_development_dependency "minitest-fail-fast", "~> 0.1.0"
   spec.add_development_dependency "minitest-focus",     "~> 1.1", ">= 1.1.2"
-  spec.add_development_dependency "webmock",            "~> 2.3"
+  spec.add_development_dependency "webmock",            "~> 3.5"
   spec.add_development_dependency "awesome_print",      "~> 1.8"
   spec.add_development_dependency "pry-byebug",         "~> 3.4"
   spec.add_development_dependency "spy",                "~> 1.0"

--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,5 +1,5 @@
 module Elastomer
-  VERSION = "3.2.1"
+  VERSION = "3.2.2"
 
   def self.version
     VERSION


### PR DESCRIPTION
Fixes #222 