### PR TITLE
Reduce the noise of the client during an inspect call by hiding connection info

### DIFF
--- a/lib/elastomer_client/client.rb
+++ b/lib/elastomer_client/client.rb
@@ -14,7 +14,7 @@ module ElastomerClient
 
   class Client
     IVAR_BLACK_LIST = [:@basic_auth, :@token_auth]
-    IVAR_NOISY_LIST = [:@api_spec, :@cluster]
+    IVAR_NOISY_LIST = [:@api_spec, :@cluster, :@connection]
 
     MAX_REQUEST_SIZE = 2**20 * 250  # 250 MB
 


### PR DESCRIPTION
Add the `@connection` instance variable to the list of noisy ivars so that it will not be output during calls to `inspect`. The amount of information is quite large and is mostly not helpful during debugging. The information is still available by other means, but removing it from the default output will make debugging clearer.