### PR TITLE
Delete unused variable in test

### DIFF
--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -146,7 +146,6 @@ describe Elastomer::Client::Bulk do
       b.index  '{"author":"pea53", "message":"just a test tweet"}', :_id => 1, :_type => "tweet"
       b.create '{"author":"John Scalzi", "title":"Old Mans War"}',  :_id => 1, :_type => "book"
     end
-    items = h["items"]
 
     assert_kind_of Integer, h["took"]
 


### PR DESCRIPTION
This isn't a blocker, but I happened to notice it as I was preparing to fix
some Ruby 2.7 warnings.