### PR TITLE
Replace Faraday::Error::* usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.0.4 (2024-04-05)
+## 6.1.0 (2024-04-09)
 - Replace `Faraday::Error::*` with `Faraday::*` error classes
 - Handle all `Faraday::Error` instead of `Faraday::Error::ClientError`
 - Unlock faraday version to allow 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.0.4 (2024-04-05)
+- Replace `Faraday::Error::*` with `Faraday::*` error classes
+- Handle all `Faraday::Error` instead of `Faraday::Error::ClientError`
+- Unlock faraday version to allow 1.0.0
+
 ## 6.0.3 (2024-04-05)
 - Add ES 8.13 REST API spec
 - Update CI and development versions from 8.7.0 to 8.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Replace `Faraday::Error::*` with `Faraday::*` error classes
 - Handle all `Faraday::Error` instead of `Faraday::Error::ClientError`
 - Unlock faraday version to allow 1.0.0
+- Bump the minimum version of faraday and faraday middleware
 
 ## 6.0.3 (2024-04-05)
 - Add ES 8.13 REST API spec

--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "addressable", "~> 2.5"
-  spec.add_dependency "faraday",     ">= 0.8"
-  spec.add_dependency "faraday_middleware", "~> 0.12"
+  spec.add_dependency "faraday",     ">= 0.17"
+  spec.add_dependency "faraday_middleware", "~> 0.14"
   spec.add_dependency "multi_json",  "~> 1.12"
   spec.add_dependency "semantic",    "~> 1.6"
 end

--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "addressable", "~> 2.5"
-  spec.add_dependency "faraday",     "~> 0.8"
+  spec.add_dependency "faraday",     ">= 0.8"
   spec.add_dependency "faraday_middleware", "~> 0.12"
   spec.add_dependency "multi_json",  "~> 1.12"
   spec.add_dependency "semantic",    "~> 1.6"

--- a/lib/elastomer_client/client.rb
+++ b/lib/elastomer_client/client.rb
@@ -270,7 +270,7 @@ module ElastomerClient
           handle_errors response
 
         # wrap Faraday errors with appropriate ElastomerClient::Client error classes
-        rescue Faraday::Error::ClientError => boom
+        rescue Faraday::Error => boom
           error = wrap_faraday_error(boom, method, path)
           raise error
         rescue OpaqueIdError => boom

--- a/lib/elastomer_client/client/errors.rb
+++ b/lib/elastomer_client/client/errors.rb
@@ -97,17 +97,6 @@ module ElastomerClient
     ConnectionFailed.fatal       = false
     RejectedExecutionError.fatal = false
 
-    # Define an ElastomerClient::Client exception class on the fly for
-    # Faraday exception classes that we don't specifically wrap.
-    Faraday::Error.constants.each do |error_name|
-      next if ::ElastomerClient::Client.const_get(error_name) rescue nil
-
-      error_class = Faraday::Error.const_get(error_name)
-      next unless error_class < Faraday::Error::ClientError
-
-      ::ElastomerClient::Client.const_set(error_name, Class.new(Error))
-    end
-
     # Exception for operations that are unsupported with the version of
     # Elasticsearch being used.
     IncompatibleVersionException = Class.new Error

--- a/lib/elastomer_client/middleware/parse_json.rb
+++ b/lib/elastomer_client/middleware/parse_json.rb
@@ -20,7 +20,7 @@ module ElastomerClient
       def parse(body)
         MultiJson.load(body) if body.respond_to?(:to_str) && !body.strip.empty?
       rescue StandardError, SyntaxError => e
-        raise Faraday::Error::ParsingError, e
+        raise Faraday::ParsingError, e
       end
 
       def process_response?(env)

--- a/lib/elastomer_client/version.rb
+++ b/lib/elastomer_client/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ElastomerClient
-  VERSION = "6.0.3"
+  VERSION = "6.0.4"
 
   def self.version
     VERSION

--- a/lib/elastomer_client/version.rb
+++ b/lib/elastomer_client/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ElastomerClient
-  VERSION = "6.0.4"
+  VERSION = "6.1.0"
 
   def self.version
     VERSION

--- a/test/client/errors_test.rb
+++ b/test/client/errors_test.rb
@@ -47,7 +47,7 @@ describe ElastomerClient::Client::Error do
   end
 
   it "is instantiated from another exception" do
-    err = Faraday::Error::ConnectionFailed.new "could not connect to host"
+    err = Faraday::ConnectionFailed.new "could not connect to host"
     err.set_backtrace %w[one two three four]
 
     err = ElastomerClient::Client::Error.new(err, "POST", "/index/doc")

--- a/test/middleware/parse_json_test.rb
+++ b/test/middleware/parse_json_test.rb
@@ -49,14 +49,14 @@ describe ElastomerClient::Middleware::ParseJson do
   end
 
   it "chokes on invalid json" do
-    assert_raises(Faraday::Error::ParsingError) { process "{!"      }
-    assert_raises(Faraday::Error::ParsingError) { process "invalid" }
+    assert_raises(Faraday::ParsingError) { process "{!"      }
+    assert_raises(Faraday::ParsingError) { process "invalid" }
 
     # surprisingly these are all valid according to MultiJson
     #
-    # assert_raises(Faraday::Error::ParsingError) { process '"a"'  }
-    # assert_raises(Faraday::Error::ParsingError) { process 'true' }
-    # assert_raises(Faraday::Error::ParsingError) { process 'null' }
-    # assert_raises(Faraday::Error::ParsingError) { process '1'    }
+    # assert_raises(Faraday::ParsingError) { process '"a"'  }
+    # assert_raises(Faraday::ParsingError) { process 'true' }
+    # assert_raises(Faraday::ParsingError) { process 'null' }
+    # assert_raises(Faraday::ParsingError) { process '1'    }
   end
 end

--- a/test/notifications_test.rb
+++ b/test/notifications_test.rb
@@ -20,7 +20,7 @@ describe ElastomerClient::Notifications do
   end
 
   it "instruments timeouts" do
-    $client.stub :connection, lambda { raise Faraday::Error::TimeoutError } do
+    $client.stub :connection, lambda { raise Faraday::TimeoutError } do
       assert_raises(ElastomerClient::Client::TimeoutError) { $client.info }
       event = @events.detect { |e| e.payload[:action] == "cluster.info" }
       exception = event.payload[:exception]


### PR DESCRIPTION
- Replace `Faraday::Error::*` with `Faraday::*` error classes (following the [upgrade guide](https://github.com/lostisland/faraday/blob/main/UPGRADING.md#errors))
- Handle all `Faraday::Error` instead of `Faraday::Error::ClientError`
- Unlock faraday version to allow 1.0.0
- Bumped up the faraday and faraday middleware gems slightly