### PR TITLE
improvement to update action docs

### DIFF
--- a/lib/elastomer_client/client/bulk.rb
+++ b/lib/elastomer_client/client/bulk.rb
@@ -280,9 +280,9 @@ module ElastomerClient
       # params   - Parameters for the update action (as a Hash) (optional)
       #
       # Examples
-      #   update({"doc" => {"foo" => "bar"}}, {:_id => 1}
-      #   update({"doc" => {"foo" => "bar"}}, {:id => 1}
-      #   update({"doc" => {foo" => "bar"}}, "_id" => 1)
+      #   update({"doc" => {"foo" => "bar"}}, {:_id => 1})
+      #   update({"doc" => {"foo" => "bar"}}, {:id => 1})
+      #   update({"doc" => {"foo" => "bar"}}, "_id" => 1)
       #
       # Returns the response from the bulk call if one was made or nil.
       def update(document, params)


### PR DESCRIPTION
Regretfully is important to note that solely  using the examples documented [here](https://github.com/github/elastomer-client/blob/ec2474b8d1837f4d2cc5fcf5cb839843257d86c6/lib/elastomer_client/client/bulk.rb#L274-L291) leads to an exception:  

**`"x_content_parse_exception"`**

Upon further investigation I came across this [ElasticSearch post](https://discuss.elastic.co/t/updating-elasticsearch-document/265705) with folks having a similar issue.

For future reference I thought it would be best to update these examples  as part of the bulk action code whilst the team has time to update https://github.com/github/elastomer-client/blob/main/docs/bulk_indexing.md