### PR TITLE
Remove timestamp and ttl deprecated parameter keys

### DIFF
--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -311,7 +311,7 @@ module ElastomerClient
         @actions.clear
       end
 
-      SPECIAL_KEYS = %w[id type index version version_type routing parent timestamp ttl consistency refresh retry_on_conflict]
+      SPECIAL_KEYS = %w[id type index version version_type routing parent consistency refresh retry_on_conflict]
       UNPREFIXED_SPECIAL_KEYS = %w[parent retry_on_conflict routing version version_type]
 
       # Internal: convert special key parameters to their wire representation

--- a/lib/elastomer_client/client/docs.rb
+++ b/lib/elastomer_client/client/docs.rb
@@ -55,8 +55,6 @@ module ElastomerClient
       #
       # Elasticsearch 2.X only:
       #
-      #   :_timestamp (deprecated)
-      #   :_ttl (deprecated)
       #   :_consistency
       #
       # Elasticsearch 5.x only:
@@ -564,7 +562,7 @@ module ElastomerClient
       end
 
       SPECIAL_KEYS= %i[
-        index type id version version_type op_type routing parent timestamp ttl
+        index type id version version_type op_type routing parent
         consistency replication refresh wait_for_active_shards
       ].inject({}) { |h, k| h[k] = "_#{k}"; h }.freeze
 


### PR DESCRIPTION
Both `timestamp` and `ttl` are deprecated indexing fields, as found in these [ES 5.0 breaking changes documents](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/breaking_50_mapping_changes.html#_literal__timestamp_literal_and_literal__ttl_literal).  

I removed these from the `SPECIAL_KEYS` array, as they are [removed in ES 6.0 ](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#_literal_timestamp_literal_and_literal_ttl_literal_in_index_requests).