### PR TITLE
Prepare for 4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.0 (2023-02-10)
+- Add ES 7 and ES 8 compatibility for existing functionality
+- Remove ES 2 support
+- Add support for newer Ruby versions (3.0, 3.1, 3.2)
+- Remove support for older Ruby versions (< 3.0)
+
 ## 3.2.3 (2020-02-26)
 - Fix warnings in Ruby 2.7 whan passing a Hash to a method that is expecting keyword arguments
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ docker compose --profile es5 up
 
 ## Releasing
 
-1. Create a new branch from `master`
+1. Create a new branch from `main`
 2. Bump the version number in `lib/elastomer/version.rb`
 3. Update `CHANGELOG.md` with info about the new version
 4. Execute `bin/rake build`. This will place a new gem file in the `pkg/` folder.

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,7 +1,7 @@
 # Elastomer Client Component
 
 All methods in the Elastomer Client gem eventually make an HTTP request to
-Elasticsearch. The [`Elastomer::Client`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client.rb)
+Elasticsearch. The [`Elastomer::Client`](https://github.com/github/elastomer-client/blob/main/lib/elastomer/client.rb)
 class is responsible for connecting to an Elasticsearch instance, making HTTP
 requests, processing the response, and handling errors. Let's look at the
 details of how `Elastomer::Client` handles HTTP communication.
@@ -64,7 +64,7 @@ Elasticsearch provides an `X-Opaque-Id` request header. Any value set in this
 request header will be returned in the corresponding response header. This
 allows the client to correlate the response from Elasticsearch with the request
 that was submitted. We have written an
-[OpaqueId](https://github.com/github/elastomer-client/blob/master/lib/elastomer/middleware/opaque_id.rb)
+[OpaqueId](https://github.com/github/elastomer-client/blob/main/lib/elastomer/middleware/opaque_id.rb)
 middleware that will abort any request if the `X-Opaque-Id` headers disagree
 between the request and the response. You can use this feature by setting
 the `:opaque_id` flag.
@@ -144,7 +144,7 @@ With the [`Addressable::Template`](https://github.com/sporkmonger/addressable#ur
 a typical search URL takes the form `{/index}{/type}/_search`. The `:index` and
 `:type` values are taken from the parameters Hash and combined with the template
 to generate the URL. The internal
-[`expand_path`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client.rb#L245)
+[`expand_path`](https://github.com/github/elastomer-client/blob/main/lib/elastomer/client.rb#L245)
 method handles the URL generation.
 
 Here are a few examples to better illustrate the concept.
@@ -209,7 +209,7 @@ Elastomer client code makes no attempt to retry an operation in the face of an
 error. However, it does classify errors into *fatal* and *retryable* exceptions.
 
 Each class that inherits from
-[`Elastomer::Client::Error`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client/errors.rb)
+[`Elastomer::Client::Error`](https://github.com/github/elastomer-client/blob/main/lib/elastomer/client/errors.rb)
 has a `fatal?` method (and the inverse `retry?` method). If an exception is
 fatal, then the request is fundamentally flawed and should not be retried.
 Passing a malformed search query or trying to search an index that does not

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -4,8 +4,8 @@ The cluster component deals with commands for managing cluster state and
 monitoring cluster health. All the commands found under the
 [cluster API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html)
 section of the Elasticsearch documentation are implemented by the
-[`cluster.rb`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client/cluster.rb)
-module and the [`nodes.rb`](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client/nodes.rb)
+[`cluster.rb`](https://github.com/github/elastomer-client/blob/main/lib/elastomer/client/cluster.rb)
+module and the [`nodes.rb`](https://github.com/github/elastomer-client/blob/main/lib/elastomer/client/nodes.rb)
 module.
 
 ## Cluster

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -94,7 +94,7 @@ locations enables you to reconcile documents between the two.
 The `:_id` field is only one of several special fields that control document
 indexing in Elasticsearch. The full list of supported fields are enumerated in
 the `index`
-[method documentation](https://github.com/github/elastomer-client/blob/master/lib/elastomer/client/docs.rb#L45-56).
+[method documentation](https://github.com/github/elastomer-client/blob/main/lib/elastomer/client/docs.rb#L45-56).
 
 As a parting note, you can also provide the index name and document type as part
 of the document itself. These fields will be extracted from the document before

--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Elastomer
-  VERSION = "3.2.3"
+  VERSION = "4.0.0"
 
   def self.version
     VERSION


### PR DESCRIPTION
This PR bumps the version to 4.0.0 and updates the CHANGELOG with latest high-level work.