### PR TITLE
Fix remaining failing tests for ES 8

### DIFF
--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -543,6 +543,7 @@ module Elastomer
         raise "a block is required" if block.nil?
 
         params = {index: self.name, type: self.type}.merge params
+        params.delete(:type) if client.version_support.es_version_8_plus?
         client.multi_search params, &block
       end
 

--- a/lib/elastomer/client/scroller.rb
+++ b/lib/elastomer/client/scroller.rb
@@ -74,6 +74,7 @@ module Elastomer
     # Returns the response body as a Hash.
     def start_scroll(opts = {})
       opts = opts.merge action: "search.start_scroll", rest_api: "search"
+      opts.delete(:type) if version_support.es_version_8_plus?
       response = get "{/index}{/type}/_search", opts
       response.body
     end


### PR DESCRIPTION
Fix the remaining test failures for ES 8. For the scroller and multi_search tests, the issue was similar to the one mentioned in #246, which is that the `type` param is no longer allowed for certain endpoints.

For the template test, the issue is that for [legacy index templates](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/indices-templates.html), ES 8 now enforces the change from a string `template` parameter to a list of strings named `index_params` ([8.6 doc](https://www.elastic.co/guide/en/elasticsearch/reference/8.6/indices-templates-v1.html)). The test includes ES 7 since the `template` param was deprecated in that version.