### PR TITLE
Move opaque id to the end of the middleware chain

### DIFF
--- a/lib/elastomer_client/client.rb
+++ b/lib/elastomer_client/client.rb
@@ -134,7 +134,6 @@ module ElastomerClient
         # Request compressed responses from ES and decompress them
         conn.use(:gzip)
         conn.request(:encode_json)
-        conn.request(:opaque_id) if @opaque_id
         conn.request(:limit_size, max_request_size:) if max_request_size
         conn.request(:elastomer_compress, compression:) if compress_body
 
@@ -148,6 +147,8 @@ module ElastomerClient
         end
 
         @connection_block&.call(conn)
+        
+        conn.request(:opaque_id) if @opaque_id
 
         if @adapter.is_a?(Array)
           conn.adapter(*@adapter)

--- a/lib/elastomer_client/client.rb
+++ b/lib/elastomer_client/client.rb
@@ -147,7 +147,7 @@ module ElastomerClient
         end
 
         @connection_block&.call(conn)
-        
+
         conn.request(:opaque_id) if @opaque_id
 
         if @adapter.is_a?(Array)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -424,6 +424,7 @@ describe ElastomerClient::Client do
     end
 
     response = client.get("/")
-    assert_equal response.headers["Fake"], "yes"
+
+    assert_equal "yes", response.headers["Fake"]
   end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require File.expand_path("../test_helper", __FILE__)
+require File.expand_path("../mock_response", __FILE__)
 require "elastomer_client/notifications"
 
 describe ElastomerClient::Client do
@@ -413,5 +414,16 @@ describe ElastomerClient::Client do
 
       refute_same $client.connection, client.connection
     end
+  end
+
+  it "does not throw OpaqueIdError for mocked response with empty opaque id" do
+    opts = $client_params.merge \
+      opaque_id: true
+    client = ElastomerClient::Client.new(**opts) do |connection|
+      connection.request(:mock_response) { |env| env.body = "{}" }
+    end
+
+    response = client.get("/")
+    assert_equal response.headers["Fake"], "yes"
   end
 end

--- a/test/mock_response.rb
+++ b/test/mock_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ElastomerClient
   module Middleware
     class MockResponse < Faraday::Middleware

--- a/test/mock_response.rb
+++ b/test/mock_response.rb
@@ -1,0 +1,28 @@
+module ElastomerClient
+  module Middleware
+    class MockResponse < Faraday::Middleware
+      def initialize(app, &block)
+        super(app)
+        @response_block = block
+      end
+
+      def call(env)
+        env.clear_body if env.needs_body?
+
+        env.status = 200
+        env.response_headers = ::Faraday::Utils::Headers.new
+        env.response_headers["Fake"] = "yes"
+        env.response = ::Faraday::Response.new
+
+        @response_block&.call(env)
+
+        env.response.finish(env) unless env.parallel?
+
+        env.response
+      end
+    end
+  end
+end
+
+Faraday::Request.register_middleware \
+  mock_response: ElastomerClient::Middleware::MockResponse


### PR DESCRIPTION
This PR moves the call to the opaque ID middleware to the end of the Faraday middleware chain. Currently the opaque ID middleware is being triggered earlier in the middleware stack and is wrapping the invocation of the other middleware in the chain after it.
This change will ensure that we can use middleware like circuit breakers without causing issues for the opaque ID middleware. So any time we short circuit the remote request, the opaque ID middleware will not be called.