### PR TITLE
[ES7 upgrade] Allow passing type param for Index APIs

### DIFF
--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -391,6 +391,7 @@ module Elastomer
         response = nil
         begin
           response = call if ready_to_send?(size)
+        # rubocop:disable Lint/UselessRescue
         rescue StandardError => err
           raise err
         ensure

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -147,7 +147,7 @@ module Elastomer
       #
       # Returns the response body as a Hash
       def update_mapping(type, body, params = {})
-        response = client.put "/{index}/_mapping/{type}", update_params(params, body: body, type: type, action: "index.update_mapping", rest_api: "indices.put_mapping")
+        response = client.put "/{index}/_mapping{/type}", update_params(params, body: body, type: type, action: "index.update_mapping", rest_api: "indices.put_mapping")
         response.body
       end
       alias_method :put_mapping, :update_mapping
@@ -585,6 +585,7 @@ module Elastomer
       def update_params(params, overrides = nil)
         h = defaults.update params
         h.update overrides unless overrides.nil?
+        h.delete(:type) if client.version_support.es_version_7_plus?
         h
       end
 

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -116,7 +116,7 @@ describe Elastomer::Client::Index do
     if $client.version_support.es_version_7_plus?
       @index.update_mapping "_doc", { properties: {
         author: $client.version_support.keyword
-      }}, { include_type_name: true }
+      }}
     else
       @index.update_mapping "book", { book: { properties: {
         author: $client.version_support.keyword
@@ -149,7 +149,7 @@ describe Elastomer::Client::Index do
     if $client.version_support.es_version_7_plus?
       @index.put_mapping "_doc", { properties: {
         author: $client.version_support.keyword
-      }}, { include_type_name: true }
+      }}
     else
       @index.put_mapping "book", { book: { properties: {
         author: $client.version_support.keyword
@@ -253,6 +253,28 @@ describe Elastomer::Client::Index do
     tokens = tokens["tokens"].map { |h| h["token"] }
 
     assert_equal %w[just few words analyze], tokens
+  end
+
+  it "accepts a type param and does not throw an error for ES7" do 
+    if !$client.version_support.es_version_7_plus?
+      skip "This test is only needed for ES 7 onwards"
+    end
+  
+    @index.create(
+      mappings: mappings_wrapper("book", {
+        _source: { enabled: false },
+          properties: { title: $client.version_support.text(analyzer: "standard") }
+      }, true)
+    )
+
+    assert_property_exists @index.mapping(type: "book")[@name], "book", "title"
+
+    @index.update_mapping "book", { properties: {
+      author: $client.version_support.keyword
+    }}
+
+    assert_property_exists @index.mapping(type: "book")[@name], "book", "author"
+    assert_property_exists @index.mapping(type: "book")[@name], "book", "title"
   end
 
   describe "when an index does not exist" do

--- a/test/client/index_test.rb
+++ b/test/client/index_test.rb
@@ -255,11 +255,11 @@ describe Elastomer::Client::Index do
     assert_equal %w[just few words analyze], tokens
   end
 
-  it "accepts a type param and does not throw an error for ES7" do 
+  it "accepts a type param and does not throw an error for ES7" do
     if !$client.version_support.es_version_7_plus?
       skip "This test is only needed for ES 7 onwards"
     end
-  
+
     @index.create(
       mappings: mappings_wrapper("book", {
         _source: { enabled: false },


### PR DESCRIPTION
For the index APIs, only 3 endpoints have a type param in ES5 - `exists_type`, `get_mapping` and `put_mapping`. These 3 endpoints have an optional type param in ES7, and if you want to pass the type param, you have to also set `include_type_param` to true. `include_type_param` is deprecated in ES7, and removed from ES8. So I thought it would be better to not use the type param at all for ES7, so I removed the type param from all ES7 index API requests. After these changes, if you do pass a type param to ES7, it will be removed before calling the actual index endpoint.

The test I added checks for `get_mapping` and `update_mapping` only. `exists_type` is deprecated in ES7 and removed from 8. We don't expose that endpoint, and I didn't find any usage of this in dotcom, so I did not add a test for it.