### PR TITLE
Add ES 7 to the CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['2.7', '3.0', '3.1']
-        ES_VERSION: ['2.4.6', '5.6.15']
+        ES_VERSION: ['2.4.6', '5.6.15', '7.17.8']
         include:
           - ES_VERSION: '2.4.6'
             ES_DOWNLOAD_URL: >-
@@ -20,6 +20,9 @@ jobs:
           - ES_VERSION: '5.6.15'
             ES_DOWNLOAD_URL: >-
               https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.15.tar.gz
+          - ES_VERSION: '7.17.8'
+            ES_DOWNLOAD_URL: >-
+              https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.8-linux-x86_64.tar.gz
     steps:
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,12 +39,8 @@ jobs:
         with:
           path: ./elasticsearch-${{ matrix.ES_VERSION }}
           key: ${{ env.cache-name }}-${{ matrix.ES_VERSION }}
-          restore-keys: |
-            ${{ env.cache-name }}-${{ matrix.ES_VERSION }}
-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+      - if: ${{ steps.cache-elasticsearch.outputs.cache-hit != 'true' }}
         name: Download Elasticsearch
-        continue-on-error: true
         run: |
           wget ${{ matrix.ES_DOWNLOAD_URL }}
           tar -xzf elasticsearch-*.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,22 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - uses: actions/checkout@v3
-      - run: 'wget ${{ matrix.ES_DOWNLOAD_URL }}'
-      - run: 'tar -xzf elasticsearch-*.tar.gz'
+      - name: Cache Elasticsearch
+        id: cache-elasticsearch
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-elasticsearch
+        with:
+          path: ./elasticsearch-${{ matrix.ES_VERSION }}
+          key: ${{ env.cache-name }}-${{ matrix.ES_VERSION }}
+          restore-keys: |
+            ${{ env.cache-name }}-${{ matrix.ES_VERSION }}
+
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: Download Elasticsearch
+        continue-on-error: true
+        run: 'wget ${{ matrix.ES_DOWNLOAD_URL }}'
+        run: 'tar -xzf elasticsearch-*.tar.gz'
       - run: './elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch -d'
       - run: gem install bundler
       - run: bundle install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: 'wget ${{ matrix.ES_DOWNLOAD_URL }}'
       - run: 'tar -xzf elasticsearch-*.tar.gz'
-      - run: "sed -i '/UseParNewGC/d' ./elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch.in.sh"
       - run: './elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch -d'
       - run: gem install bundler
       - run: bundle install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,8 +46,8 @@ jobs:
         name: Download Elasticsearch
         continue-on-error: true
         run: |
-          'wget ${{ matrix.ES_DOWNLOAD_URL }}'
-          'tar -xzf elasticsearch-*.tar.gz'
+          wget ${{ matrix.ES_DOWNLOAD_URL }}
+          tar -xzf elasticsearch-*.tar.gz
       - run: './elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch -d'
       - run: gem install bundler
       - run: bundle install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,8 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['2.7', '3.0', '3.1']
-        ES_VERSION: ['2.4.6', '5.6.15', '7.17.8']
+        ES_VERSION: ['5.6.15', '7.17.8']
         include:
-          - ES_VERSION: '2.4.6'
-            ES_DOWNLOAD_URL: >-
-              https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
           - ES_VERSION: '5.6.15'
             ES_DOWNLOAD_URL: >-
               https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.15.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,9 @@ jobs:
       - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         name: Download Elasticsearch
         continue-on-error: true
-        run: 'wget ${{ matrix.ES_DOWNLOAD_URL }}'
-        run: 'tar -xzf elasticsearch-*.tar.gz'
+        run: |
+          'wget ${{ matrix.ES_DOWNLOAD_URL }}'
+          'tar -xzf elasticsearch-*.tar.gz'
       - run: './elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch -d'
       - run: gem install bundler
       - run: bundle install

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,5 +1,0 @@
-PreCommit:
-  RuboCop:
-    enabled: true
-    problem_on_unmodified_line: ignore
-    flags: ['--fail-level', 'error', '--format', 'emacs']


### PR DESCRIPTION
Now that the existing test suite passes against ES 7, add ES 7 to the CI workflow.

Additionally, ES 2.4.6 was removed from the matrix. The `run: "sed...` line was not compatible with ES 7. While a conditional could be added, support for ES 2 is going away soon so it's simpler to remove that line and version.

The workflow also now uses Actions cache for the unzipped ES 2 and ES 5 binaries. This change speeds up the workflow runs and saves bandwidth by skipping the download step. According to the [Actions documentation](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key), feature branches should use the cache of the default branch, which can be verified once this PR is merged. 

Screenshot of skipping the download step:
<img width="392" alt="image" src="https://user-images.githubusercontent.com/310986/210625519-9081764c-8d27-4c32-878c-707b407f276c.png">

One minor cleanup: removed unused `.overcommit.yml` file.
