### PR TITLE
Update version of elastomer-client to 5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.2 (2023-05-31)
+- Add ES 8.7 REST API spec
+- Remove deprecated `type` parameter from `search_shards` API 
 ## 5.0.1 (2023-04-26)
 - Fix bug in bulk API preventing string `_id` from being removed if empty
 - Remove `_type` from document body during bulk requests for versions ES 7+

--- a/lib/elastomer_client/version.rb
+++ b/lib/elastomer_client/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ElastomerClient
-  VERSION = "5.0.1"
+  VERSION = "5.0.2"
 
   def self.version
     VERSION


### PR DESCRIPTION
Updates the version in `elastomer-client` to 5.0.2 and adds changes to CHANGELOG.