### PR TITLE
Update bulk API to remove _type if version is > 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.1 (2023-04-26)
+- Fix bug in bulk API preventing string `_id` from being removed if empty
+- Remove `_type` from document body during bulk requests for versions ES 7+
 ## 5.0.0 (2023-04-17)
 - Rename Elastomer to ElastomerClient (and elastomer to elastomer_client)
 

--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -322,6 +322,13 @@ module ElastomerClient
           params = from_document(document).merge(params)
         end
         params.delete(:_id) if params[:_id].nil? || params[:_id].to_s.empty?
+        params.delete("_id") if params["_id"].nil? || params["_id"].to_s.empty?
+
+        if client.version_support.es_version_7_plus?
+          params.delete(:_type)
+          params.delete("_type")
+        end
+
         params
       end
 

--- a/lib/elastomer_client/version.rb
+++ b/lib/elastomer_client/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ElastomerClient
-  VERSION = "5.0.0"
+  VERSION = "5.0.1"
 
   def self.version
     VERSION

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -35,8 +35,9 @@ describe ElastomerClient::Client::Docs do
   end
 
   it "raises error when writing same document twice" do
-    document = document_wrapper("book", {
+    document = ({
       _id: "documentid",
+      _type: "book",
       _op_type: "create",
       title: "Book by Author1",
       author: "Author1"
@@ -51,21 +52,23 @@ describe ElastomerClient::Client::Docs do
   end
 
   it "autogenerates IDs for documents" do
-    h = @docs.index \
-      document_wrapper("book", {
+    h = @docs.index(
+      {
         _id: nil,
         title: "Book1 by author 1",
-        author: "Author1"
+        author: "Author1",
+        _type: "book"
       })
 
     assert_created h
     assert_match %r/^\S{20,22}$/, h["_id"]
 
-    h = @docs.index \
-      document_wrapper("book", {
+    h = @docs.index(
+      {
         _id: nil,
         title: "Book2 by author 2",
-        author: "Author2"
+        author: "Author2",
+        _type: "book"
       })
 
     assert_created h
@@ -73,9 +76,10 @@ describe ElastomerClient::Client::Docs do
   end
 
   it "uses the provided document ID" do
-    h = @docs.index \
-      document_wrapper("book", {
+    h = @docs.index (
+      {
         _id: 42,
+        _type: "book",
         title: "Book1 by author 1",
         author: "Author1"
       })
@@ -85,16 +89,10 @@ describe ElastomerClient::Client::Docs do
   end
 
   it "accepts JSON encoded document strings" do
-    if $client.version_support.es_version_7_plus?
-      h = @docs.index \
-        '{"author":"Author1", "title":"Book1 by author 1"}',
-        id: 42
-    else
-      h = @docs.index \
-        '{"author":"Author1", "title":"Book1 by author 1"}',
-        id: 42,
-        type: "book"
-    end
+    h = @docs.index \
+      '{"author":"Author1", "title":"Book1 by author 1"}',
+      id: 42,
+      type: "book"
 
     assert_created h
     assert_equal "42", h["_id"]
@@ -116,8 +114,9 @@ describe ElastomerClient::Client::Docs do
     end
 
     it "indexes fields that are not recognized as indexing directives" do
-      doc = document_wrapper("book", {
+      doc = ({
         _id: "12",
+        _type: "book",
         title: "Book1",
         author: "Author1",
         _unknown_1: "unknown attribute 1",
@@ -141,12 +140,13 @@ describe ElastomerClient::Client::Docs do
     end
 
     it "extracts indexing directives from the document" do
-      doc = document_wrapper("book", {
+      doc = {
         _id: "12",
+        _type: "book",
         _routing: "author",
         title: "Book1",
         author: "Author1"
-      })
+      }
 
       h = @docs.index(doc)
 
@@ -169,20 +169,24 @@ describe ElastomerClient::Client::Docs do
 
     it "raises an exception when a known indexing directive from an unsupported version is used" do
       # Symbol keys
-      doc = document_wrapper("book", {
+      doc = ({
         _id: "12",
-        title: "Book1"
-      }).merge({_consistency: "all"})
+        _type: "book",
+        title: "Book1",
+       _consistency: "all"
+      })
 
       assert_raises(ElastomerClient::Client::IllegalArgument) do
         @docs.index(doc)
       end
 
       # String keys
-      doc = document_wrapper("book", {
+      doc = ({
         "_id" => "12",
-        "title" => "Book1"
-      }).merge({"_consistency": "all"})
+        "_type" => "book",
+        "title" => "Book1",
+        "_consistency" => "all"
+      })
 
       assert_raises(ElastomerClient::Client::IllegalArgument) do
         @docs.index(doc)
@@ -545,7 +549,9 @@ describe ElastomerClient::Client::Docs do
   end
 
   it "supports bulk operations with the same parameters as docs" do
+    debugger
     response = @docs.bulk do |b|
+      puts b
       populate!(b)
     end
 
@@ -801,16 +807,16 @@ describe ElastomerClient::Client::Docs do
   # docs - An instance of ElastomerClient::Client::Docs or ElastomerClient::Client::Bulk. If
   #        nil uses the @docs instance variable.
   def populate!(docs = @docs)
-    docs.index \
-      document_wrapper("book", {
+    docs.index ({
         _id: 1,
+        _type: "book",
         title: "Book1 by author 1",
         author: "Author1"
       })
 
-    docs.index \
-      document_wrapper("book", {
+    docs.index ({
         _id: 2,
+        _type: "book",
         title: "Book2 by author 2",
         author: "Author2"
       })

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -549,7 +549,6 @@ describe ElastomerClient::Client::Docs do
   end
 
   it "supports bulk operations with the same parameters as docs" do
-    debugger
     response = @docs.bulk do |b|
       puts b
       populate!(b)

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -550,7 +550,6 @@ describe ElastomerClient::Client::Docs do
 
   it "supports bulk operations with the same parameters as docs" do
     response = @docs.bulk do |b|
-      puts b
       populate!(b)
     end
 


### PR DESCRIPTION
This PR intends to fix two different issues: 

1. For ES 7+ compatibility, the Bulk API will no longer send the `_type` parameter if the version is 7+. 

[Link to ES documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) showing that `_type` is not a parameter for any of the bulk requests

As part of this change, all the bulk tests using this call have been updated to remove the `document_wrapper` helper method to test that the ES 5 requests still work correctly on ES 7+. The Docs API already has been doing this, so I was able to update the docs tests to remove the `document_wrapper` and confirm that all the tests still run properly. 

2. Fixes a small bug where string params were not being removed properly if the parameter was empty or nil. 

I added a test to check the scenario where id is nil or empty, which means that ES should generate its own id hash.
