### PR TITLE
Merge old and new query_values

### DIFF
--- a/lib/elastomer/client.rb
+++ b/lib/elastomer/client.rb
@@ -387,7 +387,9 @@ module Elastomer
       end
 
       uri = template.expand(expansions)
-      uri.query_values = query_values unless query_values.empty?
+      query_values.transform_keys!(&:to_s)
+      uri.query_values = (uri.query_values || {}).merge(query_values) unless query_values.empty?
+
       uri.to_s
     end
 

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -88,6 +88,18 @@ describe Elastomer::Client do
     assert_equal "/_cluster/health?level=shards", uri
   end
 
+  it "handles query parameters in path and arguments" do
+    uri = $client.expand_path "/index/_update_by_query?conflicts=proceed", routing: "1"
+
+    assert_equal "/index/_update_by_query?conflicts=proceed&routing=1", uri
+  end
+
+  it "overrides query parameters in path and with arguments" do
+    uri = $client.expand_path "/index/_update_by_query?conflicts=proceed&routing=2", routing: "1"
+
+    assert_equal "/index/_update_by_query?conflicts=proceed&routing=1", uri
+  end
+
   it "validates path expansions" do
     assert_raises(ArgumentError) {
       $client.expand_path "/{foo}/{bar}", foo: "_cluster", bar: nil


### PR DESCRIPTION
Fixes #261 

Instead of overriding the existing query_values, the new values are now merged in.

Before merging in, keys will be converted to strings to override existing values instead of appending. Otherwise the following would happen:
```ruby
expand_path("/my/path?param=1", param: "2") # => "/my/path?param=1&param=2"
expand_path("/my/path?param=1", "param" => "2") # => "/my/path?param=2"
```

Now it is consistent and both versions will give `"/my/path?param=2"`
