### PR TITLE
Do not prefix certain params passed to the Bulk API with underscores.

### DIFF
--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -319,6 +319,20 @@ describe Elastomer::Client::Bulk do
     assert_equal "Book 1", @index.docs("book").get(id: 2)["_source"]["title"]
   end
 
+  it "supports the routing parameter on index actions" do
+    document = document_wrapper("book", { _id: 1, title: "Book 1" })
+
+    response = @index.bulk do |b|
+      b.index document, { routing: "custom" }
+    end
+
+    items = response["items"]
+
+    assert_kind_of Integer, response["took"]
+    assert_bulk_index(items[0])
+    assert_equal "custom", @index.docs("book").get(id: 1)["_routing"]
+  end
+
   it "streams bulk responses" do
     ops = [
       [:index, document_wrapper("book", { title: "Book 1" }), { _id: 1, _index: @index.name }],


### PR DESCRIPTION
Closes https://github.com/github/elastomer-client/issues/256.

As per [these docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/breaking-changes-7.0.html#_camel_case_and_underscore_parameters_deprecated_in_6_x_have_been_removed), as of ES 7 certain params  (e.g. `_routing`) should be passed to the ES Bulk API without the underscore prefix. This ensures that we don't add the underscore prefix to just those params.

## Approach

- I refactored the special key handling to make it a bit easier to follow (previously, the variable names were very terse, and it was difficult to understand the distinction between key and value in `SPECIAL_KEYS_HASH`). Now the logic is driven by two arrays, and we prefix the values of those arrays just-in-time when necessary.
- I stopped adding an underscore prefix to just the keys listed in the documentation above. The result is that you might still receive an `IllegalArgument` error from the API if you use an unsupported underscored param, but you should always get the correct result if you use the correct params.