### PR TITLE
Fix index_test.rb for ES 7

### DIFF
--- a/test/assertions.rb
+++ b/test/assertions.rb
@@ -55,7 +55,11 @@ module Minitest::Assertions
   def assert_mapping_exists(response, type, message = "mapping expected to exist, but doesn't")
     mapping =
       if response.has_key?("mappings")
-        response["mappings"][type]
+        if $client.version_support.es_version_7_plus?
+          response["mappings"]
+        else
+          response["mappings"][type]
+        end
       else
         response[type]
       end
@@ -66,7 +70,11 @@ module Minitest::Assertions
   def assert_property_exists(response, type, property, message = "property expected to exist, but doesn't")
     mapping =
       if response.has_key?("mappings")
-        response["mappings"][type]
+        if $client.version_support.es_version_7_plus?
+          response["mappings"]
+        else
+          response["mappings"][type]
+        end
       else
         response[type]
       end

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -155,7 +155,7 @@ describe Elastomer::Client::Index do
         author: $client.version_support.keyword
       }}}
     end
-    
+
     assert_property_exists @index.mapping[@name], "book", "author"
     assert_property_exists @index.mapping[@name], "book", "title"
 

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -388,7 +388,7 @@ describe Elastomer::Client::Index do
       assert_equal id, percolator.id
     end
 
-    it "performs multi percolate queriess" do
+    it "performs multi percolate queries" do
       # The _percolate endpoint is removed from ES 7, and replaced with percolate queries via _search and _msearch
       if !$client.version_support.es_version_7_plus?
         # COMPATIBILITY

--- a/test/client/multi_search_test.rb
+++ b/test/client/multi_search_test.rb
@@ -162,6 +162,38 @@ describe Elastomer::Client::MultiSearch do
     end
   end
 
+  it "performs suggestion queries using the search endpoint" do
+    populate!
+
+    h = @index.multi_search do |m|
+      m.search({
+        query: {
+          match: {
+            title: "by author"
+          }
+        },
+        suggest: {
+          suggestion1: {
+            text: "by author",
+            term: {
+              field: "author"
+            }
+          }
+        }
+      })
+    end
+
+    response = h["responses"][0]
+
+    if $client.version_support.es_version_7_plus?
+      assert_equal 2, response["hits"]["total"]["value"]
+    else
+      assert_equal 2, response["hits"]["total"]
+    end
+
+    refute_nil response["suggest"], "expected suggester text to be returned"
+  end
+
   def populate!
     @docs.index \
       document_wrapper("book", {


### PR DESCRIPTION
Found a few breaking changes here:
- `_percolate` and `_mpercolate` endpoints removed: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#breaking_60_percolator_changes
- `_suggest` endpoint removed: https://www.elastic.co/guide/en/elasticsearch/reference/5.4/search-suggesters.html
I also added a test for the term suggester to multi_search_test.rb using [this documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-suggesters.html) for reference.
- Using wildcards to get aliases does not raise an error if no match is found. I did not find any documentation for this, but I found documentation on similar behavior for other endpoints - https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_open_close_index_api_allows_wildcard_expressions_that_match_no_indices_by_default

