### PR TITLE
Upgrade Ruby versions supported by library

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6']
+        ruby-version: ['2.7', '3.0', '3.1']
         ES_VERSION: ['2.4.6', '5.6.15']
         include:
           - ES_VERSION: '2.4.6'

--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-focus",     "~> 1.1", ">= 1.1.2"
   spec.add_development_dependency "webmock",            "~> 3.5"
   spec.add_development_dependency "awesome_print",      "~> 1.8"
-  spec.add_development_dependency "pry-byebug",         "~> 3.4"
+  spec.add_development_dependency "debug",              "~> 1.7.0"
   spec.add_development_dependency "spy",                "~> 1.0"
   spec.add_development_dependency "rake"
 end

--- a/lib/elastomer/notifications.rb
+++ b/lib/elastomer/notifications.rb
@@ -1,3 +1,4 @@
+require "active_support"
 require "active_support/notifications"
 require "securerandom"
 require "elastomer/client"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,5 +5,6 @@ cd "$(dirname "$0:a")/.."
 if bundle check 1>/dev/null 2>&1; then
     echo "Gem environment up-to-date"
 else
-    exec bundle install --binstubs --path vendor/gems "$@"
+    exec bundle install "$@"
+    exec bundle binstubs --all
 fi

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -240,7 +240,7 @@ describe Elastomer::Client::Bulk do
   end
 
   it "rejects documents that excceed the maximum request size" do
-    client = Elastomer::Client.new($client_params.merge(:max_request_size => 300))
+    client = Elastomer::Client.new(**$client_params.merge(:max_request_size => 300))
     index  = client.index(@name)
 
     ary = []

--- a/test/client/repository_test.rb
+++ b/test/client/repository_test.rb
@@ -25,9 +25,9 @@ describe Elastomer::Client::Repository do
   end
 
   it "cannot create a repo without a name" do
-    lambda {
+    _(lambda {
       create_repo(nil)
-    }.must_raise ArgumentError
+    }).must_raise ArgumentError
   end
 
   it "gets repos" do
@@ -67,10 +67,10 @@ describe Elastomer::Client::Repository do
 
   it "cannot update a repo without a name" do
     with_tmp_repo do |repo|
-      lambda {
+      _(lambda {
         settings = repo.get[repo.name]["settings"]
         $client.repository.update(:type => "fs", :settings => settings.merge("compress" => true))
-      }.must_raise ArgumentError
+      }).must_raise ArgumentError
     end
   end
 
@@ -83,9 +83,9 @@ describe Elastomer::Client::Repository do
   end
 
   it "cannot delete a repo without a name" do
-    lambda {
+    _(lambda {
       $client.repository.delete
-    }.must_raise ArgumentError
+    }).must_raise ArgumentError
   end
 
   it "gets snapshots" do

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -93,7 +93,7 @@ describe Elastomer::Client do
       username: "my_user",
       password: "my_secret_password"
     }, token_auth: "my_secret_token")
-    client = Elastomer::Client.new client_params
+    client = Elastomer::Client.new(**client_params)
     refute_match(/my_user/, client.inspect)
     refute_match(/my_secret_password/, client.inspect)
     refute_match(/my_secret_token/, client.inspect)
@@ -107,7 +107,7 @@ describe Elastomer::Client do
         username: "my_user",
         password: "my_secret_password"
       })
-      client = Elastomer::Client.new client_params
+      client = Elastomer::Client.new(**client_params)
 
       connection = Faraday::Connection.new
       basic_auth_spy = Spy.on(connection, :basic_auth).and_return(nil)
@@ -123,7 +123,7 @@ describe Elastomer::Client do
       client_params = $client_params.merge(basic_auth: {
         username: "my_user"
       })
-      client = Elastomer::Client.new client_params
+      client = Elastomer::Client.new(**client_params)
 
       connection = Faraday::Connection.new
       basic_auth_spy = Spy.on(connection, :basic_auth).and_return(nil)
@@ -139,7 +139,7 @@ describe Elastomer::Client do
       client_params = $client_params.merge(basic_auth: {
         password: "my_secret_password"
       })
-      client = Elastomer::Client.new client_params
+      client = Elastomer::Client.new(**client_params)
 
       connection = Faraday::Connection.new
       basic_auth_spy = Spy.on(connection, :basic_auth).and_return(nil)
@@ -153,7 +153,7 @@ describe Elastomer::Client do
 
     it "can use token authentication" do
       client_params = $client_params.merge(token_auth: "my_secret_token")
-      client = Elastomer::Client.new client_params
+      client = Elastomer::Client.new(**client_params)
 
       connection = Faraday::Connection.new
       token_auth_spy = Spy.on(connection, :token_auth).and_return(nil)
@@ -170,7 +170,7 @@ describe Elastomer::Client do
         username: "my_user",
         password: "my_secret_password"
       }, token_auth: "my_secret_token")
-      client = Elastomer::Client.new client_params
+      client = Elastomer::Client.new(**client_params)
 
       connection = Faraday::Connection.new
       basic_auth_spy = Spy.on(connection, :basic_auth).and_return(nil)
@@ -295,7 +295,7 @@ describe Elastomer::Client do
     it "does not make an HTTP request for version if it is provided at create time" do
       request = stub_request(:get, "#{$client.url}/")
 
-      client = Elastomer::Client.new $client_params.merge(es_version: "5.6.6")
+      client = Elastomer::Client.new(**$client_params.merge(es_version: "5.6.6"))
       assert_equal "5.6.6", client.version
 
       assert_not_requested request

--- a/test/middleware/opaque_id_test.rb
+++ b/test/middleware/opaque_id_test.rb
@@ -24,7 +24,7 @@ describe Elastomer::Middleware::OpaqueId do
         :opaque_id => true,
         :adapter   => [:test, stubs]
 
-    @client = Elastomer::Client.new opts
+    @client = Elastomer::Client.new(**opts)
     @client.instance_variable_set(:@version, "5.6.4")
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,7 +36,7 @@ $client_params = {
   opaque_id: false,
   strict_params: true
 }
-$client = Elastomer::Client.new $client_params
+$client = Elastomer::Client.new(**$client_params)
 
 # ensure we have an Elasticsearch server to test with
 raise "No server available at #{$client.url}" unless $client.available?
@@ -51,7 +51,7 @@ end
 
 # Now that we have the version, re-create the client with compression if supported.
 if supports_compressed_bodies_by_default?
-  $client = Elastomer::Client.new $client_params.merge(compress_body: true)
+  $client = Elastomer::Client.new(**$client_params.merge(compress_body: true))
 end
 
 # remove any lingering test indices from the cluster


### PR DESCRIPTION
In preparation for new work on this library, ensure it works with supported versions of Ruby (2.7, 3.0, 3.1) and drop unsupported versions (< 2.7).

Notes:
- Swap out `pry-byebug` for `debug` gem for better debugging
- Add `require "active_support"` to `notifications.rb` to resolve error with `uninitialized constant ActiveSupport::IsolatedExecutionState`
- Update `bootstrap` file to remove deprecation warnings
- Use `**` operator to pass hashes as keyword arguments (due to change in Ruby 3)
- Use Minitest `_` [method](https://www.rubydoc.info/gems/minitest/Minitest/Spec/DSL/InstanceMethods#_-instance_method) to remove deprecated global use of `must_raise`
