### PR TITLE
Allow a custom Faraday connection configuration block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.0 (2023-11-07)
+- Allow passing a Faraday connection configuration block to the client.
+
 ## 5.1.0 (2023-09-29)
 - Remove logic extracting parameters from document in bulk requests. Parameters now must be sent separately from the document to be parsed correctly.
 

--- a/lib/elastomer_client/client.rb
+++ b/lib/elastomer_client/client.rb
@@ -49,7 +49,7 @@ module ElastomerClient
                    read_timeout: 5, open_timeout: 2, max_retries: 0, retry_delay: 0.075,
                    opaque_id: false, adapter: Faraday.default_adapter, max_request_size: MAX_REQUEST_SIZE,
                    strict_params: false, es_version: nil, compress_body: false, compression: Zlib::DEFAULT_COMPRESSION,
-                   basic_auth: nil, token_auth: nil)
+                   basic_auth: nil, token_auth: nil, &block)
 
       @url = url || "http://#{host}:#{port}"
 
@@ -70,6 +70,7 @@ module ElastomerClient
       @compression      = compression
       @basic_auth       = basic_auth
       @token_auth       = token_auth
+      @connection_block = block
     end
 
     attr_reader :host, :port, :url
@@ -155,6 +156,8 @@ module ElastomerClient
           conn.basic_auth(@basic_auth[:username], @basic_auth[:password])
         end
 
+        @connection_block&.call(conn)
+        
         if @adapter.is_a?(Array)
           conn.adapter(*@adapter)
         else

--- a/lib/elastomer_client/client.rb
+++ b/lib/elastomer_client/client.rb
@@ -157,7 +157,7 @@ module ElastomerClient
         end
 
         @connection_block&.call(conn)
-        
+
         if @adapter.is_a?(Array)
           conn.adapter(*@adapter)
         else

--- a/lib/elastomer_client/version.rb
+++ b/lib/elastomer_client/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ElastomerClient
-  VERSION = "5.1.0"
+  VERSION = "5.2.0"
 
   def self.version
     VERSION

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -11,6 +11,18 @@ describe ElastomerClient::Client do
     assert_includes c.connection.builder.handlers, Faraday::Adapter::Test
   end
 
+  it "allows configuring the Faraday when a block is given" do
+    assert ElastomerClient::Client.new.connection.builder.handlers.none? { |handler| handler.klass == FaradayMiddleware::Instrumentation }
+
+    c = ElastomerClient::Client.new do |connection|
+      assert_kind_of(Faraday::Connection, connection)
+
+      connection.use :instrumentation
+    end
+
+    assert c.connection.builder.handlers.any? { |handler| handler.klass == FaradayMiddleware::Instrumentation }
+  end
+
   it "use Faraday's default adapter if none is specified" do
     c = ElastomerClient::Client.new
     adapter = Faraday::Adapter.lookup_middleware(Faraday.default_adapter)


### PR DESCRIPTION
Allow custom configuration of the client's Faraday connection by passing a block to the client's constructor.

Bumped minor version and updated the changelog.