### PR TITLE
Update CI for ES 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,12 @@ jobs:
         run: |
           wget ${{ matrix.ES_DOWNLOAD_URL }}
           tar -xzf elasticsearch-*.tar.gz
-      - run: './elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch -d -Expack.security.enabled=false'
+      - if: ${{ matrix.ES_VERSION == '5.6.15' }}
+        name: Run Elasticsearch
+        run: './elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch -d'
+      - if: ${{ matrix.ES_VERSION != '5.6.15' }}
+        name: Run Elasticsearch
+        run: './elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch -d -Expack.security.enabled=false'
       - run: gem install bundler
       - run: bundle install
       - run: script/poll-for-es

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,6 @@ jobs:
             ES_DOWNLOAD_URL: >-
               https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.8-linux-x86_64.tar.gz
     steps:
-      - name: Install dependencies (Ubuntu)
-        if: runner.os == 'Linux'
-        run: |-
-          sudo apt-get update
-          sudo apt-get install -y openjdk-8-jre-headless
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           wget ${{ matrix.ES_DOWNLOAD_URL }}
           tar -xzf elasticsearch-*.tar.gz
-      - run: './elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch -d'
+      - run: './elasticsearch-${{ matrix.ES_VERSION }}/bin/elasticsearch -d -Expack.security.enabled=false'
       - run: gem install bundler
       - run: bundle install
       - run: script/poll-for-es

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
-        ES_VERSION: ['5.6.15', '7.17.8']
+        ruby-version: ['3.0', '3.1', '3.2']
+        ES_VERSION: ['5.6.15', '7.17.8', '8.6.0']
         include:
           - ES_VERSION: '5.6.15'
             ES_DOWNLOAD_URL: >-
@@ -20,6 +20,9 @@ jobs:
           - ES_VERSION: '7.17.8'
             ES_DOWNLOAD_URL: >-
               https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.8-linux-x86_64.tar.gz
+          - ES_VERSION: '8.6.0'
+            ES_DOWNLOAD_URL: >-
+              https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.6.0-linux-x86_64.tar.gz
     steps:
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR adds ES 8 to the CI workflow.

Additionally:
- removes Ruby 2.7 - it will be EOL in about 2 months, so keep the CI process smaller
- removes the "Install dependencies (Ubuntu)" step - shortens build time, as updating isn't necessary, and installing a Java 8 JRE isn't needed (or wanted). ES comes bundled with more modern JREs.
- disables HTTPS for ES 8 (and 7). The command line option doesn't work with the ES 5 binary, so there's a conditional for that step.
