### PR TITLE
Removing redundant params in params.merge()

### DIFF
--- a/lib/elastomer_client/client/reindex.rb
+++ b/lib/elastomer_client/client/reindex.rb
@@ -20,12 +20,12 @@ module ElastomerClient
       attr_reader :client
 
       def reindex(body, params = {})
-        response = client.post "/_reindex", params.merge(params, body:, action: "reindex", rest_api: "reindex")
+        response = client.post "/_reindex", params.merge(body:, action: "reindex", rest_api: "reindex")
         response.body
       end
 
       def rethrottle(task_id, params = {})
-        response = client.post "/_reindex/#{task_id}/_rethrottle", params.merge(params, action: "rethrottle", rest_api: "reindex")
+        response = client.post "/_reindex/#{task_id}/_rethrottle", params.merge(action: "rethrottle", rest_api: "reindex")
         response.body
       end
 


### PR DESCRIPTION
removes 2 redundant inclusions of params in a params.merge() call in reindex.rb

** There are 2 failing tests that also fail on the main branch, unrelated to this change

```
  1) Failure:
ElastomerClient::Client::Snapshot#test_0005_gets snapshot status for one and all [test/client/snapshot_test.rb:73]:
Expected: 1
  Actual: 2

  2) Failure:
ElastomerClient::Client::Snapshot#test_0003_creates snapshots with options [test/client/snapshot_test.rb:51]:
--- expected
+++ actual
@@ -1 +1 @@
-["elastomer-snapshot-test-index"]
+[".tasks", "elastomer-snapshot-test-index"]
```