### PR TITLE
Add update_by_query

### DIFF
--- a/lib/elastomer/client/docs.rb
+++ b/lib/elastomer/client/docs.rb
@@ -289,6 +289,18 @@ module Elastomer
         @client.native_delete_by_query(query, update_params(params))
       end
 
+      # Update documents by query using Elasticsearch's _update_by_query API.
+      #
+      # See Client#update_by_query for more information.
+      #
+      # Returns a Hash of statistics about the update operations as returned by
+      # _update_by_query.
+      def update_by_query(query, params = nil)
+        query, params = extract_params(query) if params.nil?
+
+        @client.update_by_query(query, update_params(params))
+      end
+
       # Matches a provided or existing document to the stored percolator
       # queries. To match an existing document, pass `nil` as the body and
       # include `:id` in the params.

--- a/lib/elastomer/client/index.rb
+++ b/lib/elastomer/client/index.rb
@@ -526,6 +526,16 @@ module Elastomer
         docs.native_delete_by_query(query, params)
       end
 
+      # Update documents by query using Elasticsearch's _update_by_query API.
+      #
+      # See Client#update_by_query for more information.
+      #
+      # Returns a Hash of statistics about the update operations as returned by
+      # _update_by_query.
+      def update_by_query(query, params = nil)
+        docs.update_by_query(query, params)
+      end
+
       # Constructs a Percolator with the given id on this index.
       #
       # Examples

--- a/lib/elastomer/client/update_by_query.rb
+++ b/lib/elastomer/client/update_by_query.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Elastomer
+  class Client
+    # Update documents based on a query using the Elasticsearch _update_by_query API.
+    #
+    # query  - The query body as a Hash
+    # params - Parameters Hash
+    #
+    # Examples
+    #
+    #   # request body query
+    #   update_by_query({
+    #     "script": {
+    #       "source": "ctx._source.count++",
+    #       "lang": "painless"
+    #     },
+    #     "query": {
+    #       "term": {
+    #         "user.id": "kimchy"
+    #       }
+    #     }
+    #   })
+    #
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/8.7/docs-update-by-query.html
+    #
+    # Returns a Hash containing the _update_by_query response body.
+    def update_by_query(query, parameters = {})
+      UpdateByQuery.new(self, query, parameters).execute
+    end
+
+    class UpdateByQuery
+      attr_reader :client, :query, :parameters
+
+      def initialize(client, query, parameters)
+        @client = client
+        @query = query
+        @parameters = parameters
+      end
+
+      def execute
+        # TODO: Require index parameter. type is optional.
+        updated_params = parameters.merge(body: query, action: "update_by_query", rest_api: "update_by_query")
+        updated_params.delete(:type) if client.version_support.es_version_8_plus?
+        response = client.post("/{index}{/type}/_update_by_query", updated_params)
+        response.body
+      end
+    end
+  end
+end

--- a/test/client/update_by_query_test.rb
+++ b/test/client/update_by_query_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+describe Elastomer::Client::UpdateByQuery do
+  before do
+    @index = $client.index "elastomer-update-by-query-test"
+    @index.delete if @index.exists?
+    @docs = @index.docs("docs")
+  end
+
+  after do
+    @index.delete if @index.exists?
+  end
+
+  describe "when an index with documents exists" do
+    before do
+      @index.create(nil)
+      wait_for_index(@index.name)
+    end
+
+    it "updates by query" do
+      @docs.index({ _id: 0, name: "mittens" })
+      @docs.index({ _id: 1, name: "luna" })
+
+      @index.refresh
+
+      query = {
+        query: {
+          match: {
+            name: "mittens"
+          }
+        },
+        script: {
+          source: "ctx._source.name = 'mittens updated'"
+        }
+      }
+
+      response = @index.update_by_query(query)
+
+      refute_nil response["took"]
+      refute(response["timed_out"])
+      assert_equal(1, response["batches"])
+      assert_equal(1, response["total"])
+      assert_equal(1, response["updated"])
+      assert_empty(response["failures"])
+
+      @index.refresh
+      response = @docs.multi_get(ids: [0, 1])
+
+      assert_equal "mittens updated", response.fetch("docs")[0]["_source"]["name"]
+      assert_equal "luna", response.fetch("docs")[1]["_source"]["name"]
+    end
+
+    it "fails when internal version is 0" do
+      if $client.version_support.es_version_7_plus?
+        skip "Concurrency control with internal version is not supported in ES #{$client.version}"
+      end
+      @docs.index({_id: 0, name: "mittens"})
+      # Creating a document with external version 0 also sets the internal version to 0
+      # Otherwise you can't index a document with version 0.
+      @docs.index({_id: 1, _version: 0, _version_type: "external", name: "mittens"})
+      @index.refresh
+
+      query = {
+        query: {
+          match: {
+            name: "mittens"
+          }
+        }
+      }
+
+      assert_raises(Elastomer::Client::RequestError) do
+        @index.update_by_query(query)
+      end
+    end
+
+    it "fails when an unknown parameter is provided" do
+      assert_raises(Elastomer::Client::IllegalArgument) do
+        @index.update_by_query({}, foo: "bar")
+      end
+    end
+
+    it "updates by query when routing is specified" do
+      index = $client.index "elastomer-update-by-query-routing-test"
+      index.delete if index.exists?
+      type = "docs"
+      # default number of shards in ES 7 is 1, so set it to 2 shards so routing to different shards can be tested
+      settings = $client.version_support.es_version_7_plus? ? { number_of_shards: 2 } : {}
+      index.create({
+        settings: settings,
+        mappings: mappings_wrapper(type, {
+          properties: {
+            name: { type: "text", analyzer: "standard" },
+          },
+          _routing: { required: true }
+        })
+      })
+      wait_for_index(@index.name)
+      docs = index.docs(type)
+
+      docs.index({ _id: 0, _routing: "cat", name: "mittens" })
+      docs.index({ _id: 1, _routing: "cat", name: "luna" })
+      docs.index({ _id: 2, _routing: "dog", name: "mittens" })
+
+      query = {
+        query: {
+          match: {
+            name: "mittens"
+          }
+        },
+        script: {
+          source: "ctx._source.name = 'mittens updated'"
+        }
+      }
+
+      index.refresh
+      response = index.update_by_query(query, routing: "cat")
+
+      assert_equal(1, response["updated"])
+
+      response = docs.multi_get({
+        docs: [
+          { _id: 0, routing: "cat" },
+          { _id: 1, routing: "cat" },
+          { _id: 2, routing: "dog" },
+        ]
+      })
+
+      assert_equal "mittens updated", response.fetch("docs")[0]["_source"]["name"]
+      assert_equal "luna", response.fetch("docs")[1]["_source"]["name"]
+      assert_equal "mittens", response.fetch("docs")[2]["_source"]["name"]
+
+      index.delete if index.exists?
+    end
+  end
+end


### PR DESCRIPTION
Fixes #263 

This PR adds support for `_update_by_query`. 

I followed the implementation for `_delete_by_query`, but I didn't use the `native_` part. Seemed like some kind of backwards compatibility thing and just makes the interface longer? 

