### PR TITLE
Fix version_support check in bulk class

### DIFF
--- a/lib/elastomer/client/bulk.rb
+++ b/lib/elastomer/client/bulk.rb
@@ -40,7 +40,7 @@ module Elastomer
         raise "bulk request body cannot be nil" if body.nil?
         params ||= {}
         updated_params = params.merge(body: body, action: "bulk", rest_api: "bulk")
-        updated_params.delete(:type) if $client.version_support.es_version_8_plus?
+        updated_params.delete(:type) if version_support.es_version_8_plus?
 
         response = self.post "{/index}{/type}/_bulk", updated_params
         response.body


### PR DESCRIPTION
Update bulk method to remove `$client` call for `version_support`
`$client` is only available in test methods, and `version_support` is available to call directly on the `bulk` method due to reopening the `Client` class