### PR TITLE
[ES7 upgrade] Make document APIs work even when type is passed for ES7

### DIFF
--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -597,6 +597,7 @@ module Elastomer
         h = defaults.update params
         h.update overrides unless overrides.nil?
         h[:routing] = h[:routing].join(",") if h[:routing].is_a?(Array)
+        if client.version_support.es_version_7_plus? then h[:type] = "_doc" end
         h
       end
 

--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -597,7 +597,7 @@ module Elastomer
         h = defaults.update params
         h.update overrides unless overrides.nil?
         h[:routing] = h[:routing].join(",") if h[:routing].is_a?(Array)
-        if client.version_support.es_version_7_plus? then h[:type] = "_doc" end
+        h[:type] = "_doc" if client.version_support.es_version_7_plus?
         h
       end
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -720,11 +720,11 @@ describe Elastomer::Client::Docs do
     assert_equal 1, response3["total"]
   end
 
-  it "accepts a type param and does not throw an error for ES7" do 
+  it "accepts a type param and does not throw an error for ES7" do
     if !$client.version_support.es_version_7_plus?
       skip "This test is only needed for ES 7 onwards"
     end
-  
+
     h = @docs.index \
       _id: 1,
       _type: "book",

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -720,6 +720,25 @@ describe Elastomer::Client::Docs do
     assert_equal 1, response3["total"]
   end
 
+  it "accepts a type param and does not throw an error for ES7" do 
+    if !$client.version_support.es_version_7_plus?
+      skip "This test is only needed for ES 7 onwards"
+    end
+  
+    h = @docs.index \
+      _id: 1,
+      _type: "book",
+      title: "Book 1 by author 1",
+      author: "Author 1"
+
+    assert_created h
+    assert_equal "1", h["_id"]
+
+    response1 = @docs.get(id: 1, type: "book")
+
+    assert_equal "1", response1["_id"]
+  end
+
   # Create/index multiple documents.
   #
   # docs - An instance of Elastomer::Client::Docs or Elastomer::Client::Bulk. If

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -760,6 +760,15 @@ describe Elastomer::Client::Docs do
 
     assert_equal %w[Author2 Author1.1], authors
 
+    h = @docs.index \
+    _id: 3,
+    _type: "book",
+    title: "Book 3 by author 3",
+    author: "Author3"
+
+    assert_created h
+    assert_equal "3", h["_id"]
+
     h = @docs.delete id: 3, type: "book"
 
     refute @docs.exists?(id: "3", type: "book")


### PR DESCRIPTION
ES 5 has a type param for all endpoints, while ES 7 does not accept the type param. For ES 7 document APIs, the commonly used endpoints - index, get, delete, exists - need to have an `_doc` in the path. So removing type will not work for document APIs.
Because of this, I decided to add the type param and set it to `_doc`, since this ensures that all the endpoints work as expected. 
To test this change, I added an additional test, which calls all the docs endpoints that we use in dotcom (index, get, update, multi_get, delete, exists, count, search) with a type param.