### PR TITLE
Unlock faraday middleware gem version

### DIFF
--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", "~> 2.5"
   spec.add_dependency "faraday",     ">= 0.8"
-  spec.add_dependency "faraday_middleware", "~> 0.12"
+  spec.add_dependency "faraday_middleware", ">= 0.12"
   spec.add_dependency "multi_json",  "~> 1.12"
   spec.add_dependency "semantic",    "~> 1.6"
 end


### PR DESCRIPTION
This unlocks [faraday middleware gem](https://github.com/lostisland/faraday_middleware?tab=readme-ov-file) version so that it can be upgraded 