### PR TITLE
Potential fixes for 2 code scanning alerts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: CI tests
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As part of the organization's transition to default read-only permissions for the GITHUB_TOKEN, this pull request addresses a missing permission in the workflow that triggered a code scanning alert.

This PR explicitly adds the required read permissions to align with the default read only permission and is part of a larger effort for this OKR https://github.com/github/security-services/issues/455


Potential fixes for 2 code scanning alerts from the [Copilot AutoFix: Missing Permissions in Workflows](https://github.com/orgs/github/security/campaigns/20) security campaign:
- https://github.com/github/elastomer-client/security/code-scanning/6
The best way to fix this issue is to explicitly add a `permissions` block to the workflow to restrict the granted token permissions to exactly what the workflow needs. Given inspection of the workflow's steps—running Ruby setup, checking out code, caching, downloading, installing, and running tests—none of these steps seem to require `write` access, and `contents: read` should be sufficient for basic checkout, dependency installation, and downloading. Therefore, at the workflow root (after the `name:` and before `on:`), add:
  ```yaml
  permissions:
  contents: read
  ```
  Alternatively, this could be done at the job level, but it's best practice to use the workflow root unless finer-grained permissions are truly needed for different jobs.

  **Implementation details:**
  - File to edit: .github/workflows/main.yml
  - Insert `permissions:` block after the `name:` line and before the `on:` block.
  - No changes or additions needed to existing imports, steps, or method definitions.

  ---
  


- https://github.com/github/elastomer-client/security/code-scanning/2
To fix this issue, add an explicit `permissions` block to limit the `GITHUB_TOKEN` scope to the least privilege required by the job. For a Rubocop CI job, only read access to the repository contents is needed.  

  Specifically:  
  - Insert `permissions: contents: read` either at the root (applies to all jobs) or under `jobs.build` (for just this job). The root is preferred for clarity unless you have multiple jobs needing different permissions.
  - This can be added above the `jobs:` key (line 6) for workflow-level permissions.

  No imports, additional methods, or other modifications are required.

  ---
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
