### PR TITLE
Cleanup version_support.rb

### DIFF
--- a/lib/elastomer/version_support.rb
+++ b/lib/elastomer/version_support.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module Elastomer
-  # VersionSupport holds methods that (a) encapsulate version differences; or
-  # (b) give an intention-revealing name to a conditional check.
   class VersionSupport
 
     attr_reader :version
@@ -11,16 +9,12 @@ module Elastomer
     #
     # Raises ArgumentError if version is unsupported.
     def initialize(version)
-      if version < "5.0" || version >= "8.7"
+      if version < "5.0" || version >= "9.0"
         raise ArgumentError, "Elasticsearch version #{version} is not supported by elastomer-client"
       end
 
       @version = version
     end
-
-    # Elasticsearch changes some request formats in a non-backward-compatible
-    # way. Some tests need to know what version is running to structure requests
-    # as expected.
 
     # Returns true if Elasticsearch version is 7.x or higher.
     def es_version_7_plus?
@@ -31,18 +25,5 @@ module Elastomer
     def es_version_8_plus?
       version >= "8.0.0"
     end
-
-    private
-
-    # Internal: Helper to reject arguments that shouldn't be passed because
-    # merging them in would defeat the purpose of a compatibility layer.
-    def reject_args!(args, *names)
-      names.each do |name|
-        if args.include?(name.to_s) || args.include?(name.to_sym)
-          raise ArgumentError, "Argument '#{name}' is not allowed"
-        end
-      end
-    end
-
   end
 end


### PR DESCRIPTION
This PR cleans up the version_support.rb file by removing a few comments and an unused method noticed during a final review of the changes before release. It also bumps the supported version to `< 9.0`. It's reasonable to expect the library to continue working without modification through the 8.x minor releases.