### PR TITLE
Replace usage of "found" field by "result" in tests for the delete API

### DIFF
--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -107,7 +107,7 @@ module ElastomerClient
     #   #   "failure" => 0
     #   # }
     #
-    #   # sample response item:
+    #   # sample response item for ES5:
     #   # {
     #   #   "delete": {
     #   #     "_index": "foo",
@@ -116,6 +116,17 @@ module ElastomerClient
     #   #     "_version": 3,
     #   #     "status": 200,
     #   #     "found": true
+    #   #   }
+    #   # }
+    #
+    #   # sample response item for ES8:
+    #   # {
+    #   #   "delete": {
+    #   #     "_index": "foo",
+    #   #     "_id": "42",
+    #   #     "_version": 3,
+    #   #     "status": 200,
+    #   #     "result": "deleted"
     #   #   }
     #   # }
     #

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -281,7 +281,7 @@ describe ElastomerClient::Client::Docs do
     h = @docs.delete id: 1
 
     if $client.version_support.es_version_7_plus?
-      assert_equal h["result"], "deleted", "expected document to be found"
+      assert_equal "deleted", h["result"], "expected document to be found"
     else
       assert h["found"], "expected document to be found"
     end
@@ -301,7 +301,7 @@ describe ElastomerClient::Client::Docs do
     h = @docs.delete id: 42
 
     if $client.version_support.es_version_7_plus?
-      refute_equal h["result"], "deleted", "expected document to not be found"
+      refute_equal "deleted", h["result"], "expected document to not be found"
     else
       refute h["found"], "expected document to not be found"
     end

--- a/test/client/docs_test.rb
+++ b/test/client/docs_test.rb
@@ -281,7 +281,7 @@ describe ElastomerClient::Client::Docs do
     h = @docs.delete id: 1
 
     if $client.version_support.es_version_7_plus?
-      assert h["result"], "deleted"
+      assert_equal h["result"], "deleted", "expected document to be found"
     else
       assert h["found"], "expected document to be found"
     end
@@ -300,7 +300,11 @@ describe ElastomerClient::Client::Docs do
     @docs = @index.docs("book")
     h = @docs.delete id: 42
 
-    refute h["found"], "expected document to not be found"
+    if $client.version_support.es_version_7_plus?
+      refute_equal h["result"], "deleted", "expected document to not be found"
+    else
+      refute h["found"], "expected document to not be found"
+    end
   end
 
   it "deletes documents by query" do


### PR DESCRIPTION
The "found" field was removed from the delete API response ES6 onwards.
We were only using the field for assertions in 2 tests. The other usages of found in the tests are for the get API, which still has the "found" field in responses for ES8.

There was also a sample delete API response in the bulk.rb file. I added a sample response for ES8 too, to reflect the "found" field being removed from the response.