### PR TITLE
Change opaque ID middleware to not throw OpaqueIDError on 5xx responses

### DIFF
--- a/lib/elastomer_client/middleware/opaque_id.rb
+++ b/lib/elastomer_client/middleware/opaque_id.rb
@@ -36,7 +36,7 @@ module ElastomerClient
         @app.call(env).on_complete do |renv|
           response_uuid = renv[:response_headers][X_OPAQUE_ID]
           # Don't raise OpaqueIdError if the response is a 5xx
-          if response_uuid.present? && uuid != response_uuid && renv.status < 500
+          if !response_uuid.nil? && uuid != response_uuid && renv.status < 500
             raise ::ElastomerClient::Client::OpaqueIdError,
                   "Conflicting 'X-Opaque-Id' headers: request #{uuid.inspect}, response #{response_uuid.inspect}"
           end

--- a/lib/elastomer_client/middleware/opaque_id.rb
+++ b/lib/elastomer_client/middleware/opaque_id.rb
@@ -35,7 +35,8 @@ module ElastomerClient
 
         @app.call(env).on_complete do |renv|
           response_uuid = renv[:response_headers][X_OPAQUE_ID]
-          if uuid != response_uuid
+          # Don't raise OpaqueIdError if the response is a 5xx
+          if response_uuid.present? && uuid != response_uuid && renv.status < 500
             raise ::ElastomerClient::Client::OpaqueIdError,
                   "Conflicting 'X-Opaque-Id' headers: request #{uuid.inspect}, response #{response_uuid.inspect}"
           end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -427,4 +427,15 @@ describe ElastomerClient::Client do
 
     assert_equal "yes", response.headers["Fake"]
   end
+
+  it "throws ServerError and not OpaqueIdError on 5xx response" do
+    client_params = $client_params.merge \
+      opaque_id: true
+    client = ElastomerClient::Client.new(**client_params)
+
+    test_url = "#{client.url}/"
+    stub_request(:get, test_url).and_return(status: 503, headers: { "Content-Type" => "application/json" })
+
+    assert_raises(ElastomerClient::Client::ServerError) { client.request :get, test_url, {} }
+  end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -416,26 +416,50 @@ describe ElastomerClient::Client do
     end
   end
 
-  it "does not throw OpaqueIdError for mocked response with empty opaque id" do
-    opts = $client_params.merge \
-      opaque_id: true
-    client = ElastomerClient::Client.new(**opts) do |connection|
-      connection.request(:mock_response) { |env| env.body = "{}" }
+  describe "OpaqueIDError conditionals" do
+    it "does not throw OpaqueIdError for mocked response with empty opaque id" do
+      opts = $client_params.merge \
+        opaque_id: true
+      client = ElastomerClient::Client.new(**opts) do |connection|
+        connection.request(:mock_response) { |env| env.body = "{}" }
+      end
+
+      response = client.get("/")
+
+      assert_equal "yes", response.headers["Fake"]
     end
 
-    response = client.get("/")
+    it "throws OpaqueIdError on mismatched ID" do
+      client_params = $client_params.merge \
+        opaque_id: true
+      client = ElastomerClient::Client.new(**client_params)
 
-    assert_equal "yes", response.headers["Fake"]
-  end
+      test_url = "#{client.url}/"
+      stub_request(:get, test_url).and_return(status: 200, headers: { "Content-Type" => "application/json", "X-Opaque-Id" => "foo" })
 
-  it "throws ServerError and not OpaqueIdError on 5xx response" do
-    client_params = $client_params.merge \
-      opaque_id: true
-    client = ElastomerClient::Client.new(**client_params)
+      assert_raises(ElastomerClient::Client::OpaqueIdError) { client.request :get, test_url, {} }
+    end
 
-    test_url = "#{client.url}/"
-    stub_request(:get, test_url).and_return(status: 503, headers: { "Content-Type" => "application/json" })
+    it "throws OpaqueIdError on empty string ID" do
+      client_params = $client_params.merge \
+        opaque_id: true
+      client = ElastomerClient::Client.new(**client_params)
 
-    assert_raises(ElastomerClient::Client::ServerError) { client.request :get, test_url, {} }
+      test_url = "#{client.url}/"
+      stub_request(:get, test_url).and_return(status: 200, headers: { "Content-Type" => "application/json", "X-Opaque-Id" => "" })
+
+      assert_raises(ElastomerClient::Client::OpaqueIdError) { client.request :get, test_url, {} }
+    end
+
+    it "throws ServerError and not OpaqueIdError on 5xx response and nil ID" do
+      client_params = $client_params.merge \
+        opaque_id: true
+      client = ElastomerClient::Client.new(**client_params)
+
+      test_url = "#{client.url}/"
+      stub_request(:get, test_url).and_return(status: 503, headers: { "Content-Type" => "application/json" })
+
+      assert_raises(ElastomerClient::Client::ServerError) { client.request :get, test_url, {} }
+    end
   end
 end


### PR DESCRIPTION
Currently, if ES returns a 500 response, we get an `OpaqueIDError` (and not the `ServerError`) since we only [check for an opaque ID mismatch](https://github.com/github/elastomer-client/blob/main/lib/elastomer_client/middleware/opaque_id.rb#L38) and don't handle the case when opaque ID is nil.
Here I added a check so that the `OpaqueIDError` will not be thrown if there is a 5xx response from Elasticsearch, and we will get a `ElastomerClient::Client::ServerError` instead.