### PR TITLE
Update CI to 8.13.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['3.2']
-        ES_VERSION: ['5.6.15', '8.13.0']
+        ES_VERSION: ['5.6.15', '8.13.2']
         include:
           - ES_VERSION: '5.6.15'
             ES_DOWNLOAD_URL: >-
               https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.15.tar.gz
-          - ES_VERSION: '8.13.0'
+          - ES_VERSION: '8.13.2'
             ES_DOWNLOAD_URL: >-
-              https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.13.0-linux-x86_64.tar.gz
+              https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.13.2-linux-x86_64.tar.gz
     steps:
       - uses: ruby/setup-ruby@v1
         with:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   elasticsearch8.13:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.2
     container_name: es8.13
     profiles: ["es8", "all"]
     environment:


### PR DESCRIPTION
Update CI to the same patch level we're planning to use throughout.

The .2 patch includes the fix for 8.13 that downgrades the JDK. More info:
https://www.elastic.co/blog/elastic-stack-8-13-2-released
