### PR TITLE
Bump to version 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.3 (2023-04-07)
+- Fix query values specified in path get removed when query values are specified with params (#261)
+- Add support for `update_by_query` (#263)
+
 ## 4.0.2 (2023-03-03)
 - Fix ES 7+ handling of params like `routing` that were prefixed with an underscore in earlier versions
 

--- a/lib/elastomer/version.rb
+++ b/lib/elastomer/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Elastomer
-  VERSION = "4.0.2"
+  VERSION = "4.0.3"
 
   def self.version
     VERSION


### PR DESCRIPTION
This bumps the version of the gem to `4.0.3`

There is still an outstanding cleanup in #265, so this should be merged after that gets merged.

I followed the steps in the release section of the README to verify version is updated and new functionality works as expected by recreating a test with manual steps / without helpers.