### PR TITLE
Simplify the search_shards check for the type param

### DIFF
--- a/lib/elastomer_client/client/docs.rb
+++ b/lib/elastomer_client/client/docs.rb
@@ -229,11 +229,10 @@ module ElastomerClient
       # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-shards.html
       #
       # Returns the response body as a hash
-      def search_shards(params = {}, remove_type_param = false)
-        updated_params = update_params(params, action: "docs.search_shards", rest_api: "search_shards")
-        if remove_type_param then updated_params.delete(:type) end
+      def search_shards(params = {})
+        updated_params = update_params(params, { action: "docs.search_shards", rest_api: "search_shards" }, true)
 
-        response = client.get "/{index}{/type}/_search_shards", updated_params
+        response = client.get "/{index}/_search_shards", updated_params
         response.body
       end
 

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -415,7 +415,7 @@ describe ElastomerClient::Client::Docs do
   it "supports the shards search API" do
     # We add the type param to all requests (type is _doc for ES 7)
     # But the shards endpoint has to be used without the type param to return the shard data for ES 7
-    h = @docs.search_shards(params={}, remove_type_param = $client.version_support.es_version_7_plus?)
+    h = @docs.search_shards(params={})
 
     assert h.key?("nodes"), "response contains \"nodes\" information"
     assert h.key?("shards"), "response contains \"shards\" information"

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -413,8 +413,6 @@ describe ElastomerClient::Client::Docs do
   end
 
   it "supports the shards search API" do
-    # We add the type param to all requests (type is _doc for ES 7)
-    # But the shards endpoint has to be used without the type param to return the shard data for ES 7
     h = @docs.search_shards(params={})
 
     assert h.key?("nodes"), "response contains \"nodes\" information"


### PR DESCRIPTION
While going through the [ES 6 breaking changes](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_search_shards_api), I noticed the following line which suggested that the `type` in the URL path wasn't doing anything in ES 5. That means we can simplify the check for the `search_shards` method by discarding it completely on all supported ES versions.

> The search shards API no longer accepts the type url parameter, which didn’t have any effect in previous versions.