### PR TITLE
[ES 7 upgrade] Fix scroller, snapshot, template, delete by query tests

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -16,7 +16,7 @@ module Elastomer
     IVAR_BLACK_LIST = [:@basic_auth, :@token_auth]
     IVAR_NOISY_LIST = [:@api_spec, :@cluster]
 
-    MAX_REQUEST_SIZE = 250 * 2**20  # 250 MB
+    MAX_REQUEST_SIZE = 2**20 * 250  # 250 MB
 
     RETRYABLE_METHODS = %i[get head].freeze
 

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -160,7 +160,7 @@ module Elastomer
     # immediately.
     #
     class Bulk
-      DEFAULT_REQUEST_SIZE = 10 * 2**20  # 10 MB
+      DEFAULT_REQUEST_SIZE = 2**20 * 10  # 10 MB
 
       # Create a new bulk client for handling some of the details of
       # accumulating documents to index and then formatting them properly for

--- a/test/assertions.rb
+++ b/test/assertions.rb
@@ -79,6 +79,6 @@ module Minitest::Assertions
         response[type]
       end
 
-    assert mapping["properties"].has_key?(property), message # rubocop:disable Minitest/AssertWithExpectedArgument
+    assert mapping["properties"].has_key?(property), message
   end
 end

--- a/test/client/app_delete_by_query_test.rb
+++ b/test/client/app_delete_by_query_test.rb
@@ -5,6 +5,10 @@ require_relative "../test_helper"
 describe Elastomer::Client::AppDeleteByQuery do
 
   before do
+    if $client.version_support.es_version_7_plus?
+      skip "app_delete_by_query is not supported in ES version #{$client.version}"
+    end
+
     @index = $client.index "elastomer-delete-by-query-test"
     @index.delete if @index.exists?
     @docs = @index.docs("docs")

--- a/test/client/scroller_test.rb
+++ b/test/client/scroller_test.rb
@@ -7,28 +7,19 @@ describe Elastomer::Client::Scroller do
   before do
     @name  = "elastomer-scroller-test"
     @index = $client.index(@name)
+    @type =  $client.version_support.es_version_7_plus? ? "_doc" : "book"
 
     unless @index.exists?
       @index.create \
         settings: { "index.number_of_shards" => 1, "index.number_of_replicas" => 0 },
-        mappings: {
-          tweet: {
-            _source: { enabled: true }, _all: { enabled: false },
-            properties: {
-              message: $client.version_support.text(analyzer: "standard"),
-              author: $client.version_support.keyword,
-              sorter: { type: "integer" }
-            }
-          },
-          book: {
-            _source: { enabled: true }, _all: { enabled: false },
-            properties: {
-              title: $client.version_support.text(analyzer: "standard"),
-              author: $client.version_support.keyword,
-              sorter: { type: "integer" }
-            }
+        mappings: mappings_wrapper("book", {
+          _source: { enabled: true },
+          properties: {
+            title: $client.version_support.text(analyzer: "standard"),
+            author: $client.version_support.keyword,
+            sorter: { type: "integer" }
           }
-        }
+        }, true)
 
       wait_for_index(@name)
       populate!
@@ -42,65 +33,51 @@ describe Elastomer::Client::Scroller do
   it "scans over all documents in an index" do
     scan = @index.scan '{"query":{"match_all":{}}}', size: 10
 
-    counts = {"tweet" => 0, "book" => 0}
-    scan.each_document { |h| counts[h["_type"]] += 1 }
+    count = 0
+    scan.each_document { |h| count += 1 }
 
-    assert_equal 50, counts["tweet"]
-    assert_equal 25, counts["book"]
-  end
-
-  it "restricts the scan to a single document type" do
-    scan = @index.scan '{"query":{"match_all":{}}}', type: "book"
-
-    counts = {"tweet" => 0, "book" => 0}
-    scan.each_document { |h| counts[h["_type"]] += 1 }
-
-    assert_equal 0, counts["tweet"]
-    assert_equal 25, counts["book"]
+    assert_equal 25, count
   end
 
   it "limits results by query" do
     scan = @index.scan query: { bool: { should: [
-      {match: {author: "pea53"}},
       {match: {title: "17"}}
     ]}}
 
-    counts = {"tweet" => 0, "book" => 0}
-    scan.each_document { |h| counts[h["_type"]] += 1 }
+    count = 0
+    scan.each_document { |h| count += 1 }
 
-    assert_equal 50, counts["tweet"]
-    assert_equal 1, counts["book"]
+    assert_equal 1, count
   end
 
   it "scrolls and sorts over all documents" do
     scroll = @index.scroll({
       query: {match_all: {}},
       sort: {sorter: {order: :asc}}
-    }, type: "tweet")
+    }, type: @type)
 
-    tweets = []
-    scroll.each_document { |h| tweets << h["_id"].to_i }
+    books = []
+    scroll.each_document { |h| books << h["_id"].to_i }
 
-    expected = (0...50).to_a.reverse
+    expected = (0...25).to_a.reverse
 
-    assert_equal expected, tweets
+    assert_equal expected, books
   end
 
   it "propagates URL query strings" do
-    scan = @index.scan(nil, { q: "author:pea53 || title:17" })
+    scan = @index.scan(nil, { q: "title:1 || title:17" })
 
-    counts = {"tweet" => 0, "book" => 0}
-    scan.each_document { |h| counts[h["_type"]] += 1 }
+    count = 0
+    scan.each_document { |h| count += 1 }
 
-    assert_equal 50, counts["tweet"]
-    assert_equal 1, counts["book"]
+    assert_equal 2, count
   end
 
   it "clears one or more scroll IDs" do
     h = $client.start_scroll \
       body: {query: {match_all: {}}},
       index: @index.name,
-      type: "tweet",
+      type: @type,
       scroll: "1m",
       size: 10
 
@@ -122,16 +99,12 @@ describe Elastomer::Client::Scroller do
 
   def populate!
     h = @index.bulk do |b|
-      50.times { |num|
-        b.index %Q({"author":"pea53","message":"this is tweet number #{num}","sorter":#{50-num}}), _id: num, _type: "tweet"
-      }
-    end
-
-    h["items"].each { |item| assert_bulk_index(item) }
-
-    h = @index.bulk do |b|
       25.times { |num|
+      if $client.version_support.es_version_7_plus?
+        b.index %Q({"author":"Pratchett","title":"DiscWorld Book #{num}","sorter":#{25-num}}), _id: num
+      else
         b.index %Q({"author":"Pratchett","title":"DiscWorld Book #{num}","sorter":#{25-num}}), _id: num, _type: "book"
+      end
       }
     end
 

--- a/test/client/scroller_test.rb
+++ b/test/client/scroller_test.rb
@@ -100,11 +100,11 @@ describe Elastomer::Client::Scroller do
   def populate!
     h = @index.bulk do |b|
       25.times { |num|
-      if $client.version_support.es_version_7_plus?
-        b.index %Q({"author":"Pratchett","title":"DiscWorld Book #{num}","sorter":#{25-num}}), _id: num
-      else
-        b.index %Q({"author":"Pratchett","title":"DiscWorld Book #{num}","sorter":#{25-num}}), _id: num, _type: "book"
-      end
+        if $client.version_support.es_version_7_plus?
+          b.index %Q({"author":"Pratchett","title":"DiscWorld Book #{num}","sorter":#{25-num}}), _id: num
+        else
+          b.index %Q({"author":"Pratchett","title":"DiscWorld Book #{num}","sorter":#{25-num}}), _id: num, _type: "book"
+        end
       }
     end
 

--- a/test/client/template_test.rb
+++ b/test/client/template_test.rb
@@ -26,9 +26,9 @@ describe Elastomer::Client::Cluster do
     @template.create({
       template: "test-elastomer*",
       settings: { number_of_shards: 3 },
-      mappings: {
-        doco: { _source: { enabled: false }}
-      }
+      mappings: mappings_wrapper("book", {
+        _source: { enabled: false }
+      })
     })
 
     assert_predicate @template, :exists?, " we now have a cluster-test template"
@@ -36,7 +36,13 @@ describe Elastomer::Client::Cluster do
     template = @template.get
 
     assert_equal [@name], template.keys
-    assert_equal "test-elastomer*", template[@name]["template"]
+
+    if $client.version_support.es_version_7_plus? 
+      assert_equal "test-elastomer*", template[@name]["index_patterns"][0]
+    else
+      assert_equal "test-elastomer*", template[@name]["template"]
+    end
+
     assert_equal "3", template[@name]["settings"]["index"]["number_of_shards"]
   end
 end

--- a/test/client/template_test.rb
+++ b/test/client/template_test.rb
@@ -37,7 +37,7 @@ describe Elastomer::Client::Cluster do
 
     assert_equal [@name], template.keys
 
-    if $client.version_support.es_version_7_plus? 
+    if $client.version_support.es_version_7_plus?
       assert_equal "test-elastomer*", template[@name]["index_patterns"][0]
     else
       assert_equal "test-elastomer*", template[@name]["template"]


### PR DESCRIPTION
This PR fixes scroller, snapshot, template, delete by query tests for ES 7. 
Once this PR merges, all tests should pass for ES 7.

Notes:
- While fixing the native_delete_by_query tests, I found that the default `number_of_shards` for an index in ES 7 is 1, while in ES 5 it was 5. Since ES 7 was only creating 1 shard, deleting by specifying `_routing` values did not work because all the documents were in the same shard ([link to documentation for _routing](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-routing-field.html)). I also noticed that the calculation of the shard number for each document we index has changed in ES 7:

ES 7:
<img width="640" alt="image" src="https://user-images.githubusercontent.com/25975390/210444464-b1005327-8263-4cad-9346-02f733de9a49.png">
ES 5:
<img width="629" alt="image" src="https://user-images.githubusercontent.com/25975390/210444569-d4926693-9c14-4308-81fa-5cc023ecdbb2.png">
I am not sure if and how this routing change in ES 7 affects github/github, but thought it was worth noting.

- app_delete_by_query is [deprecated](https://github.com/github/elastomer-client/blob/main/lib/elastomer/client/app_delete_by_query.rb#L6) ES 5 onwards, so I skipped those tests for ES 7
- The cluster setting `ingest.geoip.downloader.enabled` [defaults to true in ES 7](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/geoip-processor.html#geoip-cluster-settings), which was causing snapshot tests to fail, since we assert that the snapshot we create only has 1 index, but we were getting an additional `.geoip_databases` index. So I just updated the cluster setting [here](https://github.com/github/elastomer-client/blob/richa-d/fixTestsPart5/test/client/snapshot_test.rb#L17-L19) to be set to false so that we only have 1 index.
- Changes to bulk.rb, assertions.rb and client.rb are only to fix rubocop errors