### PR TITLE
[ES upgrade] Fix docs, delete by query tests

### DIFF
--- a/docker/elasticsearch7plus.yml
+++ b/docker/elasticsearch7plus.yml
@@ -10,3 +10,4 @@ path:
 transport.port: 9300
 http.port: 9200
 http.max_content_length: 50mb
+ingest.geoip.downloader.enabled: false

--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -39,8 +39,10 @@ module Elastomer
       else
         raise "bulk request body cannot be nil" if body.nil?
         params ||= {}
+        updated_params = params.merge(body: body, action: "bulk", rest_api: "bulk")
+        updated_params.delete(:type) if $client.version_support.es_version_8_plus?
 
-        response = self.post "{/index}{/type}/_bulk", params.merge(body: body, action: "bulk", rest_api: "bulk")
+        response = self.post "{/index}{/type}/_bulk", updated_params
         response.body
       end
     end

--- a/lib/elastomer/client/native_delete_by_query.rb
+++ b/lib/elastomer/client/native_delete_by_query.rb
@@ -34,7 +34,9 @@ module Elastomer
 
       def execute
         # TODO: Require index parameter. type is optional.
-        response = client.post("/{index}{/type}/_delete_by_query", parameters.merge(body: query, action: "delete_by_query", rest_api: "delete_by_query"))
+        updated_params = parameters.merge(body: query, action: "delete_by_query", rest_api: "delete_by_query")
+        updated_params.delete(:type) if client.version_support.es_version_8_plus?
+        response = client.post("/{index}{/type}/_delete_by_query", updated_params)
         response.body
       end
     end

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -721,7 +721,7 @@ describe Elastomer::Client::Docs do
   end
 
   it "accepts a type param and does not throw an error for ES7" do
-    if !$client.version_support.es_version_7_plus?
+    if !$client.version_support.es_version_7_plus? || $client.version_support.es_version_8_plus?
       skip "This test is only needed for ES 7 onwards"
     end
 


### PR DESCRIPTION
This PR fixes tests for docs and delete by query endpoints.
Note: For the docs endpoints, some endpoints like get and delete still need `_doc` types, while the other endpoints do not accept a type.