### PR TITLE
Update convert_special_keys to properly handle ES8 unprefixed keys

### DIFF
--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -356,6 +356,8 @@ module ElastomerClient
         opts = {}
 
         SPECIAL_KEYS.each do |key|
+          next if key == "type" && client.version_support.es_version_7_plus?
+
           omit_prefix = (
             client.version_support.es_version_7_plus? &&
             UNPREFIXED_SPECIAL_KEYS.include?(key)

--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -368,11 +368,17 @@ module ElastomerClient
 
           if document.key?(prefixed_key)
             opts[converted_key.to_sym] = document.delete(prefixed_key)
-          elsif document.key?(prefixed_key.to_sym)
+          end
+
+          if document.key?(prefixed_key.to_sym)
             opts[converted_key.to_sym] = document.delete(prefixed_key.to_sym)
-          elsif document.key?(key)
+          end
+
+          if document.key?(key)
             opts[converted_key.to_sym] = document.delete(key)
-          elsif document.key?(key.to_sym)
+          end
+
+          if document.key?(key.to_sym)
             opts[converted_key.to_sym] = document.delete(key.to_sym)
           end
         end

--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -356,7 +356,7 @@ module ElastomerClient
         opts = {}
 
         SPECIAL_KEYS.each do |key|
-          next if key == "type" && client.version_support.es_version_7_plus?
+          next if key == "type" && client.version_support.es_version_8_plus?
 
           omit_prefix = (
             client.version_support.es_version_7_plus? &&
@@ -393,20 +393,29 @@ module ElastomerClient
       def convert_special_keys(params)
         new_params = params.dup
 
-        SPECIAL_KEYS.each do |original_key|
+        SPECIAL_KEYS.each do |key|
           omit_prefix = (
             client.version_support.es_version_7_plus? &&
-            UNPREFIXED_SPECIAL_KEYS.include?(original_key)
+            UNPREFIXED_SPECIAL_KEYS.include?(key)
           )
 
-          converted_key = (omit_prefix ? "" : "_") + original_key
+          prefixed_key = "_" + key
+          converted_key = (omit_prefix ? "" : "_") + key
 
-          if new_params.key?(original_key)
-            new_params[converted_key] = new_params.delete(original_key)
+          if new_params.key?(prefixed_key)
+            new_params[converted_key] = new_params.delete(prefixed_key)
           end
 
-          if new_params.key?(original_key.to_sym)
-            new_params[converted_key.to_sym] = new_params.delete(original_key.to_sym)
+          if new_params.key?(prefixed_key.to_sym)
+            new_params[converted_key.to_sym] = new_params.delete(prefixed_key.to_sym)
+          end
+
+          if new_params.key?(key)
+            new_params[converted_key] = new_params.delete(key)
+          end
+
+          if new_params.key?(key.to_sym)
+            new_params[converted_key.to_sym] = new_params.delete(key.to_sym)
           end
         end
 

--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -366,17 +366,11 @@ module ElastomerClient
 
           if document.key?(prefixed_key)
             opts[converted_key.to_sym] = document.delete(prefixed_key)
-          end
-
-          if document.key?(prefixed_key.to_sym)
+          elsif document.key?(prefixed_key.to_sym)
             opts[converted_key.to_sym] = document.delete(prefixed_key.to_sym)
-          end
-
-          if document.key?(key)
+          elsif document.key?(key)
             opts[converted_key.to_sym] = document.delete(key)
-          end
-
-          if document.key?(key.to_sym)
+          elsif document.key?(key.to_sym)
             opts[converted_key.to_sym] = document.delete(key.to_sym)
           end
         end


### PR DESCRIPTION
This PR handles 2 bugs

1. Adds an additional check to prevent `type` from being used as a special key in ES8. `type` is allowed to be a normal field in ES8, and should not be converted to anything else.
2. As per [these docs](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/breaking-changes-7.0.html#_camel_case_and_underscore_parameters_deprecated_in_6_x_have_been_removed), as of ES 7, certain params (e.g. _routing) should be passed to the ES Bulk API without the underscore prefix. This PR updates `convert_special_keys` method to check for the prefixed keys as well as the non-prefixed keys in the parameters, and converts it to the correct key based on the version of ES. 