### PR TITLE
Unlock faraday_middleware version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.1.1 (2024-06-05)
+- Unlock faraday_middleware version to allow 1.x
+
 ## 6.1.0 (2024-04-09)
 - Replace `Faraday::Error::*` with `Faraday::*` error classes
 - Handle all `Faraday::Error` instead of `Faraday::Error::ClientError`

--- a/elastomer-client.gemspec
+++ b/elastomer-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "addressable", "~> 2.5"
   spec.add_dependency "faraday",     ">= 0.17"
-  spec.add_dependency "faraday_middleware", "~> 0.14"
+  spec.add_dependency "faraday_middleware", ">= 0.14"
   spec.add_dependency "multi_json",  "~> 1.12"
   spec.add_dependency "semantic",    "~> 1.6"
 end

--- a/lib/elastomer_client/version.rb
+++ b/lib/elastomer_client/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ElastomerClient
-  VERSION = "6.1.0"
+  VERSION = "6.1.1"
 
   def self.version
     VERSION

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -9,7 +9,7 @@ describe ElastomerClient::Client do
   it "uses the adapter specified at creation" do
     c = ElastomerClient::Client.new(adapter: :test)
 
-    assert_includes c.connection.builder.handlers, Faraday::Adapter::Test
+    assert_equal c.connection.builder.adapter, Faraday::Adapter::Test
   end
 
   it "allows configuring the Faraday when a block is given" do
@@ -28,7 +28,7 @@ describe ElastomerClient::Client do
     c = ElastomerClient::Client.new
     adapter = Faraday::Adapter.lookup_middleware(Faraday.default_adapter)
 
-    assert_includes c.connection.builder.handlers, adapter
+    assert_equal c.connection.builder.adapter, adapter
   end
 
   it "uses the same connection for all requests" do


### PR DESCRIPTION
This is a followup to https://github.com/github/elastomer-client/pull/309

We can't upgrade faraday to 1.x without also upgrading faraday_middleware to 1.x, so the previous PR didn't get us all the way there.

Not much changes in faraday_middleware 1.x except for faraday 1.x support, so I expect elastomer-client to be fully compatible.

(We'll revisit this once more for faraday 2.0, which drops the faraday_middleware gem entirely, but that's a problem for another day.)