### PR TITLE
Rename MiniTest to Minitest

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,7 +47,7 @@ raise "No server available at #{$client.url}" unless $client.available?
 puts "Elasticsearch version is #{$client.version}"
 
 # remove any lingering test indices from the cluster
-MiniTest.after_run do
+Minitest.after_run do
   $client.cluster.indices.keys.each do |name|
     next unless name =~ /^elastomer-/i
     $client.index(name).delete


### PR DESCRIPTION
Tests and CI are failing due to the latest version of `minitest` removing an old compatibility layer, which was allowing "MiniTest" (capital T) to be used where "Minitest" (lowercase T) should have been used. This codebase does not need that layer, so a simple rename fixes all the tests.

From https://github.com/minitest/minitest/blob/master/History.rdoc#5190--2023-07-26-
> Only load minitest/unit (aka ancient MiniTest compatibility layer) if [ENV](https://github.com/minitest/minitest/blob/master/%22MT_COMPAT%22)