### PR TITLE
Change port to use default of 9200

### DIFF
--- a/docker/docker-compose.es24.yml
+++ b/docker/docker-compose.es24.yml
@@ -23,7 +23,7 @@ services:
       - esrepos:/usr/share/elasticsearch/repos
       - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
     ports:
-      - 127.0.0.1:19200:9200
+      - 127.0.0.1:9200:9200
 
 volumes:
   esrepos:

--- a/docker/docker-compose.es56.yml
+++ b/docker/docker-compose.es56.yml
@@ -26,7 +26,7 @@ services:
       - esrepos:/usr/share/elasticsearch/repos
       - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
     ports:
-      - 127.0.0.1:19200:9200
+      - 127.0.0.1:9200:9200
 
 volumes:
   esrepos:

--- a/docs/client.md
+++ b/docs/client.md
@@ -26,25 +26,12 @@ client.port  #=> 9200
 client.url   #=> 'http://localhost:9200'
 ```
 
-[Boxen](https://boxen.github.com) configures Elasticsearch to listen on port
-`19200` instead of the standard port. We can provide either the full URL or just
-a different port number if Elasticsearch is running on `localhost`.
-
-```ruby
-client = Elastomer::Client.new :port => 19200
-client.host  #=> 'localhost'
-client.port  #=> 19200
-client.url   #=> 'http://localhost:19200'
-
-client = Elastomer::Client.new :url => "http://localhost:19200"
-```
-
 Elasticsearch works best with persistent connections. We can use the
 `Net::HTTP::Persistent` adapter with Faraday.
 
 ```ruby
 client = Elastomer::Client.new \
-  :port    => 19200,
+  :port    => 9200,
   :adapter => :net_http_persistent
 ```
 
@@ -59,7 +46,7 @@ timeout can be set for each request.
 
 ```ruby
 client = Elastomer::Client.new \
-  :url          => "http://localhost:19200",
+  :url          => "http://localhost:9200",
   :adapter      => :net_http_persistent,
   :open_timeout => 1,
   :read_timeout => 5
@@ -84,7 +71,7 @@ the `:opaque_id` flag.
 
 ```ruby
 client = Elastomer::Client.new \
-  :url       => "http://localhost:19200",
+  :url       => "http://localhost:9200",
   :adapter   => :net_http_persistent,
   :opaque_id => true
 ```

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -23,7 +23,7 @@ returns a very simple cluster health status report.
 
 ```ruby
 require 'elastomer/client'
-client = Elastomer::Client.new :port => 19200
+client = Elastomer::Client.new :port => 9200
 
 # the current health summary
 client.cluster.health
@@ -126,7 +126,7 @@ module in elastomer-client.
 
 ```ruby
 require 'elastomer/client'
-client = Elastomer::Client.new :port => 19200
+client = Elastomer::Client.new :port => 9200
 
 # gather OS, JVM, and process information from the local node
 client.nodes("_local").info(:info => %w[os jvm process])

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -12,7 +12,7 @@ documents components are equivalent.
 
 ```ruby
 require 'elastomer/client'
-client = Elastomer::Client.new :port => 19200
+client = Elastomer::Client.new :port => 9200
 
 docs1 = client.index("blog").docs("post")
 docs2 = client.docs("blog", "post")

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ called.
 
 ```ruby
 require 'elastomer/client'
-client = Elastomer::Client.new :port => 19200
+client = Elastomer::Client.new :port => 9200
 
 # you can provide an index name
 index = client.index "blog"

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -14,7 +14,7 @@ The event namespace is `request.client.elastomer`.
   :action  => "docs.search",
   :context => nil,
   :body    => "{\"query\":{\"match_all\":{}}}",
-  :url     => #<URI::HTTP:0x007fb6f3e98b60 URL:http://localhost:19200/index-test/_search?size=0>,
+  :url     => #<URI::HTTP:0x007fb6f3e98b60 URL:http://localhost:9200/index-test/_search?size=0>,
   :method  => :get,
   :status  => 200
 }

--- a/script/cibuild
+++ b/script/cibuild
@@ -54,7 +54,7 @@ output_fold() {
 
 trap cleanup EXIT
 
-export ES_PORT=${ES_PORT:-19200}
+export ES_PORT=${ES_PORT:-9200}
 
 es_version=${ES_VERSION:-24}
 docker_compose="docker-compose --file docker/docker-compose.es${es_version}.yml"


### PR DESCRIPTION
Change the port used to run ES locally from 19200 to 9200, which is the default. That makes it easier to run tests and develop locally without having to override the port (e.g., with `ES_PORT`).

**Notes:**
- change in the Docker files
- remove the client.md section on Boxen (no longer used) which talks about running it on 19200
- update anywhere 19200 was used in docs