### PR TITLE
[ES7 upgrade] Fix docs tests and skip percolator and multi percolator tests

### DIFF
--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -225,8 +225,11 @@ module Elastomer
       # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-shards.html
       #
       # Returns the response body as a hash
-      def search_shards(params = {})
-        response = client.get "/{index}{/type}/_search_shards", update_params(params, action: "docs.search_shards", rest_api: "search_shards")
+      def search_shards(params = {}, remove_type_param = false)
+        updated_params = update_params(params, action: "docs.search_shards", rest_api: "search_shards")
+        if remove_type_param then updated_params.delete(:type) end
+
+        response = client.get "/{index}{/type}/_search_shards", updated_params
         response.body
       end
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -11,25 +11,16 @@ describe Elastomer::Client::Docs do
     unless @index.exists?
       @index.create \
         settings: { "index.number_of_shards" => 1, "index.number_of_replicas" => 0 },
-        mappings: {
-          doc1: {
-            _source: { enabled: true }, _all: { enabled: false },
-            properties: {
-              title: $client.version_support.text(analyzer: "standard", term_vector: "with_positions_offsets"),
-              author: $client.version_support.keyword
-            }
-          },
-          doc2: {
-            _source: { enabled: true }, _all: { enabled: false },
-            properties: {
-              title: $client.version_support.text(analyzer: "standard", term_vector: "with_positions_offsets"),
-              author: $client.version_support.keyword
-            }
+        mappings: mappings_wrapper("book", {
+          _source: { enabled: true },
+          properties: {
+            title: $client.version_support.text(analyzer: "standard", term_vector: "with_positions_offsets"),
+            author: $client.version_support.keyword
           }
-        }
+        }, true)
 
       # COMPATIBILITY
-      if requires_percolator_mapping?
+      if !$client.version_support.es_version_7_plus? && requires_percolator_mapping?
         @index.update_mapping("percolator", { properties: { query: { type: "percolator"}}})
       end
 
@@ -44,13 +35,12 @@ describe Elastomer::Client::Docs do
   end
 
   it "raises error when writing same document twice" do
-    document = {
+    document = document_wrapper("book", {
       _id: "documentid",
-      _type: "doc2",
       _op_type: "create",
-      title: "the author of logging",
-      author: "pea53"
-    }
+      title: "Book by Author1",
+      author: "Author1"
+    })
     h = @docs.index document.dup
 
     assert_created h
@@ -62,27 +52,21 @@ describe Elastomer::Client::Docs do
 
   it "autogenerates IDs for documents" do
     h = @docs.index \
-          _type: "doc2",
-          title: "the author of logging",
-          author: "pea53"
+      document_wrapper("book", {
+        _id: nil,
+        title: "Book1 by author 1",
+        author: "Author1"
+      })
 
     assert_created h
     assert_match %r/^\S{20,22}$/, h["_id"]
 
     h = @docs.index \
-          _id: nil,
-          _type: "doc3",
-          title: "the author of rubber-band",
-          author: "grantr"
-
-    assert_created h
-    assert_match %r/^\S{20,22}$/, h["_id"]
-
-    h = @docs.index \
-          _id: "",
-          _type: "doc4",
-          title: "the author of toml",
-          author: "mojombo"
+      document_wrapper("book", {
+        _id: nil,
+        title: "Book2 by author 2",
+        author: "Author2"
+      })
 
     assert_created h
     assert_match %r/^\S{20,22}$/, h["_id"]
@@ -90,52 +74,65 @@ describe Elastomer::Client::Docs do
 
   it "uses the provided document ID" do
     h = @docs.index \
-          _id: "42",
-          _type: "doc2",
-          title: "the author of logging",
-          author: "pea53"
+      document_wrapper("book", {
+        _id: 42,
+        title: "Book1 by author 1",
+        author: "Author1"
+      })
 
     assert_created h
     assert_equal "42", h["_id"]
   end
 
   it "accepts JSON encoded document strings" do
-    h = @docs.index \
-          '{"author":"pea53", "title":"the author of logging"}',
-          id: "42",
-          type: "doc2"
+    if $client.version_support.es_version_7_plus?
+      h = @docs.index \
+        '{"author":"Author1", "title":"Book1 by author 1"}',
+        id: 42
+    else
+      h = @docs.index \
+        '{"author":"Author1", "title":"Book1 by author 1"}',
+        id: 42,
+        type: "book"
+    end
 
     assert_created h
     assert_equal "42", h["_id"]
-
-    h = @docs.index \
-          '{"author":"grantr", "title":"the author of rubber-band"}',
-          type: "doc2"
-
-    assert_created h
-    assert_match %r/^\S{20,22}$/, h["_id"]
   end
 
   describe "indexing directive fields" do
+    before do
+      # Since we set dynamic: strict, adding the above doc to the index throws an error, so update the index to allow dynamic mapping
+      if !$client.version_support.es_version_7_plus?
+        @index.update_mapping "book", { book: { dynamic: "true" } }
+      end
+    end
+
+    after do
+      # Since we set dynamic: strict, adding the above doc to the index throws an error, so update the index to allow dynamic mapping
+      if !$client.version_support.es_version_7_plus?
+        @index.update_mapping "book", { book: { dynamic: "strict" } }
+      end
+    end
+
     it "indexes fields that are not recognized as indexing directives" do
-      doc = {
-        :_id => "12",
-        :_type => "doc2",
-        :title => "The Adventures of Huckleberry Finn",
-        :author => "Mark Twain",
-        :_unknown_1 => "unknown attribute 1",
-        "_unknown_2" => "unknown attribute 2"
-      }
+      doc = document_wrapper("book", {
+        _id: "12",
+        title: "Book1",
+        author: "Author1",
+        _unknown_1: "unknown attribute 1",
+        "_unknown_2": "unknown attribute 2"
+      })
 
       h = @docs.index(doc)
 
       assert_created h
       assert_equal "12", h["_id"]
 
-      indexed_doc = @docs.get(type: "doc2", id: "12")
+      indexed_doc = $client.version_support.es_version_7_plus? ? @docs.get(id: "12") : @docs.get(type: "book", id: "12")
       expected = {
-        "title" => "The Adventures of Huckleberry Finn",
-        "author" => "Mark Twain",
+        "title" => "Book1",
+        "author" => "Author1",
         "_unknown_1" => "unknown attribute 1",
         "_unknown_2" => "unknown attribute 2"
       }
@@ -144,13 +141,12 @@ describe Elastomer::Client::Docs do
     end
 
     it "extracts indexing directives from the document" do
-      doc = {
-        :_id => "12",
-        "_type" => "doc2",
-        :_routing => "author",
-        :title => "The Adventures of Huckleberry Finn",
-        :author => "Mark Twain"
-      }
+      doc = document_wrapper("book", {
+        _id: "12",
+        _routing: "author",
+        title: "Book1",
+        author: "Author1"
+      })
 
       h = @docs.index(doc)
 
@@ -162,10 +158,10 @@ describe Elastomer::Client::Docs do
       refute doc.key?("_type")
       refute doc.key?(:_routing)
 
-      indexed_doc = @docs.get(type: "doc2", id: "12")
+      indexed_doc = $client.version_support.es_version_7_plus? ? @docs.get(id: "12") : @docs.get(type: "book", id: "12")
       expected = {
-        "title" => "The Adventures of Huckleberry Finn",
-        "author" => "Mark Twain",
+        "title" => "Book1",
+        "author" => "Author1"
       }
 
       assert_equal expected, indexed_doc["_source"]
@@ -174,22 +170,20 @@ describe Elastomer::Client::Docs do
     # COMPATIBILITY: Fail fast on known indexing directives that aren't for this version of ES
     it "raises an exception when a known indexing directive from an unsupported version is used" do
       # Symbol keys
-      doc = {
+      doc = document_wrapper("book", {
         _id: "12",
-        _type: "doc2",
-        title: "The Adventures of Huckleberry Finn"
-      }.merge(incompatible_indexing_directive)
+        title: "Book1"
+      }).merge(incompatible_indexing_directive)
 
       assert_raises(Elastomer::Client::IllegalArgument) do
         @docs.index(doc)
       end
 
       # String keys
-      doc = {
+      doc = document_wrapper("book", {
         "_id" => "12",
-        "_type" => "doc2",
-        "title" => "The Adventures of Huckleberry Finn"
-      }.merge(incompatible_indexing_directive.stringify_keys)
+        "title" => "Book1"
+      }).merge(incompatible_indexing_directive.stringify_keys)
 
       assert_raises(Elastomer::Client::IllegalArgument) do
         @docs.index(doc)
@@ -198,49 +192,49 @@ describe Elastomer::Client::Docs do
   end
 
   it "gets documents from the search index" do
-    h = @docs.get id: "1", type: "doc1"
+    h = $client.version_support.es_version_7_plus? ? @docs.get(id: "1") : @docs.get(id: "1", type: "book")
 
     refute_found h
 
     populate!
 
-    h = @docs.get id: "1", type: "doc1"
+    h = $client.version_support.es_version_7_plus? ? @docs.get(id: "1") : @docs.get(id: "1", type: "book")
 
     assert_found h
-    assert_equal "mojombo", h["_source"]["author"]
+    assert_equal "Author1", h["_source"]["author"]
   end
 
-  it "checks if documents exist in the search index" do
-    refute @docs.exists?(id: "1", type: "doc1")
+  it "checks if documents exist in the search indexx" do
+    refute $client.version_support.es_version_7_plus? ? @docs.exists?(id: "1") : @docs.exists?(id: "1", type: "book")
     populate!
 
-    assert @docs.exists?(id: "1", type: "doc1")
+    assert $client.version_support.es_version_7_plus? ? @docs.exists?(id: "1") : @docs.exists?(id: "1", type: "book")
   end
 
   it "checks if documents exist in the search index with .exist?" do
-    refute @docs.exist?(id: "1", type: "doc1")
+    refute $client.version_support.es_version_7_plus? ? @docs.exist?(id: "1") : @docs.exist?(id: "1", type: "book")
     populate!
 
-    assert @docs.exist?(id: "1", type: "doc1")
+    assert $client.version_support.es_version_7_plus? ? @docs.exist?(id: "1") : @docs.exist?(id: "1", type: "book")
   end
 
   it "gets multiple documents from the search index" do
     populate!
 
     h = @docs.multi_get docs: [
-      { _id: 1, _type: "doc1" },
-      { _id: 1, _type: "doc2" }
+      document_wrapper("book", { _id: 1 }),
+      document_wrapper("book", { _id: 2 })
     ]
     authors = h["docs"].map { |d| d["_source"]["author"] }
 
-    assert_equal %w[mojombo pea53], authors
+    assert_equal %w[Author1 Author2], authors
 
-    h = @docs.multi_get({ids: [2, 1]}, type: "doc1")
+    h = $client.version_support.es_version_7_plus? ? @docs.multi_get({ids: [2, 1]}) : @docs.multi_get({ids: [2, 1]}, type: "book")
     authors = h["docs"].map { |d| d["_source"]["author"] }
 
-    assert_equal %w[defunkt mojombo], authors
+    assert_equal %w[Author2 Author1], authors
 
-    h = @index.docs("doc1").multi_get ids: [1, 2, 3, 4]
+    h = @index.docs("book").multi_get ids: [1, 2, 3, 4]
 
     assert_found h["docs"][0]
     assert_found h["docs"][1]
@@ -252,19 +246,19 @@ describe Elastomer::Client::Docs do
     populate!
 
     h = @docs.mget docs: [
-      { _id: 1, _type: "doc1" },
-      { _id: 1, _type: "doc2" }
+      document_wrapper("book", { _id: 1 }),
+      document_wrapper("book", { _id: 2 })
     ]
     authors = h["docs"].map { |d| d["_source"]["author"] }
 
-    assert_equal %w[mojombo pea53], authors
+    assert_equal %w[Author1 Author2], authors
 
-    h = @docs.mget({ids: [2, 1]}, type: "doc1")
+    h = @docs.mget({ids: [2, 1]})
     authors = h["docs"].map { |d| d["_source"]["author"] }
 
-    assert_equal %w[defunkt mojombo], authors
+    assert_equal %w[Author2 Author1], authors
 
-    h = @index.docs("doc1").mget ids: [1, 2, 3, 4]
+    h = @index.docs("book").mget ids: [1, 2, 3, 4]
 
     assert_found h["docs"][0]
     assert_found h["docs"][1]
@@ -274,16 +268,21 @@ describe Elastomer::Client::Docs do
 
   it "deletes documents from the search index" do
     populate!
-    @docs = @index.docs("doc2")
+    @docs = @index.docs("book")
 
     h = @docs.multi_get ids: [1, 2]
     authors = h["docs"].map { |d| d["_source"]["author"] }
 
-    assert_equal %w[pea53 grantr], authors
+    assert_equal %w[Author1 Author2], authors
 
     h = @docs.delete id: 1
 
-    assert h["found"], "expected document to be found"
+    if $client.version_support.es_version_7_plus?
+      assert h["result"], "deleted"
+    else
+      assert h["found"], "expected document to be found"
+    end
+
     h = @docs.multi_get ids: [1, 2]
 
     refute_found h["docs"][0]
@@ -295,7 +294,7 @@ describe Elastomer::Client::Docs do
   end
 
   it "does not care if you delete a document that is not there" do
-    @docs = @index.docs("doc2")
+    @docs = @index.docs("book")
     h = @docs.delete id: 42
 
     refute h["found"], "expected document to not be found"
@@ -303,14 +302,14 @@ describe Elastomer::Client::Docs do
 
   it "deletes documents by query" do
     populate!
-    @docs = @index.docs("doc2")
+    @docs = @index.docs("book")
 
     h = @docs.multi_get ids: [1, 2]
     authors = h["docs"].map { |d| d["_source"]["author"] }
 
-    assert_equal %w[pea53 grantr], authors
+    assert_equal %w[Author1 Author2], authors
 
-    h = @docs.delete_by_query(q: "author:grantr")
+    h = @docs.delete_by_query(q: "author:Author2")
 
     if supports_native_delete_by_query?
       assert_equal(1, h["deleted"])
@@ -340,7 +339,7 @@ describe Elastomer::Client::Docs do
     h = @docs.delete_by_query(
       query: {
         bool: {
-          filter: {term: {author: "pea53"}}
+          filter: {term: {author: "Author1"}}
         }
       }
     )
@@ -354,32 +353,48 @@ describe Elastomer::Client::Docs do
   it "searches for documents" do
     h = @docs.search q: "*:*"
 
-    assert_equal 0, h["hits"]["total"]
+    if $client.version_support.es_version_7_plus?
+      assert_equal 0, h["hits"]["total"]["value"]
+    else
+      assert_equal 0, h["hits"]["total"]
+    end
 
     populate!
 
     h = @docs.search q: "*:*"
 
-    assert_equal 4, h["hits"]["total"]
+    if $client.version_support.es_version_7_plus?
+      assert_equal 2, h["hits"]["total"]["value"]
+    else
+      assert_equal 2, h["hits"]["total"]
+    end
 
-    h = @docs.search q: "*:*", type: "doc1"
+    if !$client.version_support.es_version_7_plus?
+      h = @docs.search q: "*:*", type: "book"
 
-    assert_equal 2, h["hits"]["total"]
+      assert_equal 2, h["hits"]["total"]
+    end
 
     h = @docs.search({
       query: {match_all: {}},
-      post_filter: {term: {author: "defunkt"}}
-    }, type: %w[doc1 doc2])
+      post_filter: {term: {author: "Author1"}}
+    })
 
-    assert_equal 1, h["hits"]["total"]
+    if $client.version_support.es_version_7_plus?
+      assert_equal 1, h["hits"]["total"]["value"]
+    else
+      assert_equal 1, h["hits"]["total"]
+    end
 
     hit = h["hits"]["hits"].first
 
-    assert_equal "the author of resque", hit["_source"]["title"]
+    assert_equal "Book1 by author 1", hit["_source"]["title"]
   end
 
   it "supports the shards search API" do
-    h = @docs.search_shards(type: "docs1")
+    # We add the type param to all requests (type is _doc for ES 7)
+    # But the shards endpoint has to be used without the type param to return the shard data for ES 7
+    h = @docs.search_shards(params={}, remove_type_param = $client.version_support.es_version_7_plus?)
 
     assert h.key?("nodes"), "response contains \"nodes\" information"
     assert h.key?("shards"), "response contains \"shards\" information"
@@ -388,10 +403,10 @@ describe Elastomer::Client::Docs do
 
   it "generates QueryParsingError exceptions on bad input when searching" do
     query = {query: {query_string: {query: "OR should fail"}}}
-    assert_raises(Elastomer::Client::QueryParsingError) { @docs.search(query, type: %w[doc1 doc2]) }
+    assert_raises(Elastomer::Client::QueryParsingError) { @docs.search(query) }
 
     query = {query: {foo_is_not_valid: {}}}
-    assert_raises(Elastomer::Client::QueryParsingError) { @docs.search(query, type: %w[doc1 doc2]) }
+    assert_raises(Elastomer::Client::QueryParsingError) { @docs.search(query) }
   end
 
   it "counts documents" do
@@ -403,23 +418,21 @@ describe Elastomer::Client::Docs do
 
     h = @docs.count q: "*:*"
 
-    assert_equal 4, h["count"]
-
-    h = @docs.count q: "*:*", type: "doc1"
-
     assert_equal 2, h["count"]
 
-    h = @docs.count q: "*:*", type: "doc1,doc2"
+    if !$client.version_support.es_version_7_plus?
+      h = @docs.count(q: "*:*", type: "book")
 
-    assert_equal 4, h["count"]
+      assert_equal 2, h["count"]
+    end
 
     h = @docs.count({
       query: {
         bool: {
-          filter: {term: {author: "defunkt"}}
+          filter: {term: {author: "Author1"}}
         }
       }
-    }, type: %w[doc1 doc2])
+    })
 
     assert_equal 1, h["count"]
   end
@@ -427,17 +440,25 @@ describe Elastomer::Client::Docs do
   it "explains scoring" do
     populate!
 
-    h = @docs.explain({
-      query: {
-        match: {
-          "author" => "defunkt"
+    h = $client.version_support.es_version_7_plus? ?
+      @docs.explain({
+        query: {
+          match: {
+            "author" => "Author1"
+          }
         }
-      }
-    }, type: "doc1", id: 2)
+      }, id: 1)
+      : @docs.explain({
+        query: {
+          match: {
+            "author" => "Author1"
+          }
+        }
+      }, id: 1, type: "book")
 
     assert h["matched"]
 
-    h = @docs.explain(type: "doc2", id: 2, q: "pea53")
+    h = $client.version_support.es_version_7_plus? ? @docs.explain(id: 2, q: "Author1") : @docs.explain(type: "book", id: 2, q: "Author1")
 
     refute h["matched"]
   end
@@ -453,10 +474,10 @@ describe Elastomer::Client::Docs do
       query: {
         filtered: {
           query: {match_all: {}},
-          filter: {term: {author: "defunkt"}}
+          filter: {term: {author: "Author2"}}
         }
       }
-    }, type: %w[doc1 doc2])
+    })
 
     if filtered_query_removed?
       refute h["valid"]
@@ -467,10 +488,10 @@ describe Elastomer::Client::Docs do
     h = @docs.validate({
       query: {
         bool: {
-          filter: {term: {author: "defunkt"}}
+          filter: {term: {author: "Author2"}}
         }
       }
-    }, type: %w[doc1 doc2])
+    })
 
     assert h["valid"]
   end
@@ -478,37 +499,35 @@ describe Elastomer::Client::Docs do
   it "updates documents" do
     populate!
 
-    h = @docs.get id: "1", type: "doc1"
+    h = $client.version_support.es_version_7_plus? ? @docs.get(id: "1") : @docs.get(id: "1", type: "book")
 
     assert_found h
-    assert_equal "mojombo", h["_source"]["author"]
+    assert_equal "Author1", h["_source"]["author"]
 
-    @docs.update({
+    @docs.update(document_wrapper("book", {
       _id: "1",
-      _type: "doc1",
-      doc: {author: "TwP"}
-    })
-    h = @docs.get id: "1", type: "doc1"
+      doc: {author: "Author1.1"}
+    }))
+    h = $client.version_support.es_version_7_plus? ? @docs.get(id: "1") : @docs.get(id: "1", type: "book")
 
     assert_found h
-    assert_equal "TwP", h["_source"]["author"]
+    assert_equal "Author1.1", h["_source"]["author"]
 
     if $client.version >= "0.90"
-      @docs.update({
+      @docs.update(document_wrapper("book", {
         _id: "42",
-        _type: "doc1",
         doc: {
-          author: "TwP",
-          title: "the ineffable beauty of search"
+          author: "Author42",
+          title: "Book42"
         },
         doc_as_upsert: true
-      })
+      }))
 
-      h = @docs.get id: "42", type: "doc1"
+      h = $client.version_support.es_version_7_plus? ? @docs.get(id: "42") : @docs.get(id: "42", type: "book")
 
       assert_found h
-      assert_equal "TwP", h["_source"]["author"]
-      assert_equal "the ineffable beauty of search", h["_source"]["title"]
+      assert_equal "Author42", h["_source"]["author"]
+      assert_equal "Book42", h["_source"]["title"]
     end
   end
 
@@ -519,60 +538,60 @@ describe Elastomer::Client::Docs do
 
     assert_kind_of Integer, response["took"]
 
-    response = @docs.get(id: 1, type: "doc1")
+    response = $client.version_support.es_version_7_plus? ? @docs.get(id: 1) : @docs.get(id: 1, type: "book")
 
     assert_found response
-    assert_equal "mojombo", response["_source"]["author"]
+    assert_equal "Author1", response["_source"]["author"]
   end
 
   it "provides access to term vector statistics" do
     populate!
 
-    response = @docs.termvector type: "doc2", id: 1, fields: "title"
+    response = $client.version_support.es_version_7_plus? ? @docs.termvector(id: 1, fields: "title") : @docs.termvector(type: "book", id: 1, fields: "title")
 
     assert response["term_vectors"]["title"]
     assert response["term_vectors"]["title"]["field_statistics"]
     assert response["term_vectors"]["title"]["terms"]
-    assert_equal %w[author logging of the], response["term_vectors"]["title"]["terms"].keys
+    assert_equal %w[1 author book1 by], response["term_vectors"]["title"]["terms"].keys
   end
 
   it "provides access to term vector statistics with .termvectors" do
     populate!
 
-    response = @docs.termvectors type: "doc2", id: 1, fields: "title"
+    response = $client.version_support.es_version_7_plus? ? @docs.termvectors(id: 1, fields: "title") : @docs.termvectors(type: "book", id: 1, fields: "title")
 
     assert response["term_vectors"]["title"]
     assert response["term_vectors"]["title"]["field_statistics"]
     assert response["term_vectors"]["title"]["terms"]
-    assert_equal %w[author logging of the], response["term_vectors"]["title"]["terms"].keys
+    assert_equal %w[1 author book1 by], response["term_vectors"]["title"]["terms"].keys
   end
 
   it "provides access to term vector statistics with .term_vector" do
     populate!
 
-    response = @docs.term_vector type: "doc2", id: 1, fields: "title"
+    response = $client.version_support.es_version_7_plus? ? @docs.term_vector(id: 1, fields: "title") : @docs.term_vector(type: "book", id: 1, fields: "title")
 
     assert response["term_vectors"]["title"]
     assert response["term_vectors"]["title"]["field_statistics"]
     assert response["term_vectors"]["title"]["terms"]
-    assert_equal %w[author logging of the], response["term_vectors"]["title"]["terms"].keys
+    assert_equal %w[1 author book1 by], response["term_vectors"]["title"]["terms"].keys
   end
 
   it "provides access to term vector statistics with .term_vectors" do
     populate!
 
-    response = @docs.term_vectors type: "doc2", id: 1, fields: "title"
+    response = $client.version_support.es_version_7_plus? ? @docs.term_vectors(id: 1, fields: "title") : @docs.term_vectors(type: "book", id: 1, fields: "title")
 
     assert response["term_vectors"]["title"]
     assert response["term_vectors"]["title"]["field_statistics"]
     assert response["term_vectors"]["title"]["terms"]
-    assert_equal %w[author logging of the], response["term_vectors"]["title"]["terms"].keys
+    assert_equal %w[1 author book1 by], response["term_vectors"]["title"]["terms"].keys
   end
 
   it "provides access to multi term vector statistics" do
     populate!
 
-    response = @docs.multi_termvectors({ids: [1, 2]}, type: "doc2", fields: "title", term_statistics: true)
+    response = $client.version_support.es_version_7_plus? ? @docs.multi_termvectors({ids: [1, 2]}, fields: "title", term_statistics: true) : @docs.multi_termvectors({ids: [1, 2]}, type: "book", fields: "title", term_statistics: true)
     docs = response["docs"]
 
     assert docs
@@ -582,7 +601,7 @@ describe Elastomer::Client::Docs do
   it "provides access to multi term vector statistics with .multi_term_vectors" do
     populate!
 
-    response = @docs.multi_term_vectors({ids: [1, 2]}, type: "doc2", fields: "title", term_statistics: true)
+    response = $client.version_support.es_version_7_plus? ? @docs.multi_term_vectors({ids: [1, 2]}, fields: "title", term_statistics: true) : @docs.multi_term_vectors({ids: [1, 2]}, type: "book", fields: "title", term_statistics: true)
     docs = response["docs"]
 
     assert docs
@@ -590,95 +609,105 @@ describe Elastomer::Client::Docs do
   end
 
   it "percolates a given document" do
-    populate!
+    if !$client.version_support.es_version_7_plus?
+      populate!
 
-    percolator1 = @index.percolator "1"
-    response = percolator1.create query: { match: { author: "pea53" } }
+      percolator1 = @index.percolator "1"
+      response = percolator1.create query: { match: { author: "Author1" } }
 
-    assert response["created"], "Couldn't create the percolator query"
-    percolator2 = @index.percolator "2"
-    response = percolator2.create query: { match: { author: "defunkt" } }
+      assert response["created"], "Couldn't create the percolator query"
+      percolator2 = @index.percolator "2"
+      response = percolator2.create query: { match: { author: "Author2" } }
 
-    assert response["created"], "Couldn't create the percolator query"
-    @index.refresh
+      assert response["created"], "Couldn't create the percolator query"
+      @index.refresh
 
-    response = @index.docs("doc1").percolate(doc: { author: "pea53" })
+      response = @index.docs("book").percolate(doc: { author: "Author1" })
 
-    assert_equal 1, response["matches"].length
-    assert_equal "1", response["matches"][0]["_id"]
+      assert_equal 1, response["matches"].length
+      assert_equal "1", response["matches"][0]["_id"]
+    end
   end
 
   it "percolates an existing document" do
-    populate!
+    if !$client.version_support.es_version_7_plus?
+      populate!
 
-    percolator1 = @index.percolator "1"
-    response = percolator1.create query: { match: { author: "pea53" } }
+      percolator1 = @index.percolator "1"
+      response = percolator1.create query: { match: { author: "Author1" } }
 
-    assert response["created"], "Couldn't create the percolator query"
-    percolator2 = @index.percolator "2"
-    response = percolator2.create query: { match: { author: "defunkt" } }
+      assert response["created"], "Couldn't create the percolator query"
+      percolator2 = @index.percolator "2"
+      response = percolator2.create query: { match: { author: "Author2" } }
 
-    assert response["created"], "Couldn't create the percolator query"
-    @index.refresh
+      assert response["created"], "Couldn't create the percolator query"
+      @index.refresh
 
-    response = @index.docs("doc2").percolate(nil, id: "1")
+      response = @index.docs("book").percolate(nil, id: "1")
 
-    assert_equal 1, response["matches"].length
-    assert_equal "1", response["matches"][0]["_id"]
+      assert_equal 1, response["matches"].length
+      assert_equal "1", response["matches"][0]["_id"]
+    end
   end
 
   it "counts the matches for percolating a given document" do
-    populate!
+    if !$client.version_support.es_version_7_plus?
+      populate!
 
-    percolator1 = @index.percolator "1"
-    response = percolator1.create query: { match: { author: "pea53" } }
+      percolator1 = @index.percolator "1"
+      response = percolator1.create query: { match: { author: "Author1" } }
 
-    assert response["created"], "Couldn't create the percolator query"
-    percolator2 = @index.percolator "2"
-    response = percolator2.create query: { match: { author: "defunkt" } }
+      assert response["created"], "Couldn't create the percolator query"
+      percolator2 = @index.percolator "2"
+      response = percolator2.create query: { match: { author: "Author2" } }
 
-    assert response["created"], "Couldn't create the percolator query"
-    @index.refresh
+      assert response["created"], "Couldn't create the percolator query"
+      @index.refresh
 
-    count = @index.docs("doc1").percolate_count doc: { author: "pea53" }
+      count = @index.docs("book").percolate_count doc: { author: "Author1" }
 
-    assert_equal 1, count
+      assert_equal 1, count
+    end
   end
 
   it "counts the matches for percolating an existing document" do
-    populate!
+    if !$client.version_support.es_version_7_plus?
+      populate!
 
-    percolator1 = @index.percolator "1"
-    response = percolator1.create query: { match: { author: "pea53" } }
+      percolator1 = @index.percolator "1"
+      response = percolator1.create query: { match: { author: "Author1" } }
 
-    assert response["created"], "Couldn't create the percolator query"
-    percolator2 = @index.percolator "2"
-    response = percolator2.create query: { match: { author: "defunkt" } }
+      assert response["created"], "Couldn't create the percolator query"
+      percolator2 = @index.percolator "2"
+      response = percolator2.create query: { match: { author: "Author2" } }
 
-    assert response["created"], "Couldn't create the percolator query"
-    @index.refresh
+      assert response["created"], "Couldn't create the percolator query"
+      @index.refresh
 
-    count = @index.docs("doc2").percolate_count(nil, id: "1")
+      count = @index.docs("book").percolate_count(nil, id: "1")
 
-    assert_equal 1, count
+      assert_equal 1, count
+    end
   end
 
   it "performs multi percolate queries" do
-    @index.percolator("1").create query: { match_all: { } }
-    @index.percolator("2").create query: { match: { author: "pea53" } }
-    @index.refresh
+    if !$client.version_support.es_version_7_plus?
+      @index.percolator("1").create query: { match_all: { } }
+      @index.percolator("2").create query: { match: { author: "Author1" } }
+      @index.refresh
 
-    h = @index.docs("doc2").multi_percolate do |m|
-      m.percolate author: "pea53"
-      m.percolate author: "grantr"
-      m.count({}, { author: "grantr" })
+      h = @index.docs("book").multi_percolate do |m|
+        m.percolate author: "Author1"
+        m.percolate author: "Author2"
+        m.count({}, { author: "Author2" })
+      end
+
+      response1, response2, response3 = h["responses"]
+
+      assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+      assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
+      assert_equal 1, response3["total"]
     end
-
-    response1, response2, response3 = h["responses"]
-
-    assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
-    assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
-    assert_equal 1, response3["total"]
   end
 
   # Create/index multiple documents.
@@ -687,28 +716,18 @@ describe Elastomer::Client::Docs do
   #        nil uses the @docs instance variable.
   def populate!(docs = @docs)
     docs.index \
-      _id: 1,
-      _type: "doc1",
-      title: "the author of gravatar",
-      author: "mojombo"
+      document_wrapper("book", {
+        _id: 1,
+        title: "Book1 by author 1",
+        author: "Author1"
+      })
 
     docs.index \
-      _id: 2,
-      _type: "doc1",
-      title: "the author of resque",
-      author: "defunkt"
-
-    docs.index \
-      _id: 1,
-      _type: "doc2",
-      title: "the author of logging",
-      author: "pea53"
-
-    docs.index \
-      _id: 2,
-      _type: "doc2",
-      title: "the author of rubber-band",
-      author: "grantr"
+      document_wrapper("book", {
+        _id: 2,
+        title: "Book2 by author 2",
+        author: "Author2"
+      })
 
     @index.refresh
   end

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -702,7 +702,7 @@ describe Elastomer::Client::Docs do
     if $client.version_support.es_version_7_plus?
       skip "Multi percolate not supported in ES version #{$client.version}"
     end
-  
+
     @index.percolator("1").create query: { match_all: { } }
     @index.percolator("2").create query: { match: { author: "Author1" } }
     @index.refresh

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -609,105 +609,115 @@ describe Elastomer::Client::Docs do
   end
 
   it "percolates a given document" do
-    if !$client.version_support.es_version_7_plus?
-      populate!
-
-      percolator1 = @index.percolator "1"
-      response = percolator1.create query: { match: { author: "Author1" } }
-
-      assert response["created"], "Couldn't create the percolator query"
-      percolator2 = @index.percolator "2"
-      response = percolator2.create query: { match: { author: "Author2" } }
-
-      assert response["created"], "Couldn't create the percolator query"
-      @index.refresh
-
-      response = @index.docs("book").percolate(doc: { author: "Author1" })
-
-      assert_equal 1, response["matches"].length
-      assert_equal "1", response["matches"][0]["_id"]
+    if $client.version_support.es_version_7_plus?
+      skip "Percolate not supported in ES version #{$client.version}"
     end
+
+    populate!
+
+    percolator1 = @index.percolator "1"
+    response = percolator1.create query: { match: { author: "Author1" } }
+
+    assert response["created"], "Couldn't create the percolator query"
+    percolator2 = @index.percolator "2"
+    response = percolator2.create query: { match: { author: "Author2" } }
+
+    assert response["created"], "Couldn't create the percolator query"
+    @index.refresh
+
+    response = @index.docs("book").percolate(doc: { author: "Author1" })
+
+    assert_equal 1, response["matches"].length
+    assert_equal "1", response["matches"][0]["_id"]
   end
 
   it "percolates an existing document" do
-    if !$client.version_support.es_version_7_plus?
-      populate!
-
-      percolator1 = @index.percolator "1"
-      response = percolator1.create query: { match: { author: "Author1" } }
-
-      assert response["created"], "Couldn't create the percolator query"
-      percolator2 = @index.percolator "2"
-      response = percolator2.create query: { match: { author: "Author2" } }
-
-      assert response["created"], "Couldn't create the percolator query"
-      @index.refresh
-
-      response = @index.docs("book").percolate(nil, id: "1")
-
-      assert_equal 1, response["matches"].length
-      assert_equal "1", response["matches"][0]["_id"]
+    if $client.version_support.es_version_7_plus?
+      skip "Percolate not supported in ES version #{$client.version}"
     end
+
+    populate!
+
+    percolator1 = @index.percolator "1"
+    response = percolator1.create query: { match: { author: "Author1" } }
+
+    assert response["created"], "Couldn't create the percolator query"
+    percolator2 = @index.percolator "2"
+    response = percolator2.create query: { match: { author: "Author2" } }
+
+    assert response["created"], "Couldn't create the percolator query"
+    @index.refresh
+
+    response = @index.docs("book").percolate(nil, id: "1")
+
+    assert_equal 1, response["matches"].length
+    assert_equal "1", response["matches"][0]["_id"]
   end
 
   it "counts the matches for percolating a given document" do
-    if !$client.version_support.es_version_7_plus?
-      populate!
-
-      percolator1 = @index.percolator "1"
-      response = percolator1.create query: { match: { author: "Author1" } }
-
-      assert response["created"], "Couldn't create the percolator query"
-      percolator2 = @index.percolator "2"
-      response = percolator2.create query: { match: { author: "Author2" } }
-
-      assert response["created"], "Couldn't create the percolator query"
-      @index.refresh
-
-      count = @index.docs("book").percolate_count doc: { author: "Author1" }
-
-      assert_equal 1, count
+    if $client.version_support.es_version_7_plus?
+      skip "Percolate not supported in ES version #{$client.version}"
     end
+
+    populate!
+
+    percolator1 = @index.percolator "1"
+    response = percolator1.create query: { match: { author: "Author1" } }
+
+    assert response["created"], "Couldn't create the percolator query"
+    percolator2 = @index.percolator "2"
+    response = percolator2.create query: { match: { author: "Author2" } }
+
+    assert response["created"], "Couldn't create the percolator query"
+    @index.refresh
+
+    count = @index.docs("book").percolate_count doc: { author: "Author1" }
+
+    assert_equal 1, count
   end
 
   it "counts the matches for percolating an existing document" do
-    if !$client.version_support.es_version_7_plus?
-      populate!
-
-      percolator1 = @index.percolator "1"
-      response = percolator1.create query: { match: { author: "Author1" } }
-
-      assert response["created"], "Couldn't create the percolator query"
-      percolator2 = @index.percolator "2"
-      response = percolator2.create query: { match: { author: "Author2" } }
-
-      assert response["created"], "Couldn't create the percolator query"
-      @index.refresh
-
-      count = @index.docs("book").percolate_count(nil, id: "1")
-
-      assert_equal 1, count
+    if $client.version_support.es_version_7_plus?
+      skip "Percolate not supported in ES version #{$client.version}"
     end
+
+    populate!
+
+    percolator1 = @index.percolator "1"
+    response = percolator1.create query: { match: { author: "Author1" } }
+
+    assert response["created"], "Couldn't create the percolator query"
+    percolator2 = @index.percolator "2"
+    response = percolator2.create query: { match: { author: "Author2" } }
+
+    assert response["created"], "Couldn't create the percolator query"
+    @index.refresh
+
+    count = @index.docs("book").percolate_count(nil, id: "1")
+
+    assert_equal 1, count
   end
 
   it "performs multi percolate queries" do
-    if !$client.version_support.es_version_7_plus?
-      @index.percolator("1").create query: { match_all: { } }
-      @index.percolator("2").create query: { match: { author: "Author1" } }
-      @index.refresh
-
-      h = @index.docs("book").multi_percolate do |m|
-        m.percolate author: "Author1"
-        m.percolate author: "Author2"
-        m.count({}, { author: "Author2" })
-      end
-
-      response1, response2, response3 = h["responses"]
-
-      assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
-      assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
-      assert_equal 1, response3["total"]
+    if $client.version_support.es_version_7_plus?
+      skip "Multi percolate not supported in ES version #{$client.version}"
     end
+  
+    @index.percolator("1").create query: { match_all: { } }
+    @index.percolator("2").create query: { match: { author: "Author1" } }
+    @index.refresh
+
+    h = @index.docs("book").multi_percolate do |m|
+      m.percolate author: "Author1"
+      m.percolate author: "Author2"
+      m.count({}, { author: "Author2" })
+    end
+
+    response1, response2, response3 = h["responses"]
+
+    assert_equal ["1", "2"], response1["matches"].map { |match| match["_id"] }.sort
+    assert_equal ["1"], response2["matches"].map { |match| match["_id"] }.sort
+    assert_equal 1, response3["total"]
   end
 
   # Create/index multiple documents.

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -204,7 +204,7 @@ describe Elastomer::Client::Docs do
     assert_equal "Author1", h["_source"]["author"]
   end
 
-  it "checks if documents exist in the search indexx" do
+  it "checks if documents exist in the search index" do
     refute $client.version_support.es_version_7_plus? ? @docs.exists?(id: "1") : @docs.exists?(id: "1", type: "book")
     populate!
 

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -138,4 +138,4 @@ describe Elastomer::Client::MultiPercolate do
     @index.refresh
   end
   # rubocop:enable Metrics/MethodLength
-end
+end unless $client.version_support.es_version_7_plus?

--- a/test/client/multi_percolate_test.rb
+++ b/test/client/multi_percolate_test.rb
@@ -5,6 +5,10 @@ require_relative "../test_helper"
 describe Elastomer::Client::MultiPercolate do
 
   before do
+    if $client.version_support.es_version_7_plus?
+      skip "Multi percolate not supported in ES version #{$client.version}"
+    end
+
     @name  = "elastomer-mpercolate-test"
     @index = $client.index(@name)
 
@@ -138,4 +142,4 @@ describe Elastomer::Client::MultiPercolate do
     @index.refresh
   end
   # rubocop:enable Metrics/MethodLength
-end unless $client.version_support.es_version_7_plus?
+end

--- a/test/client/percolator_test.rb
+++ b/test/client/percolator_test.rb
@@ -5,6 +5,10 @@ require_relative "../test_helper"
 describe Elastomer::Client::Percolator do
 
   before do
+    if $client.version_support.es_version_7_plus?
+      skip "Percolate not supported in ES version #{$client.version}"
+    end
+
     @index = $client.index "elastomer-percolator-test"
     @index.delete if @index.exists?
     @docs = @index.docs("docs")
@@ -64,4 +68,4 @@ describe Elastomer::Client::Percolator do
       assert_raises(ArgumentError) { @index.percolator nil }
     end
   end
-end unless $client.version_support.es_version_7_plus?
+end

--- a/test/client/percolator_test.rb
+++ b/test/client/percolator_test.rb
@@ -64,4 +64,4 @@ describe Elastomer::Client::Percolator do
       assert_raises(ArgumentError) { @index.percolator nil }
     end
   end
-end
+end unless $client.version_support.es_version_7_plus?


### PR DESCRIPTION
This PR fixes tests for docs on ES 7.
I also added changes to skip percolator and multi percolator tests for ES 7, since those endpoints were removed ES 6 onwards and adding new tests will need more changes, and we don't use the percolator endpoints on dotcom.
