### PR TITLE
Add ES 7 to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['2.7', '3.0', '3.1']
-        ES_VERSION: ['2.4.6', '5.6.15']
+        ES_VERSION: ['2.4.6', '5.6.15', '7.17.8']
         include:
           - ES_VERSION: '2.4.6'
             ES_DOWNLOAD_URL: >-
@@ -20,6 +20,9 @@ jobs:
           - ES_VERSION: '5.6.15'
             ES_DOWNLOAD_URL: >-
               https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.15.tar.gz
+          - ES_VERSION: '7.17.8'
+            ES_DOWNLOAD_URL: >-
+              https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.8-linux-x86_64.tar.gz
     steps:
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: 'wget ${{ matrix.ES_DOWNLOAD_URL }}'
       - run: 'tar -xzf elasticsearch-*.tar.gz'
-      - run: "sed -i '/UseParNewGC/d' ./elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch.in.sh"
       - run: './elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch -d'
       - run: gem install bundler
       - run: bundle install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,8 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['2.7', '3.0', '3.1']
-        ES_VERSION: ['2.4.6', '5.6.15', '7.17.8']
+        ES_VERSION: ['5.6.15', '7.17.8']
         include:
-          - ES_VERSION: '2.4.6'
-            ES_DOWNLOAD_URL: >-
-              https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
           - ES_VERSION: '5.6.15'
             ES_DOWNLOAD_URL: >-
               https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.15.tar.gz


### PR DESCRIPTION
With the previous PR, existing tests now pass against ES 7. Add ES 7 to the workflow file to run the full suite against it.