### PR TITLE
Fix document parameters passed to bulk API when prefixed with underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.3 (2023-05-31)
+- Allow deprecated underscored parameters to work for Bulk API for versions ES 7+. 
+- Allow non-underscored parameters to work for Bulk API for version ES 5. 
 ## 5.0.2 (2023-05-31)
 - Add ES 8.7 REST API spec
 - Remove deprecated `type` parameter from `search_shards` API 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.3 (2023-05-31)
+## 5.0.3 (2023-06-14)
 - Allow deprecated underscored parameters to work for Bulk API for versions ES 7+. 
 - Allow non-underscored parameters to work for Bulk API for version ES 5. 
 ## 5.0.2 (2023-05-31)

--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -327,8 +327,6 @@ module ElastomerClient
         if client.version_support.es_version_7_plus?
           params.delete(:_type)
           params.delete("_type")
-          params.delete(:_routing)
-          params.delete("_routing")
         end
 
         params
@@ -345,7 +343,12 @@ module ElastomerClient
         opts = {}
 
         SPECIAL_KEYS.each do |key|
-          prefixed_key = "_#{key}"
+          omit_prefix = (
+            client.version_support.es_version_7_plus? &&
+            UNPREFIXED_SPECIAL_KEYS.include?(key)
+          )
+
+          prefixed_key = (omit_prefix ? "" : "_") + key
 
           if document.key?(prefixed_key)
             opts[prefixed_key.to_sym] = document.delete(prefixed_key)

--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -358,6 +358,14 @@ module ElastomerClient
           if document.key?(prefixed_key.to_sym)
             opts[converted_key.to_sym] = document.delete(prefixed_key.to_sym)
           end
+
+          if document.key?(key)
+            opts[converted_key.to_sym] = document.delete(key)
+          end
+
+          if document.key?(key.to_sym)
+            opts[converted_key.to_sym] = document.delete(key.to_sym)
+          end
         end
 
         opts

--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -348,14 +348,15 @@ module ElastomerClient
             UNPREFIXED_SPECIAL_KEYS.include?(key)
           )
 
-          prefixed_key = (omit_prefix ? "" : "_") + key
+          prefixed_key = "_" + key
+          converted_key = (omit_prefix ? "" : "_") + key
 
           if document.key?(prefixed_key)
-            opts[prefixed_key.to_sym] = document.delete(prefixed_key)
+            opts[converted_key.to_sym] = document.delete(prefixed_key)
           end
 
           if document.key?(prefixed_key.to_sym)
-            opts[prefixed_key.to_sym] = document.delete(prefixed_key.to_sym)
+            opts[converted_key.to_sym] = document.delete(prefixed_key.to_sym)
           end
         end
 

--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -327,6 +327,8 @@ module ElastomerClient
         if client.version_support.es_version_7_plus?
           params.delete(:_type)
           params.delete("_type")
+          params.delete(:_routing)
+          params.delete("_routing")
         end
 
         params

--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -335,6 +335,8 @@ module ElastomerClient
       # Internal: Extract special keys for bulk indexing from the given
       # `document`. The keys and their values are returned as a Hash from this
       # method. If a value is `nil` then it will be ignored.
+      # This will cover all cases to properly convert parameters for ES5-ES8,
+      # whether or not the prefix should be underscored or not.
       #
       # document - The document Hash
       #

--- a/lib/elastomer_client/version.rb
+++ b/lib/elastomer_client/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ElastomerClient
-  VERSION = "5.0.2"
+  VERSION = "5.0.3"
 
   def self.version
     VERSION

--- a/test/client/bulk_test.rb
+++ b/test/client/bulk_test.rb
@@ -356,6 +356,34 @@ describe ElastomerClient::Client::Bulk do
     assert_equal "custom", @index.docs("book").get(id: 1)["_routing"]
   end
 
+  it "supports the routing parameter within documents with underscore" do
+    document = { _id: 1,  _type: "book", _routing: "custom", title: "Book 1" }
+
+    response = @index.bulk do |b|
+      b.index document
+    end
+
+    items = response["items"]
+
+    assert_kind_of Integer, response["took"]
+    assert_bulk_index(items[0])
+    assert_equal "custom", @index.docs("book").get(id: 1)["_routing"]
+  end
+
+  it "supports the routing parameter within documents without underscore" do
+    document = { _id: 1,  _type: "book", routing: "custom", title: "Book 1" }
+
+    response = @index.bulk do |b|
+      b.index document
+    end
+
+    items = response["items"]
+
+    assert_kind_of Integer, response["took"]
+    assert_bulk_index(items[0])
+    assert_equal "custom", @index.docs("book").get(id: 1)["_routing"]
+  end
+
   it "streams bulk responses" do
     ops = [
       [:index, document_wrapper("book", { title: "Book 1" }), { _id: 1, _index: @index.name }],


### PR DESCRIPTION
Related to https://github.com/github/elastomer-client/pull/257

As per [these docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/breaking-changes-7.0.html#_camel_case_and_underscore_parameters_deprecated_in_6_x_have_been_removed), as of ES 7 certain params (e.g. _routing) should be passed to the ES Bulk API without the underscore prefix. The previous PR linked above handled that for parameters explicitly passed to the Bulk request. However, we also pass these parameters with some documents that are then converted to bulk parameters in the `from_document` method.

This PR updates the `from_document` method to handle underscored parameters being passed through the document for ES7+. 

I've added logic to fix this for when the parameter is passed as underscore, and when the parameter is not passed as underscore, so that it will work for both versions of ES5 and in ES8 depending on how you pass the parameter in.