### PR TITLE
Use kwargs explicitly in call to Url.new

### DIFF
--- a/lib/elastomer/client/rest_api_spec/rest_api.rb
+++ b/lib/elastomer/client/rest_api_spec/rest_api.rb
@@ -15,7 +15,7 @@ module Elastomer::Client::RestApiSpec
     def initialize(documentation:, methods:, url:, body: nil)
       @documentation = documentation
       @methods = Array(methods)
-      @url = Url.new(url)
+      @url = Url.new(**url)
       @body = body
     end
 


### PR DESCRIPTION
In Ruby 2.7 passing a Hash to a method that is expecting keyword arguments triggers
a warning.

The `url` value is a Hash here.