### PR TITLE
Update version to 4.0.1

### DIFF
--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Elastomer
-  VERSION = "4.0.0"
+  VERSION = "4.0.1"
 
   def self.version
     VERSION


### PR DESCRIPTION
Update `Elastomer` version to `4.0.1` in order to release a new tag