### PR TITLE
Bump to version 4.0.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.2 (2023-03-03)
+- Fix ES 7+ handling of params like `routing` that were prefixed with an underscore in earlier versions
+
 ## 4.0.1 (2023-02-10)
 - Fix a bug in the bulk API interface that prevents a version check from working correctly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1 (2023-02-10)
+- Fix a bug in the bulk API interface that prevents a version check from working correctly
+
 ## 4.0.0 (2023-02-10)
 - Add ES 7 and ES 8 compatibility for existing functionality
 - Remove ES 2 support

--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Elastomer
-  VERSION = "4.0.1"
+  VERSION = "4.0.2"
 
   def self.version
     VERSION


### PR DESCRIPTION
This bumps the version of this gem to `4.0.2` in order to package the fix for #256.

I have tested that the new version of the gem works properly in a local environment as per https://github.com/github/elastomer-client#releasing.