### PR TITLE
Update CHANGELOG and version to 5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.0.4 (2023-06-20)
+- Remove support for `timestamp` and `ttl` index parameters
 ## 5.0.3 (2023-06-14)
 - Allow deprecated underscored parameters to work for Bulk API for versions ES 7+. 
 - Allow non-underscored parameters to work for Bulk API for version ES 5. 

--- a/lib/elastomer_client/version.rb
+++ b/lib/elastomer_client/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ElastomerClient
-  VERSION = "5.0.3"
+  VERSION = "5.0.4"
 
   def self.version
     VERSION


### PR DESCRIPTION
Update CHANGELOG and version for last changes from this [PR](https://github.com/github/elastomer-client/pull/273)