### PR TITLE
add rethrottle support to reindex api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
+## 6.2.1 (2024-12-10)
+- Add support for rethrottling reindex tasks
+
 ## 6.2.0 (2024-11-06)
-- Added support for reindex API
-- Removed CI checks for ES 5.6.15
+- Add support for reindex API
+- Remove CI checks for ES 5.6.15
 
 ## 6.1.1 (2024-06-05)
 - Unlock faraday_middleware version to allow 1.x

--- a/lib/elastomer_client/client/reindex.rb
+++ b/lib/elastomer_client/client/reindex.rb
@@ -24,6 +24,11 @@ module ElastomerClient
         response.body
       end
 
+      def rethrottle(task_id, params = {})
+        response = client.post "/_reindex/#{task_id}/_rethrottle", params.merge(params, action: "rethrottle", rest_api: "reindex")
+        response.body
+      end
+
     end
   end
 end

--- a/lib/elastomer_client/version.rb
+++ b/lib/elastomer_client/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ElastomerClient
-  VERSION = "6.2.0"
+  VERSION = "6.2.1"
 
   def self.version
     VERSION


### PR DESCRIPTION
For native reindexing, it will be important to be able to throttle reindex operations incase they become too expensive. This PR adds support for that to elastomer-client. A subsequent PR will add it to the elastomer reindex framework